### PR TITLE
feat: initialize mo credential can GC failed logset Pod

### DIFF
--- a/api/core/v1alpha1/logset_types.go
+++ b/api/core/v1alpha1/logset_types.go
@@ -75,7 +75,7 @@ type InitialConfig struct {
 	// cannot be tuned after cluster creation currently.
 	// default to 3 if LogSet replicas >= 3, to 1 otherwise
 	// +required
-	HAKeeperReplicas *int `json:"haKeeperReplicas,omitempty"`
+	// HAKeeperReplicas *int `json:"haKeeperReplicas,omitempty"`
 
 	// LogShardReplicas is the replica numbers of each log shard,
 	// cannot be tuned after cluster creation currently.

--- a/api/core/v1alpha1/logset_webhook.go
+++ b/api/core/v1alpha1/logset_webhook.go
@@ -50,13 +50,13 @@ func (r *LogSet) Default() {
 }
 
 func (r *LogSetBasic) Default() {
-	if r.InitialConfig.HAKeeperReplicas == nil {
-		if r.Replicas >= minHAReplicas {
-			r.InitialConfig.HAKeeperReplicas = pointer.Int(minHAReplicas)
-		} else {
-			r.InitialConfig.HAKeeperReplicas = pointer.Int(singleReplica)
-		}
-	}
+	//if r.InitialConfig.HAKeeperReplicas == nil {
+	//	if r.Replicas >= minHAReplicas {
+	//		r.InitialConfig.HAKeeperReplicas = pointer.Int(minHAReplicas)
+	//	} else {
+	//		r.InitialConfig.HAKeeperReplicas = pointer.Int(singleReplica)
+	//	}
+	//}
 	if r.InitialConfig.LogShardReplicas == nil {
 		if r.Replicas >= minHAReplicas {
 			r.InitialConfig.LogShardReplicas = pointer.Int(minHAReplicas)
@@ -138,11 +138,11 @@ func (r *LogSetBasic) validateInitialConfig() field.ErrorList {
 	var errs field.ErrorList
 	parent := field.NewPath("spec").Child("initialConfig")
 
-	if hrs := r.InitialConfig.HAKeeperReplicas; hrs == nil {
-		errs = append(errs, field.Invalid(parent.Child("haKeeperReplicas"), hrs, "haKeeperReplicas must be set"))
-	} else if *hrs > int(r.Replicas) {
-		errs = append(errs, field.Invalid(parent.Child("haKeeperReplicas"), hrs, "haKeeperReplicas must not larger then logservice replicas"))
-	}
+	//if hrs := r.InitialConfig.HAKeeperReplicas; hrs == nil {
+	//	errs = append(errs, field.Invalid(parent.Child("haKeeperReplicas"), hrs, "haKeeperReplicas must be set"))
+	//} else if *hrs > int(r.Replicas) {
+	//	errs = append(errs, field.Invalid(parent.Child("haKeeperReplicas"), hrs, "haKeeperReplicas must not larger then logservice replicas"))
+	//}
 
 	if lrs := r.InitialConfig.LogShardReplicas; lrs == nil {
 		errs = append(errs, field.Invalid(parent.Child("logShardReplicas"), lrs, "logShardReplicas must be set"))

--- a/api/core/v1alpha1/matrixonecluster_types.go
+++ b/api/core/v1alpha1/matrixonecluster_types.go
@@ -15,6 +15,7 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -56,6 +57,11 @@ type MatrixOneClusterSpec struct {
 // MatrixOneClusterStatus defines the observed state of MatrixOneCluster
 type MatrixOneClusterStatus struct {
 	ConditionalStatus `json:",inline"`
+
+	// CredentialRef is the initial credential of the mo database which can be
+	// used to connect to the database.
+	CredentialRef *corev1.LocalObjectReference `json:"credentialRef,omitempty"`
+
 	// TP is the TP set status
 	TP *CNSetStatus `json:"tp,omitempty"`
 	// AP is the AP set status

--- a/api/core/v1alpha1/matrixonecluster_webhook_test.go
+++ b/api/core/v1alpha1/matrixonecluster_webhook_test.go
@@ -116,7 +116,7 @@ var _ = Describe("MatrixOneCluster Webhook", func() {
 		By("reject invalid replicas")
 		invalidReplicas := tpl.DeepCopy()
 		invalidReplicas.Spec.LogService.Replicas = 2
-		invalidReplicas.Spec.LogService.InitialConfig.HAKeeperReplicas = pointer.Int(3)
+		invalidReplicas.Spec.LogService.InitialConfig.LogShardReplicas = pointer.Int(3)
 		Expect(k8sClient.Create(context.TODO(), emptySharedStorage)).ToNot(Succeed())
 	})
 
@@ -158,7 +158,7 @@ var _ = Describe("MatrixOneCluster Webhook", func() {
 		By("defaults should be set on creation")
 		Expect(cluster.Spec.TP.ServiceType).ToNot(BeEmpty(), "CN serviceType should have default")
 		Expect(cluster.Spec.LogService.InitialConfig.LogShardReplicas).ToNot(BeNil(), "LogService initialConfig should have default")
-		Expect(*cluster.Spec.LogService.InitialConfig.HAKeeperReplicas).To(Equal(3), "default haKeeperReplicas should follow the replicas of logservice")
+		Expect(*cluster.Spec.LogService.InitialConfig.LogShardReplicas).To(Equal(3), "default logShardReplicas should follow the replicas of logservice")
 
 		By("accept valid update")
 		cluster.Spec.LogService.Replicas = 5
@@ -175,7 +175,7 @@ var _ = Describe("MatrixOneCluster Webhook", func() {
 		Expect(k8sClient.Update(context.TODO(), invalidReplica)).ToNot(Succeed(), "logservice replicas cannot be lower than HAKeeperReplicas")
 
 		mutateInitialConfig := cluster.DeepCopy()
-		mutateInitialConfig.Spec.LogService.InitialConfig.HAKeeperReplicas = pointer.Int(*mutateInitialConfig.Spec.LogService.InitialConfig.HAKeeperReplicas - 1)
+		mutateInitialConfig.Spec.LogService.InitialConfig.LogShardReplicas = pointer.Int(*mutateInitialConfig.Spec.LogService.InitialConfig.LogShardReplicas - 1)
 		Expect(k8sClient.Update(context.TODO(), invalidReplica)).ToNot(Succeed(), "initialConfig should be immutable")
 	})
 })

--- a/api/core/v1alpha1/zz_generated.deepcopy.go
+++ b/api/core/v1alpha1/zz_generated.deepcopy.go
@@ -408,11 +408,6 @@ func (in *InitialConfig) DeepCopyInto(out *InitialConfig) {
 		*out = new(int)
 		**out = **in
 	}
-	if in.HAKeeperReplicas != nil {
-		in, out := &in.HAKeeperReplicas, &out.HAKeeperReplicas
-		*out = new(int)
-		**out = **in
-	}
 	if in.LogShardReplicas != nil {
 		in, out := &in.LogShardReplicas, &out.LogShardReplicas
 		*out = new(int)
@@ -798,6 +793,11 @@ func (in *MatrixOneClusterSpec) DeepCopy() *MatrixOneClusterSpec {
 func (in *MatrixOneClusterStatus) DeepCopyInto(out *MatrixOneClusterStatus) {
 	*out = *in
 	in.ConditionalStatus.DeepCopyInto(&out.ConditionalStatus)
+	if in.CredentialRef != nil {
+		in, out := &in.CredentialRef, &out.CredentialRef
+		*out = new(corev1.LocalObjectReference)
+		**out = **in
+	}
 	if in.TP != nil {
 		in, out := &in.TP, &out.TP
 		*out = new(CNSetStatus)

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_logsets.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_logsets.yaml
@@ -60,11 +60,6 @@ spec:
                     description: DNShards is the initial number of DN shards, cannot
                       be tuned after cluster creation currently. default to 1
                     type: integer
-                  haKeeperReplicas:
-                    description: HAKeeperReplicas is the initial number of HAKeeper
-                      replicas, cannot be tuned after cluster creation currently.
-                      default to 3 if LogSet replicas >= 3, to 1 otherwise
-                    type: integer
                   logShardReplicas:
                     description: LogShardReplicas is the replica numbers of each log
                       shard, cannot be tuned after cluster creation currently. default

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_matrixoneclusters.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_matrixoneclusters.yaml
@@ -230,11 +230,6 @@ spec:
                           cannot be tuned after cluster creation currently. default
                           to 1
                         type: integer
-                      haKeeperReplicas:
-                        description: HAKeeperReplicas is the initial number of HAKeeper
-                          replicas, cannot be tuned after cluster creation currently.
-                          default to 3 if LogSet replicas >= 3, to 1 otherwise
-                        type: integer
                       logShardReplicas:
                         description: LogShardReplicas is the replica numbers of each
                           log shard, cannot be tuned after cluster creation currently.
@@ -683,6 +678,16 @@ spec:
                   - type
                   type: object
                 type: array
+              credentialRef:
+                description: CredentialRef is the initial credential of the mo database
+                  which can be used to connect to the database.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               dn:
                 description: DN is the DN set status
                 properties:

--- a/deploy/crds/core.matrixorigin.io_logsets.yaml
+++ b/deploy/crds/core.matrixorigin.io_logsets.yaml
@@ -60,11 +60,6 @@ spec:
                     description: DNShards is the initial number of DN shards, cannot
                       be tuned after cluster creation currently. default to 1
                     type: integer
-                  haKeeperReplicas:
-                    description: HAKeeperReplicas is the initial number of HAKeeper
-                      replicas, cannot be tuned after cluster creation currently.
-                      default to 3 if LogSet replicas >= 3, to 1 otherwise
-                    type: integer
                   logShardReplicas:
                     description: LogShardReplicas is the replica numbers of each log
                       shard, cannot be tuned after cluster creation currently. default

--- a/deploy/crds/core.matrixorigin.io_matrixoneclusters.yaml
+++ b/deploy/crds/core.matrixorigin.io_matrixoneclusters.yaml
@@ -230,11 +230,6 @@ spec:
                           cannot be tuned after cluster creation currently. default
                           to 1
                         type: integer
-                      haKeeperReplicas:
-                        description: HAKeeperReplicas is the initial number of HAKeeper
-                          replicas, cannot be tuned after cluster creation currently.
-                          default to 3 if LogSet replicas >= 3, to 1 otherwise
-                        type: integer
                       logShardReplicas:
                         description: LogShardReplicas is the replica numbers of each
                           log shard, cannot be tuned after cluster creation currently.
@@ -683,6 +678,16 @@ spec:
                   - type
                   type: object
                 type: array
+              credentialRef:
+                description: CredentialRef is the initial credential of the mo database
+                  which can be used to connect to the database.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               dn:
                 description: DN is the DN set status
                 properties:

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -181,7 +181,6 @@ _Appears in:_
 | --- | --- |
 | `logShards` _[int](#int)_ | LogShards is the initial number of log shards, cannot be tuned after cluster creation currently. default to 1 |
 | `dnShards` _[int](#int)_ | DNShards is the initial number of DN shards, cannot be tuned after cluster creation currently. default to 1 |
-| `haKeeperReplicas` _[int](#int)_ | HAKeeperReplicas is the initial number of HAKeeper replicas, cannot be tuned after cluster creation currently. default to 3 if LogSet replicas >= 3, to 1 otherwise |
 | `logShardReplicas` _[int](#int)_ | LogShardReplicas is the replica numbers of each log shard, cannot be tuned after cluster creation currently. default to 3 if LogSet replicas >= 3, to 1 otherwise |
 
 

--- a/examples/mo-cluster.yaml
+++ b/examples/mo-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mo
 spec:
   imageRepository: matrixorigin/matrixone
-  version: nightly-c371317c
+  version: nightly-43446ad2
   logService:
     replicas: 3
     sharedStorage:
@@ -17,14 +17,14 @@ spec:
       size: 10Gi
   dn:
     replicas: 2
-#    # cacheVolume specifies a dedicated volume for DN's local cache
-#    cacheVolume:
-#      size: 10Gi
+    # cacheVolume specifies a dedicated volume for DN's local cache
+    cacheVolume:
+      size: 10Gi
   tp:
     replicas: 2
-#    # cacheVolume specifies a dedicated volume for CN's local cache
-#    cacheVolume:
-#      size: 10Gi
+    # cacheVolume specifies a dedicated volume for CN's local cache
+    cacheVolume:
+      size: 10Gi
 
 #  # Uncomment this section to enable CN nodes for analytic processing
 #  ap:

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -6,13 +6,9 @@ OPNAMESPACE=${OPNAMESPACE:-"mo-system"}
 
 function e2e::check() {
   CMD=pgrep
-  PPROC=ginkgo
   crds=$(kubectl get crds --no-headers=true | awk '/matrixorigin/{print $1}')
   echo "> E2E check"
-  if [ -n "`$CMD $PPROC`" ]; then
-    echo "Already running e2e test, Wait for E2E Ready or Kill it"
-    exit 1
-  elif [[ $crds != "" ]]; then
+  if [[ $crds != "" ]]; then
     echo "Please delete old CRDS"
     exit 1
   else
@@ -65,8 +61,8 @@ function e2e::cleanup() {
 }
 
 function e2e::workflow() {
-  trap "e2e::cleanup" EXIT
   e2e::check
+  trap "e2e::cleanup" EXIT
   e2e::install
   e2e::run
 }

--- a/pkg/controllers/common/common.go
+++ b/pkg/controllers/common/common.go
@@ -74,6 +74,9 @@ const (
 	ActionRequiredLabelKey   = "matrixorigin.io/action-required"
 	ActionRequiredLabelValue = "True"
 
+	// LogSetOwnerKey is set to the orphaned LogSet Pod that is left by failover
+	LogSetOwnerKey = "matrixorigin.io/logset-owner"
+
 	AWSAccessKeyID     = "AWS_ACCESS_KEY_ID"
 	AWSSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
 )

--- a/pkg/controllers/logset/bootstrap.go
+++ b/pkg/controllers/logset/bootstrap.go
@@ -78,7 +78,7 @@ func bootstrap(ctx *recon.Context[*v1alpha1.LogSet]) ([]bootstrapReplica, error)
 	}
 
 	// if the bootstrap decision has not yet been made,pick a bootstrap decision
-	n := *ctx.Obj.Spec.InitialConfig.HAKeeperReplicas
+	n := *ctx.Obj.Spec.InitialConfig.LogShardReplicas
 	// pick first N pods as initial HAKeeperReplicas
 	for i := 0; i < n; i++ {
 		rid := idRangeStart + i

--- a/pkg/controllers/logset/sts_test.go
+++ b/pkg/controllers/logset/sts_test.go
@@ -80,7 +80,6 @@ func Test_syncPodSpec(t *testing.T) {
 						InitialConfig: v1alpha1.InitialConfig{
 							LogShards:        pointer.Int(1),
 							DNShards:         pointer.Int(1),
-							HAKeeperReplicas: pointer.Int(3),
 							LogShardReplicas: pointer.Int(3),
 						},
 					},

--- a/pkg/controllers/mocluster/controller.go
+++ b/pkg/controllers/mocluster/controller.go
@@ -14,15 +14,25 @@
 package mocluster
 
 import (
+	"fmt"
 	"github.com/matrixorigin/matrixone-operator/api/core/v1alpha1"
 	recon "github.com/matrixorigin/matrixone-operator/runtime/pkg/reconciler"
 	"github.com/matrixorigin/matrixone-operator/runtime/pkg/util"
 	"go.uber.org/multierr"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"time"
+)
+
+const (
+	resyncAfter = 15 * time.Second
+
+	usernameKey = "username"
+	passwordKey = "password"
 )
 
 var _ recon.Actor[*v1alpha1.MatrixOneCluster] = &MatrixOneClusterActor{}
@@ -105,9 +115,57 @@ func (r *MatrixOneClusterActor) Observe(ctx *recon.Context[*v1alpha1.MatrixOneCl
 	mo.Status.LogService = &ls.Status
 	mo.Status.DN = &dn.Status
 	mo.Status.TP = &tp.Status
-	mo.Status.ConditionalStatus.SetCondition(readyCondition(mo))
 	mo.Status.ConditionalStatus.SetCondition(syncedCondition(mo))
-	return nil, nil
+
+	subResourcesReady := readyCondition(mo)
+
+	if mo.Status.CredentialRef == nil {
+		// cluster not initialized
+		if subResourcesReady.Status == metav1.ConditionFalse {
+			// the underlying sets are not ready, wait
+			mo.Status.ConditionalStatus.SetCondition(subResourcesReady)
+			return nil, recon.ErrReSync("wait cluster ready to complete initialization", resyncAfter)
+		}
+		// checkpoint the status before the initialize action
+		mo.Status.ConditionalStatus.SetCondition(metav1.Condition{
+			Type:   recon.ConditionTypeReady,
+			Status: metav1.ConditionFalse,
+			Reason: "ClusterNotInitialized",
+		})
+		return r.Initialize, nil
+	}
+	mo.Status.ConditionalStatus.SetCondition(subResourcesReady)
+
+	if recon.IsReady(&mo.Status) {
+		return nil, nil
+	}
+	return nil, recon.ErrReSync("matrixone cluster is not ready", resyncAfter)
+}
+
+// Initialize the MO cluster
+func (r *MatrixOneClusterActor) Initialize(ctx *recon.Context[*v1alpha1.MatrixOneCluster]) error {
+	// 1. generate the secret
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      credentialName(ctx.Obj),
+		},
+		StringData: map[string]string{
+			// TODO: avoid using hardcoded username password
+			usernameKey: "dump",
+			passwordKey: "111",
+		},
+	}
+	if err := ctx.CreateOwned(sec); err != nil {
+		return err
+	}
+	// 2. initialize the cluster
+	// TODO: initialize users that using the above secret after MO support ALTER USER
+
+	// 3. update the status
+	ctx.Obj.Status.SetCondition(readyCondition(ctx.Obj))
+	ctx.Obj.Status.CredentialRef = &corev1.LocalObjectReference{Name: sec.Name}
+	return ctx.UpdateStatus(ctx.Obj)
 }
 
 func readyCondition(mo *v1alpha1.MatrixOneCluster) metav1.Condition {
@@ -216,4 +274,8 @@ func (r *MatrixOneClusterActor) Reconcile(mgr manager.Manager) error {
 				Owns(&v1alpha1.CNSet{}).
 				Owns(&v1alpha1.WebUI{})
 		}))
+}
+
+func credentialName(mo *v1alpha1.MatrixOneCluster) string {
+	return fmt.Sprintf("%s-credential", mo.Name)
 }

--- a/pkg/controllers/mocluster/controller_test.go
+++ b/pkg/controllers/mocluster/controller_test.go
@@ -21,6 +21,7 @@ import (
 	recon "github.com/matrixorigin/matrixone-operator/runtime/pkg/reconciler"
 	. "github.com/onsi/gomega"
 	kruisev1 "github.com/openkruise/kruise-api/apps/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -68,12 +69,14 @@ func TestMatrixOneClusterActor_Observe(t *testing.T) {
 		name    string
 		objects []client.Object
 		mo      *v1alpha1.MatrixOneCluster
-		expect  func(g *WithT, mo *v1alpha1.MatrixOneCluster, c client.Client)
+		expect  func(g *WithT, mo *v1alpha1.MatrixOneCluster, err error, c client.Client)
+
+		expectAction func(g *WithT, action recon.Action[*v1alpha1.MatrixOneCluster])
 	}{{
 		name:    "create",
 		objects: nil,
 		mo:      tpl.DeepCopy(),
-		expect: func(g *WithT, mo *v1alpha1.MatrixOneCluster, c client.Client) {
+		expect: func(g *WithT, mo *v1alpha1.MatrixOneCluster, _ error, c client.Client) {
 			g.Expect(c.Get(ctx, types.NamespacedName{Namespace: "default", Name: "test"}, &v1alpha1.LogSet{})).To(Succeed())
 			g.Expect(c.Get(ctx, types.NamespacedName{Namespace: "default", Name: "test"}, &v1alpha1.DNSet{})).To(Succeed())
 			g.Expect(c.Get(ctx, types.NamespacedName{Namespace: "default", Name: "test-tp"}, &v1alpha1.CNSet{})).To(Succeed())
@@ -82,7 +85,11 @@ func TestMatrixOneClusterActor_Observe(t *testing.T) {
 		},
 	}, {
 		name: "ready",
-		mo:   tpl.DeepCopy(),
+		mo: func() *v1alpha1.MatrixOneCluster {
+			mo := tpl.DeepCopy()
+			mo.Status.CredentialRef = &corev1.LocalObjectReference{Name: "test"}
+			return mo
+		}(),
 		objects: []client.Object{
 			&v1alpha1.LogSet{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test"},
@@ -112,8 +119,9 @@ func TestMatrixOneClusterActor_Observe(t *testing.T) {
 				},
 			},
 		},
-		expect: func(g *WithT, mo *v1alpha1.MatrixOneCluster, c client.Client) {
+		expect: func(g *WithT, mo *v1alpha1.MatrixOneCluster, err error, c client.Client) {
 			g.Expect(recon.IsReady(&mo.Status)).To(BeTrue())
+			g.Expect(err).To(Succeed())
 		},
 	}, {
 		name: "synced",
@@ -147,7 +155,7 @@ func TestMatrixOneClusterActor_Observe(t *testing.T) {
 				},
 			},
 		},
-		expect: func(g *WithT, mo *v1alpha1.MatrixOneCluster, c client.Client) {
+		expect: func(g *WithT, mo *v1alpha1.MatrixOneCluster, err error, c client.Client) {
 			g.Expect(recon.IsSynced(&mo.Status)).To(BeTrue())
 		},
 	}, {
@@ -182,7 +190,7 @@ func TestMatrixOneClusterActor_Observe(t *testing.T) {
 				},
 			},
 		},
-		expect: func(g *WithT, mo *v1alpha1.MatrixOneCluster, c client.Client) {
+		expect: func(g *WithT, mo *v1alpha1.MatrixOneCluster, err error, c client.Client) {
 			g.Expect(recon.IsSynced(&mo.Status)).To(BeFalse())
 			cond, ok := recon.GetCondition(&mo.Status, recon.ConditionTypeReady)
 			g.Expect(ok).To(BeTrue())
@@ -220,11 +228,49 @@ func TestMatrixOneClusterActor_Observe(t *testing.T) {
 				},
 			},
 		},
-		expect: func(g *WithT, mo *v1alpha1.MatrixOneCluster, c client.Client) {
+		expect: func(g *WithT, mo *v1alpha1.MatrixOneCluster, err error, c client.Client) {
 			g.Expect(recon.IsSynced(&mo.Status)).To(BeFalse())
 			cond, ok := recon.GetCondition(&mo.Status, recon.ConditionTypeSynced)
 			g.Expect(ok).To(BeTrue())
 			g.Expect(cond.Reason).To(Equal("DNSetNotSynced"))
+		},
+	}, {
+		name: "initializeDB",
+		mo:   tpl.DeepCopy(),
+		objects: []client.Object{
+			&v1alpha1.LogSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test"},
+				Status: v1alpha1.LogSetStatus{
+					ConditionalStatus: v1alpha1.ConditionalStatus{Conditions: []metav1.Condition{{
+						Type:   recon.ConditionTypeReady,
+						Status: metav1.ConditionTrue,
+					}}},
+				},
+			},
+			&v1alpha1.DNSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test"},
+				Status: v1alpha1.DNSetStatus{
+					ConditionalStatus: v1alpha1.ConditionalStatus{Conditions: []metav1.Condition{{
+						Type:   recon.ConditionTypeReady,
+						Status: metav1.ConditionTrue,
+					}}},
+				},
+			},
+			&v1alpha1.CNSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-tp"},
+				Status: v1alpha1.CNSetStatus{
+					ConditionalStatus: v1alpha1.ConditionalStatus{Conditions: []metav1.Condition{{
+						Type:   recon.ConditionTypeReady,
+						Status: metav1.ConditionTrue,
+					}}},
+				},
+			},
+		},
+		expect: func(g *WithT, mo *v1alpha1.MatrixOneCluster, err error, c client.Client) {
+			g.Expect(recon.IsReady(&mo.Status)).To(BeFalse())
+		},
+		expectAction: func(g *WithT, action recon.Action[*v1alpha1.MatrixOneCluster]) {
+			g.Expect(action.String()).To(ContainSubstring("Initialize"))
 		},
 	}}
 	for _, tt := range tests {
@@ -235,9 +281,11 @@ func TestMatrixOneClusterActor_Observe(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			eventEmitter := fake.NewMockEventEmitter(mockCtrl)
 			ctx := fake.NewContext(tt.mo, cli, eventEmitter)
-			_, err := r.Observe(ctx)
-			g.Expect(err).To(Succeed())
-			tt.expect(g, tt.mo, cli)
+			action, err := r.Observe(ctx)
+			tt.expect(g, tt.mo, err, cli)
+			if tt.expectAction != nil {
+				tt.expectAction(g, action)
+			}
 		})
 	}
 }

--- a/test/e2e/logset_test.go
+++ b/test/e2e/logset_test.go
@@ -26,7 +26,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
 	"time"
 )
 
@@ -50,7 +52,7 @@ var _ = Describe("MatrixOneCluster test", func() {
 		l := &v1alpha1.LogSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: env.Namespace,
-				Name:      "log",
+				Name:      "log-" + rand.String(6),
 			},
 			Spec: v1alpha1.LogSetSpec{
 				LogSetBasic: v1alpha1.LogSetBasic{
@@ -99,8 +101,8 @@ var _ = Describe("MatrixOneCluster test", func() {
 		}
 		Expect(kubeCli.Update(ctx, l)).To(Succeed())
 		Eventually(func() error {
-			if err := kubeCli.Get(ctx, types.NamespacedName{Namespace: l.Namespace, Name: "log-log-3"}, &corev1.Pod{}); err != nil {
-				logger.Info("wait failover create new pod log-log-3")
+			if err := kubeCli.Get(ctx, types.NamespacedName{Namespace: l.Namespace, Name: fmt.Sprintf("%s-log-3", l.Name)}, &corev1.Pod{}); err != nil {
+				logger.Info("wait failover create new pod log-3")
 				return errWait
 			}
 			return nil
@@ -135,6 +137,18 @@ var _ = Describe("MatrixOneCluster test", func() {
 			if !apierrors.IsNotFound(err) {
 				logger.Errorw("unexpected error when get logset", "logset", l, "error", err)
 				return err
+			}
+			podList := &corev1.PodList{}
+			err = kubeCli.List(ctx, podList, client.InNamespace(l.Namespace))
+			if err != nil {
+				logger.Errorw("error list pods", "error", err)
+				return err
+			}
+			for _, pod := range podList.Items {
+				if strings.HasPrefix(pod.Name, l.Name) {
+					logger.Infow("Pod that belongs to the logset is not cleaned", "pod", pod.Name)
+					return errWait
+				}
 			}
 			return nil
 		}, teardownClusterTimeout, pollInterval).Should(Succeed())

--- a/test/e2e/matrixonecluster_test.go
+++ b/test/e2e/matrixonecluster_test.go
@@ -36,7 +36,7 @@ import (
 const (
 	createClusterTimeout   = 5 * time.Minute
 	rollingUpdateTimeout   = 5 * time.Minute
-	teardownClusterTimeout = 5 * time.Minute
+	teardownClusterTimeout = 10 * time.Minute
 	pollInterval           = 15 * time.Second
 	portForwardTimeout     = 10 * time.Second
 	sqlTestTimeout         = 5 * time.Minute


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

close #252 
close #248 

This PR contains several minor fixes / feats:

1. Write the initial credentials of MO to a k8s secret;
2. Fix `e2e.sh`, avoid corrupting a cluster that already has e2e or operator running;
3. Fix hanging logset Pods on logset deletion, i.e. GC failed logset Pod;
4. Refine `LogSet` config, remove the `HAKeeperReplicas` field;

**What this PR does / why we need it:**

Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
