### PR TITLE
fix: add failover limit

### DIFF
--- a/api/core/v1alpha1/matrixonecluster_webhook.go
+++ b/api/core/v1alpha1/matrixonecluster_webhook.go
@@ -45,6 +45,9 @@ func (r *MatrixOneCluster) Default() {
 	if r.Spec.AP != nil {
 		r.Spec.AP.Default()
 	}
+	for _, cn := range r.Spec.CNGroups {
+		cn.Default()
+	}
 }
 
 // +kubebuilder:webhook:path=/validate-core-matrixorigin-io-v1alpha1-matrixonecluster,mutating=false,failurePolicy=fail,sideEffects=None,groups=core.matrixorigin.io,resources=matrixoneclusters,verbs=create;update,versions=v1alpha1,name=vmatrixonecluster.kb.io,admissionReviewVersions=v1;v1beta1
@@ -76,6 +79,9 @@ func (r *MatrixOneCluster) validateMutateCommon() field.ErrorList {
 	}
 	if r.Spec.AP != nil {
 		errs = append(errs, r.Spec.AP.ValidateCreate()...)
+	}
+	for _, cn := range r.Spec.CNGroups {
+		errs = append(errs, cn.ValidateCreate()...)
 	}
 	if r.Spec.Version == "" {
 		errs = append(errs, field.Invalid(field.NewPath("spec").Child("version"), "", "version must be set"))

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.9
-	github.com/matrixorigin/controller-runtime v0.0.0-20230329033025-17c57685ca8e
+	github.com/matrixorigin/controller-runtime v0.0.0-20230506073151-147840610357
 	github.com/matrixorigin/matrixone v0.7.1-0.20230420141550-d8f67c26e3db
 	github.com/matrixorigin/matrixone-operator/api v0.0.0-20220926063007-e629f86256d2
 	github.com/minio/minio-go/v7 v7.0.51

--- a/go.sum
+++ b/go.sum
@@ -436,8 +436,8 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/matrixorigin/controller-runtime v0.0.0-20230329033025-17c57685ca8e h1:sU9krNHBWcB6FEmwt+2hq4YWOFA1MiMKSto2UBs/p8M=
-github.com/matrixorigin/controller-runtime v0.0.0-20230329033025-17c57685ca8e/go.mod h1:IIoGs+JDhphlLsUDFc8yRjKZ2cHBORadUddhXDNeMts=
+github.com/matrixorigin/controller-runtime v0.0.0-20230506073151-147840610357 h1:NHH+Se08YEzH1jg3oI6elxzJYWGk60CT4zWppYhL3EM=
+github.com/matrixorigin/controller-runtime v0.0.0-20230506073151-147840610357/go.mod h1:IIoGs+JDhphlLsUDFc8yRjKZ2cHBORadUddhXDNeMts=
 github.com/matrixorigin/dragonboat/v4 v4.0.0-20230426084722-d189534f8004 h1:HwxzjxWB6oYwdA4gBXDgjjZiwpGKzBUfpGNzDbuJMwo=
 github.com/matrixorigin/dragonboat/v4 v4.0.0-20230426084722-d189534f8004/go.mod h1:bR6ZGoUwApH4/P4+AezNGT0xehljg+j+Z/Q2Fz+Y4a0=
 github.com/matrixorigin/goetty/v2 v2.0.0-20221212132037-abf2d4c05484 h1:0RKWcsZlKfzHuhsUXZV+3hqjG+EHMC5t5UQvCkLJvtM=


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #302 

**What this PR does / why we need it:**

Automatically failover majority logset Pods is risky, this PR introduce failover limit to ensure failover never migrate majority pods.

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
