### PR TITLE
fix: make cluster runnable

### DIFF
--- a/examples/logset.yaml
+++ b/examples/logset.yaml
@@ -3,7 +3,7 @@ kind: LogSet
 metadata:
   name: logset
 spec:
-  image: aylei/mo-service:0.1.2
+  image: aylei/mo-service:0.1.7
   replicas: 3
   sharedStorage:
     s3:
@@ -11,6 +11,9 @@ spec:
   volume:
     size: 10Gi
     storageClassName: gp2
+  resources:
+    requests:
+      cpu: 1
   nodeSelector:
     kubernetes.io/arch: amd64
   initialConfig:

--- a/examples/mo-cluster.yaml
+++ b/examples/mo-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mo
 spec:
   imageRepository: aylei/mo-service
-  version: 0.1.2
+  version: 0.1.7
   logService:
     resources:
       requests:


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Make the cluster runnable before CN is ready, so that we can add other logics.

```
kg po
NAME       READY   STATUS    RESTARTS      AGE
mo-cn-0    1/1     Running   0             29m
mo-cn-1    1/1     Running   0             29m
mo-dn-0    1/1     Running   0             29m
mo-dn-1    1/1     Running   0             29m
mo-log-0   1/1     Running   1 (29m ago)   30m
mo-log-1   1/1     Running   1 (29m ago)   30m
mo-log-2   1/1     Running   2 (29m ago)   30m
```

**What this PR does / why we need it:**

Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
