### PR TITLE
fix: fix set default memory cache size for cnset

### DIFF
--- a/api/core/v1alpha1/cnset_webhook.go
+++ b/api/core/v1alpha1/cnset_webhook.go
@@ -44,7 +44,7 @@ func (r *CNSetSpec) Default() {
 	if r.ServiceType == "" {
 		r.ServiceType = corev1.ServiceTypeClusterIP
 	}
-	if r.Resources.Requests.Memory() != nil && r.SharedStorageCache.MemoryCacheSize == nil {
+	if r.Resources.Requests.Memory().Value() != 0 && r.SharedStorageCache.MemoryCacheSize == nil {
 		// default memory cache size to 50% request memory
 		size := r.Resources.Requests.Memory().DeepCopy()
 		size.Set(size.Value() / 2)


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes # https://github.com/matrixorigin/MO-Cloud/issues/970

**What this PR does / why we need it:**

`r.Resources.Requests.Memory()` never be nil, should set MemoryCacheSize when request not 0 

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
