### PR TITLE
fix: set mo option gossip-allow-self-as-seed is true when log service…

### DIFF
--- a/pkg/controllers/logset/configmap.go
+++ b/pkg/controllers/logset/configmap.go
@@ -138,6 +138,10 @@ func buildConfigMap(ls *v1alpha1.LogSet) (*corev1.ConfigMap, error) {
 	conf.Set([]string{"logservice", "deployment-id"}, deploymentID(ls))
 	conf.Set([]string{"logservice", "logservice-listen-address"}, fmt.Sprintf("0.0.0.0:%d", logServicePort))
 	conf.Set([]string{"hakeeper-client", "discovery-address"}, fmt.Sprintf("%s:%d", discoverySvcAddress(ls), logServicePort))
+	if ls.Spec.Replicas == 1 {
+		// logservice cannot start up if this gossip option is not set when there is only one replica
+		conf.Set([]string{"logservice", "gossip-allow-self-as-seed"}, true)
+	}
 	s, err := conf.ToString()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
… replica is 1

**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #300

**What this PR does / why we need it:**
set `gossip-allow-self-as-seed=true` is must required when there is only one log service replica

Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
