### PR TITLE
fix: panic issue when dnset dep is not

### DIFF
--- a/api/core/v1alpha1/cnset_types.go
+++ b/api/core/v1alpha1/cnset_types.go
@@ -105,7 +105,10 @@ func (s *CNSet) GetDependencies() []recon.Dependency {
 			ReadyFunc: func(l *LogSet) bool {
 				return recon.IsReady(&l.Status)
 			},
-		}, &recon.ObjectDependency[*DNSet]{
+		})
+	}
+	if s.Deps.DNSet != nil {
+		deps = append(deps, &recon.ObjectDependency[*DNSet]{
 			ObjectRef: s.Deps.DNSet,
 			ReadyFunc: func(s *DNSet) bool {
 				return recon.IsReady(&s.Status)


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

This PR fix a panic issue when DN dep is not set for CN while a logset dep is set.

**What this PR does / why we need it:**

Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
