### PR TITLE
fix: fixed pod management behavior on CN scaling

### DIFF
--- a/pkg/controllers/cnstore/controller.go
+++ b/pkg/controllers/cnstore/controller.go
@@ -130,6 +130,7 @@ func (c *withCNSet) OnPreparingDelete(ctx *recon.Context[*corev1.Pod]) error {
 	}
 	for _, sess := range resp.GetSessions() {
 		if sess.Account != "" && sess.Account != "sys" {
+			ctx.Log.Info("session is not drained, session account", "account", sess.Account)
 			accountSession++
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes CN scaling behavior

1. Failed/Completed Pod may abort failover (scale-out)
2. There is no CN to accept migrated sessions on Pod rolling-re-create scenario

**What this PR does / why we need it:**

Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
