### PR TITLE
fix: gen sha256 sum before restore

### DIFF
--- a/pkg/controllers/br/command.go
+++ b/pkg/controllers/br/command.go
@@ -80,6 +80,7 @@ type RestoreCommand struct {
 func (c *RestoreCommand) String() string {
 	sb := strings.Builder{}
 	sb.WriteString(fmt.Sprintf("echo $%s > /mo_br.meta", RawMetaEnv))
+	sb.WriteString(` && sha256sum mo_br.meta | awk '{printf "%s",$1}' > mo_br.meta.sha256`)
 	sb.WriteString(" && /mo_br restore")
 	sb.WriteString(fmt.Sprintf(" %s", c.BackupID))
 	sb.WriteString(" --restore_dir s3")


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

mo-backup new version need sha256 checksum, generate the checksum before restore

**What this PR does / why we need it:**

Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
