### PR TITLE
chore: enqueue merge job on comment

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -9,9 +9,10 @@ queue_rules:
 pull_request_rules:
   - name: put pr to queue
     conditions:
-      - "#approved-reviews-by>=2"
+      - "#approved-reviews-by>=1"
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
+      - "label=can-merge"
     actions:
       queue:
         name: shared_queue

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,16 @@
+name: Enqueue Merge
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ startsWith(github.event.comment.body, '/merge') }}
+        with:
+          labels: |
+            can-merge


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

This PR refine the mergify rule:
- only 1 approve is required, same as current branch protection rule
- to avoid unwanted merge, there should be an explicit `/merge` chatops comment to mark the PR as `can-merge`

**What this PR does / why we need it:**

Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
