### PR TITLE
fix: fixed CN label sync on cluster recreation

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -180,7 +180,7 @@ func main() {
 	}
 
 	if features.DefaultFeatureGate.Enabled(features.CNLabel) {
-		cnLabelController := cnlabel.NewController(hacli.NewManager(mgr.GetClient()))
+		cnLabelController := cnlabel.NewController(hacli.NewManager(mgr.GetClient(), mgr.GetLogger()))
 		err = cnLabelController.Reconcile(mgr)
 		exitIf(err, "unable to set up cnlabel controller")
 	} else {


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

close #345

**What this PR does / why we need it:**

For better performance, operator now caches HAKeeper client, which should be evicted on cluster recreation. This PR add cache eviction and logservice readiness check to make the CN label controller robust.

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
