### PR TITLE
feat: setup lock-service communication in operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL=/usr/bin/env bash -o pipefail
 REPO ?= "matrixorigin/matrixone-operator"
 TAG ?= "latest"
 GOPROXY ?= "https://proxy.golang.org,direct"
-MO_VERSION ?= "nightly-0bfcd47"
+MO_VERSION ?= "nightly-21a33df5"
 MO_IMAGE_REPO ?= "matrixorigin/matrixone"
 BRANCH ?= main
 

--- a/charts/matrixone-operator/values.yaml
+++ b/charts/matrixone-operator/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 image:
   repository: matrixorigin/matrixone-operator
   pullPolicy: IfNotPresent
-  tag: "sha-c939c87"
+  tag: "sha-772fa30"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/pkg/controllers/cnset/resource.go
+++ b/pkg/controllers/cnset/resource.go
@@ -58,7 +58,7 @@ lsc=$(mktemp)
 cat <<EOF > ${lsc}
 service-address = "${ADDR}:{{ .LockServicePort }}"
 EOF
-sed -i "/\[cn.LockService\]/r ${lsc}" ${conf}
+sed -i "/\[cn.lockservice\]/r ${lsc}" ${conf}
 
 echo "/mo-service -cfg ${conf}"
 exec /mo-service -cfg ${conf}
