### PR TITLE
fix: set cnset status replicas to cloneset ready replicas

### DIFF
--- a/api/core/v1alpha1/cnset_types.go
+++ b/api/core/v1alpha1/cnset_types.go
@@ -113,6 +113,7 @@ type CNSetStatus struct {
 	Stores []CNStore `json:"stores,omitempty"`
 
 	Replicas      int32  `json:"replicas,omitempty"`
+	ReadyReplicas int32  `json:"readyReplicas,omitempty"`
 	LabelSelector string `json:"labelSelector,omitempty"`
 
 	Host string `json:"host,omitempty"`

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_cnsets.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_cnsets.yaml
@@ -370,6 +370,9 @@ spec:
                 type: string
               port:
                 type: integer
+              readyReplicas:
+                format: int32
+                type: integer
               replicas:
                 format: int32
                 type: integer

--- a/deploy/crds/core.matrixorigin.io_cnsets.yaml
+++ b/deploy/crds/core.matrixorigin.io_cnsets.yaml
@@ -370,6 +370,9 @@ spec:
                 type: string
               port:
                 type: integer
+              readyReplicas:
+                format: int32
+                type: integer
               replicas:
                 format: int32
                 type: integer

--- a/pkg/controllers/cnset/controller.go
+++ b/pkg/controllers/cnset/controller.go
@@ -119,6 +119,7 @@ func (c *Actor) Observe(ctx *recon.Context[*v1alpha1.CNSet]) (recon.Action[*v1al
 	}
 	cn.Status.Stores = stores
 	cn.Status.Replicas = cs.Status.Replicas
+	cn.Status.ReadyReplicas = cs.Status.ReadyReplicas
 	cn.Status.LabelSelector = cs.Status.LabelSelector
 	// sync status from cloneset
 	if cs.Status.ReadyReplicas >= cn.Spec.Replicas {


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes # https://github.com/matrixorigin/MO-Cloud/issues/1321

**What this PR does / why we need it:**

only when cn pod ready, the cluster `ready` condition should be true

**Special notes for your reviewer:**

There are two ways to fix this probelm:

1. the simple one, let `cn.status.replicas` mean the ready replicas, not the total replicas, that is what this pr does. also in `unit-agent`, field `cn.status.replicas` means the ready replicas.
2. the complex one, add another `cn.status.readyReplicas` field to indicate ready replicas


**Additional documentation (e.g. design docs, usage docs, etc.):**

in openkruise cloneset the field `cs.Status.Replicas` means the total replicas