### PR TITLE
refactor: simplify code via generic

### DIFF
--- a/.github/actions/dev_env/action.yml
+++ b/.github/actions/dev_env/action.yml
@@ -13,4 +13,4 @@ runs:
       uses: actions/setup-go@v3
       with:
         go-version:
-          ${{ env.golang_version }}
+          ${{ env.golang-version }}

--- a/pkg/controllers/components/pod_control.go
+++ b/pkg/controllers/components/pod_control.go
@@ -13,17 +13,3 @@
 // limitations under the License.
 
 package components
-
-import (
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-func MakePodList() *corev1.PodList {
-	return &corev1.PodList{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: "v1",
-		},
-	}
-}

--- a/pkg/controllers/components/pvc_control.go
+++ b/pkg/controllers/components/pvc_control.go
@@ -13,21 +13,3 @@
 // limitations under the License.
 
 package components
-
-import (
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-func MakePersistentVolumeClaim() error {
-	return nil
-}
-
-func MakePersistentVolumeClaimListEmptyObj() *corev1.PersistentVolumeClaimList {
-	return &corev1.PersistentVolumeClaimList{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "PersistentVolumeClaim",
-		},
-	}
-}

--- a/pkg/controllers/components/service_control.go
+++ b/pkg/controllers/components/service_control.go
@@ -21,7 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func MakeService(svc *corev1.Service, moc *v1alpha1.MatrixoneCluster, ls map[string]string, isHeadless bool) (*corev1.Service, error) {
+func MakeService(moc *v1alpha1.MatrixoneCluster, ls map[string]string, isHeadless bool) (*corev1.Service, error) {
+	svc := &corev1.Service{}
 	svc.TypeMeta = metav1.TypeMeta{
 		APIVersion: "v1",
 		Kind:       "Service",
@@ -101,20 +102,6 @@ func MakeService(svc *corev1.Service, moc *v1alpha1.MatrixoneCluster, ls map[str
 	return svc, nil
 }
 
-func MakeServiceEmptyObj() *corev1.Service {
-	return &corev1.Service{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Service",
-		},
-	}
-}
-
-func MakeServiceListEmptyObj() *corev1.ServiceList {
-	return &corev1.ServiceList{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
-	}
+func RetainClusterIP(prev, curr *corev1.Service) {
+	curr.Spec.ClusterIP = prev.Spec.ClusterIP
 }

--- a/pkg/controllers/components/statefulset_control.go
+++ b/pkg/controllers/components/statefulset_control.go
@@ -236,21 +236,3 @@ func getPersistentVolumeClaim(moc *v1alpha1.MatrixoneCluster, ls map[string]stri
 	return pvc
 
 }
-
-func MakeStatefulSetEmptyObj() *appsv1.StatefulSet {
-	return &appsv1.StatefulSet{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "StatefulSet",
-		},
-	}
-}
-
-func MakeStatefulSetListEmptyObj() *appsv1.StatefulSetList {
-	return &appsv1.StatefulSetList{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "StatefulSet",
-			APIVersion: "apps/v1",
-		},
-	}
-}

--- a/pkg/controllers/matrixone/event.go
+++ b/pkg/controllers/matrixone/event.go
@@ -88,7 +88,7 @@ func (e EmitEventFuncs) EmitEventRollingDeployWait(obj, k8sObj object) {
 // EmitEventOnCreate shall emit event on CREATE operation
 func (e EmitEventFuncs) EmitEventOnCreate(obj, createObj object, err error) {
 	if err != nil {
-		errMsg := fmt.Errorf("Error creating object [%s] in namespace [%s:%s] due to [%s]", createObj.GetName(), createObj.GetObjectKind().GroupVersionKind().Kind, createObj.GetNamespace(), err.Error())
+		errMsg := fmt.Errorf("Error creating object [%s:%s] in namespace [%s] due to [%s]", createObj.GetName(), createObj.GetObjectKind().GroupVersionKind().Kind, createObj.GetNamespace(), err.Error())
 		e.Event(obj, corev1.EventTypeWarning, string(matrixoneCreateFail), errMsg.Error())
 	} else {
 		msg := fmt.Sprintf("Successfully created object [%s:%s] in namespace [%s]", createObj.GetName(), createObj.GetObjectKind().GroupVersionKind().Kind, createObj.GetNamespace())

--- a/pkg/controllers/matrixone/handler.go
+++ b/pkg/controllers/matrixone/handler.go
@@ -493,8 +493,8 @@ func executeFinalizers(sdk client.Client, moc *v1alpha1.MatrixoneCluster, emitEv
 
 func deleteSTSAndPVC(sdk client.Client, moc *v1alpha1.MatrixoneCluster, stsList []*appsv1.StatefulSet, pvcList []*v1.PersistentVolumeClaim, emitEvents EventEmitter) error {
 
-	for _, sts := range stsList {
-		err := Delete(context.TODO(), sdk, moc, sts, emitEvents, &client.DeleteAllOfOptions{})
+	for i := range stsList {
+		err := Delete(context.TODO(), sdk, moc, stsList[i], emitEvents, &client.DeleteAllOfOptions{})
 		if err != nil {
 			return err
 		}

--- a/pkg/controllers/matrixone/interface.go
+++ b/pkg/controllers/matrixone/interface.go
@@ -104,7 +104,7 @@ func extractList[T object](listObj objectList) ([]T, error) {
 		if obj, ok := item.(T); ok {
 			res = append(res, obj)
 		} else {
-			return nil, errors.Errorf("unexpected type: %T", items[0])
+			return nil, errors.Errorf("unexpected type: %T", item)
 		}
 	}
 	return res, nil

--- a/pkg/controllers/matrixone/interface.go
+++ b/pkg/controllers/matrixone/interface.go
@@ -50,9 +50,8 @@ func newObject[T any]() T {
 	var obj T
 	if typ := reflect.TypeOf(obj); typ.Kind() == reflect.Ptr {
 		return reflect.New(typ.Elem()).Interface().(T)
-	} else {
-		return obj
 	}
+	return obj
 }
 
 // Get methods shall the get the object.
@@ -87,7 +86,15 @@ func List[T object, TList objectList](
 	return extractList[T](listObj)
 }
 
+// extractList extract the items from an objectList interface.
+// ideally, we should have a type constraint between Object and ObjectList:
+//     type ObjectList[T] interface {
+//         GetItems() []T 
+//     }
+// so that the conversion can be type-safe. But the generated code of client-go
+// does not have such constraint yet.
 func extractList[T object](listObj objectList) ([]T, error) {
+
 	items, err := meta.ExtractList(listObj)
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/utils/utils.go
+++ b/pkg/controllers/utils/utils.go
@@ -28,7 +28,7 @@ func FirstNonEmptyStr(s1 string, s2 string) string {
 }
 
 // Note that all the arguments passed to this function must have zero value of Nil.
-func FirstNonNilValue(v1, v2 interface{}) interface{} {
+func FirstNonNilValue(v1, v2 any) any {
 	if !reflect.ValueOf(v1).IsNil() {
 		return v1
 	}


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

**Which issue(s) this PR fixes:**

N/A

**What this PR does / why we need it:**

This PR tries to simplify current codebase via the type parameter introduced in go 1.18. However, due to the limitations of current go implementation, there are some drawbacks:

Cons:
- I cannot find any type constraints between generic `Object` and `ObjectList` (e.g. `*v1.Pod` and `*v1.PodList`) since the `metav1.ListInterface` is not generic. Reflection is used as a workaround.
- `Reader` and  `Writer` interface are replaced with functions since [method does not support type parameter yet](https://go.googlesource.com/proposal/+/refs/heads/master/design/43651-type-parameters.md#no-parameterized-methods)

Pros (from the author's perspective):
- Though the callee code is a bit more complex due to reflection, most of type-casting are eliminated in the code of callers, which means better type safety.
- Overall readability is improved, probably.

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