@@ -190,7 +190,7 @@ func buildCNSetConfigMap(cn *v1alpha1.CNSet, ls *v1alpha1.LogSet) (*corev1.Confi
 	cfg.Set([]string{"hakeeper-client", "service-addresses"}, logset.HaKeeperAdds(ls))
 	// cfg.Set([]string{"hakeeper-client", "discovery-address"}, ls.Status.Discovery.String())
 	cfg.Set([]string{"cn", "role"}, cn.Spec.Role)
-	cfg.Set([]string{"cn", "LockService", "listen-address"}, fmt.Sprintf("0.0.0.0:%d", common.LockServicePort))
+	cfg.Set([]string{"cn", "lockservice", "listen-address"}, fmt.Sprintf("0.0.0.0:%d", common.LockServicePort))
 	s, err := cfg.ToString()
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/cnset/resource.go
+++ b/pkg/controllers/cnset/resource.go
@@ -53,7 +53,7 @@ EOF
 # build instance config
 sed "/\[cn\]/r ${bc}" {{ .ConfigFilePath }} > ${conf}
 
-# append lock-service confisg
+# append lock-service configs
 lsc=$(mktemp)
 cat <<EOF > ${lsc}
 service-address = "${ADDR}:{{ .LockServicePort }}"

--- a/pkg/controllers/cnset/resource.go
+++ b/pkg/controllers/cnset/resource.go
@@ -53,6 +53,13 @@ EOF
 # build instance config
 sed "/\[cn\]/r ${bc}" {{ .ConfigFilePath }} > ${conf}
 
+# append lock-service confisg
+lsc=$(mktemp)
+cat <<EOF > ${lsc}
+service-address = "${ADDR}:{{ .LockServicePort }}"
+EOF
+sed -i "/\[cn.LockService\]/r ${lsc}" ${conf}
+
 echo "/mo-service -cfg ${conf}"
 exec /mo-service -cfg ${conf}
 `))
@@ -61,6 +68,8 @@ type model struct {
 	ConfigFilePath string
 	CNSQLPort      int
 	CNRpcPort      int
+
+	LockServicePort int
 }
 
 func buildHeadlessSvc(cn *v1alpha1.CNSet) *corev1.Service {
@@ -181,15 +190,17 @@ func buildCNSetConfigMap(cn *v1alpha1.CNSet, ls *v1alpha1.LogSet) (*corev1.Confi
 	cfg.Set([]string{"hakeeper-client", "service-addresses"}, logset.HaKeeperAdds(ls))
 	// cfg.Set([]string{"hakeeper-client", "discovery-address"}, ls.Status.Discovery.String())
 	cfg.Set([]string{"cn", "role"}, cn.Spec.Role)
+	cfg.Set([]string{"cn", "LockService", "listen-address"}, fmt.Sprintf("0.0.0.0:%d", common.LockServicePort))
 	s, err := cfg.ToString()
 	if err != nil {
 		return nil, err
 	}
 	buff := new(bytes.Buffer)
 	err = startScriptTpl.Execute(buff, &model{
-		ConfigFilePath: fmt.Sprintf("%s/%s", common.ConfigPath, common.ConfigFile),
-		CNSQLPort:      CNSQLPort,
-		CNRpcPort:      cnRPCPort,
+		ConfigFilePath:  fmt.Sprintf("%s/%s", common.ConfigPath, common.ConfigFile),
+		CNSQLPort:       CNSQLPort,
+		CNRpcPort:       cnRPCPort,
+		LockServicePort: common.LockServicePort,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/common/consts.go
+++ b/pkg/controllers/common/consts.go
@@ -1,0 +1,18 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package common
+
+const (
+	LockServicePort = 6003
+)

--- a/pkg/controllers/dnset/resource.go
+++ b/pkg/controllers/dnset/resource.go
@@ -56,7 +56,7 @@ EOF
 # build instance config
 sed "/\[dn\]/r ${bc}" {{ .ConfigFilePath }} > ${conf}
 
-# append lock-service confisg
+# append lock-service configs
 lsc=$(mktemp)
 cat <<EOF > ${lsc}
 service-address = "${ADDR}:{{ .LockServicePort }}"

--- a/pkg/controllers/dnset/resource.go
+++ b/pkg/controllers/dnset/resource.go
@@ -61,7 +61,7 @@ lsc=$(mktemp)
 cat <<EOF > ${lsc}
 service-address = "${ADDR}:{{ .LockServicePort }}"
 EOF
-sed -i "/\[dn.LockService\]/r ${lsc}" ${conf}
+sed -i "/\[dn.lockservice\]/r ${lsc}" ${conf}
 
 # there is a chance that the dns is not yet added to kubedns and the
 # server will crash, wait before myself to be resolvable
@@ -167,7 +167,7 @@ func buildDNSetConfigMap(dn *v1alpha1.DNSet, ls *v1alpha1.LogSet) (*corev1.Confi
 	conf.Merge(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, dn.Spec.CacheVolume, &dn.Spec.SharedStorageCache))
 	conf.Set([]string{"service-type"}, serviceType)
 	conf.Set([]string{"dn", "listen-address"}, getListenAddress())
-	conf.Set([]string{"dn", "LockService", "listen-address"}, fmt.Sprintf("0.0.0.0:%d", common.LockServicePort))
+	conf.Set([]string{"dn", "lockservice", "listen-address"}, fmt.Sprintf("0.0.0.0:%d", common.LockServicePort))
 	s, err := conf.ToString()
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/dnset/resource.go
+++ b/pkg/controllers/dnset/resource.go
@@ -56,6 +56,13 @@ EOF
 # build instance config
 sed "/\[dn\]/r ${bc}" {{ .ConfigFilePath }} > ${conf}
 
+# append lock-service confisg
+lsc=$(mktemp)
+cat <<EOF > ${lsc}
+service-address = "${ADDR}:{{ .LockServicePort }}"
+EOF
+sed -i "/\[dn.LockService\]/r ${lsc}" ${conf}
+
 # there is a chance that the dns is not yet added to kubedns and the
 # server will crash, wait before myself to be resolvable
 elapseTime=0
@@ -81,6 +88,8 @@ exec /mo-service -cfg ${conf}
 type model struct {
 	DNServicePort  int
 	ConfigFilePath string
+
+	LockServicePort int
 }
 
 func syncReplicas(dn *v1alpha1.DNSet, cs *kruise.StatefulSet) {
@@ -158,6 +167,7 @@ func buildDNSetConfigMap(dn *v1alpha1.DNSet, ls *v1alpha1.LogSet) (*corev1.Confi
 	conf.Merge(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, dn.Spec.CacheVolume, &dn.Spec.SharedStorageCache))
 	conf.Set([]string{"service-type"}, serviceType)
 	conf.Set([]string{"dn", "listen-address"}, getListenAddress())
+	conf.Set([]string{"dn", "LockService", "listen-address"}, fmt.Sprintf("0.0.0.0:%d", common.LockServicePort))
 	s, err := conf.ToString()
 	if err != nil {
 		return nil, err
@@ -165,8 +175,9 @@ func buildDNSetConfigMap(dn *v1alpha1.DNSet, ls *v1alpha1.LogSet) (*corev1.Confi
 
 	buff := new(bytes.Buffer)
 	err = startScriptTpl.Execute(buff, &model{
-		DNServicePort:  dnServicePort,
-		ConfigFilePath: fmt.Sprintf("%s/%s", common.ConfigPath, common.ConfigFile),
+		DNServicePort:   dnServicePort,
+		LockServicePort: common.LockServicePort,
+		ConfigFilePath:  fmt.Sprintf("%s/%s", common.ConfigPath, common.ConfigFile),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/dnset/resource_test.go
+++ b/pkg/controllers/dnset/resource_test.go
@@ -65,7 +65,7 @@ service-type = "DN"
 [dn]
 listen-address = "0.0.0.0:41010"
 
-[dn.LockService]
+[dn.lockservice]
 listen-address = "0.0.0.0:6003"
 
 [[fileservice]]
@@ -134,7 +134,7 @@ type = "distributed-tae"
 [dn]
 listen-address = "0.0.0.0:41010"
 
-[dn.LockService]
+[dn.lockservice]
 listen-address = "0.0.0.0:6003"
 
 [[fileservice]]

--- a/pkg/controllers/dnset/resource_test.go
+++ b/pkg/controllers/dnset/resource_test.go
@@ -65,6 +65,9 @@ service-type = "DN"
 [dn]
 listen-address = "0.0.0.0:41010"
 
+[dn.LockService]
+listen-address = "0.0.0.0:6003"
+
 [[fileservice]]
 backend = "DISK"
 data-dir = "/var/lib/matrixone/data"
@@ -130,6 +133,9 @@ type = "distributed-tae"
 
 [dn]
 listen-address = "0.0.0.0:41010"
+
+[dn.LockService]
+listen-address = "0.0.0.0:6003"
 
 [[fileservice]]
 backend = "DISK"


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

close #304 

The configuration will be constructed as below:

CN:
```toml
[cn]
uuid = "00000000-0000-0000-0000-200000000000"
listen-address = "0.0.0.0:6002"
service-address = "test-tp-cn-0.test-tp-cn-headless.e2e-1679290889849056000.svc:6002"
sql-address = "test-tp-cn-0.test-tp-cn-headless.e2e-1679290889849056000.svc:6001"
role = "TP"

[cn.lockservice]
service-address = "test-tp-cn-0.test-tp-cn-headless.e2e-1679290889849056000.svc:6003"
listen-address = "0.0.0.0:6003"
```

DN:
```toml
[dn]
uuid = "00000000-0000-0000-0000-100000000000"
service-address = "test-dn-0.test-dn-headless.e2e-1679290889849056000.svc:41010"
listen-address = "0.0.0.0:41010"

[dn.lockservice]
service-address = "test-dn-0.test-dn-headless.e2e-1679290889849056000.svc:6003"
listen-address = "0.0.0.0:6003"
```

**What this PR does / why we need it:**

Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
