### PR TITLE
fix: set CN draining if store-drain-enabled

### DIFF
--- a/pkg/controllers/cnset/resource.go
+++ b/pkg/controllers/cnset/resource.go
@@ -264,6 +264,9 @@ func buildCNSetConfigMap(cn *v1alpha1.CNSet, ls *v1alpha1.LogSet) (*corev1.Confi
 		}
 		cfg.Set([]string{"cn", "python-udf-client", "server-address"}, fmt.Sprintf("localhost:%d", port))
 	}
+	if cn.Spec.ScalingConfig.GetStoreDrainEnabled() {
+		cfg.Set([]string{"cn", "init-work-state"}, "Draining")
+	}
 	s, err := cfg.ToString()
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/cnset/resource_test.go
+++ b/pkg/controllers/cnset/resource_test.go
@@ -1,0 +1,174 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cnset
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/matrixorigin/matrixone-operator/api/core/v1alpha1"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"testing"
+)
+
+func Test_buildCNSetConfigMap(t *testing.T) {
+	type args struct {
+		cn *v1alpha1.CNSet
+		ls *v1alpha1.LogSet
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantConfig string
+		wantErr    bool
+	}{
+		{
+			name: "default",
+			args: args{
+				cn: &v1alpha1.CNSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test",
+					},
+				},
+				ls: &v1alpha1.LogSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test",
+					},
+					Spec: v1alpha1.LogSetSpec{SharedStorage: v1alpha1.SharedStorageProvider{
+						FileSystem: &v1alpha1.FileSystemProvider{
+							Path: "/test",
+						},
+					}},
+					Status: v1alpha1.LogSetStatus{
+						Discovery: &v1alpha1.LogSetDiscovery{
+							Port:    6001,
+							Address: "test",
+						},
+					},
+				},
+			},
+			wantConfig: `data-dir = "/var/lib/matrixone/data"
+service-type = "CN"
+
+[cn]
+port-base = 6002
+role = ""
+
+[cn.lockservice]
+listen-address = "0.0.0.0:6003"
+
+[[fileservice]]
+backend = "DISK"
+data-dir = "/var/lib/matrixone/data"
+name = "LOCAL"
+
+[[fileservice]]
+backend = "DISK"
+data-dir = "/test"
+name = "S3"
+
+[[fileservice]]
+backend = "DISK-ETL"
+data-dir = "/test"
+name = "ETL"
+
+[fileservice.cache]
+memory-capacity = "1B"
+
+[hakeeper-client]
+service-addresses = []
+`,
+		},
+		{
+			name: "store-drain-enabled",
+			args: args{
+				cn: &v1alpha1.CNSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test",
+					},
+					Spec: v1alpha1.CNSetSpec{
+						ScalingConfig: v1alpha1.ScalingConfig{
+							StoreDrainEnabled: pointer.Bool(true),
+						},
+					},
+				},
+				ls: &v1alpha1.LogSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test",
+					},
+					Spec: v1alpha1.LogSetSpec{SharedStorage: v1alpha1.SharedStorageProvider{
+						FileSystem: &v1alpha1.FileSystemProvider{
+							Path: "/test",
+						},
+					}},
+					Status: v1alpha1.LogSetStatus{
+						Discovery: &v1alpha1.LogSetDiscovery{
+							Port:    6001,
+							Address: "test",
+						},
+					},
+				},
+			},
+			wantConfig: `data-dir = "/var/lib/matrixone/data"
+service-type = "CN"
+
+[cn]
+init-work-state = "Draining"
+port-base = 6002
+role = ""
+
+[cn.lockservice]
+listen-address = "0.0.0.0:6003"
+
+[[fileservice]]
+backend = "DISK"
+data-dir = "/var/lib/matrixone/data"
+name = "LOCAL"
+
+[[fileservice]]
+backend = "DISK"
+data-dir = "/test"
+name = "S3"
+
+[[fileservice]]
+backend = "DISK-ETL"
+data-dir = "/test"
+name = "ETL"
+
+[fileservice.cache]
+memory-capacity = "1B"
+
+[hakeeper-client]
+service-addresses = []
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			got, err := buildCNSetConfigMap(tt.args.cn, tt.args.ls)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildDNSetConfigMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			g.Expect(got.Data["config.toml"]).NotTo(BeNil())
+			g.Expect(cmp.Diff(tt.wantConfig, got.Data["config.toml"])).To(BeEmpty())
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

close https://github.com/matrixorigin/MO-Cloud/issues/2044

```
mysql> show backend servers;
+--------------------------------------+---------------------+------------+-----------------------------------------------+
| UUID                                 | Address             | Work State | Labels                                        |
+--------------------------------------+---------------------+------------+-----------------------------------------------+
| 62343135-3136-3437-3661-353239383339 | 172.20.144.131:6001 | Working    | account:ba537a2b_43e7_4a2c_a6fe_b945278ef41a; |
| 65363231-3433-3463-3339-336564666237 | 172.20.150.3:6001   | Draining   |                                               |
| 61666565-3261-6361-3239-663534373438 | 172.20.149.131:6001 | Draining   |                                               |
| 31343430-3266-6231-3763-626161636362 | 172.20.129.4:6001   | Working    |                                               |
| 32383634-3731-3638-3262-373530353032 | 172.20.132.133:6001 | Working    |                                               |
+--------------------------------------+---------------------+------------+-----------------------------------------------+
5 rows in set (0.04 sec)

mysql> show backend servers;
+--------------------------------------+---------------------+------------+-----------------------------------------------+
| UUID                                 | Address             | Work State | Labels                                        |
+--------------------------------------+---------------------+------------+-----------------------------------------------+
| 32383634-3731-3638-3262-373530353032 | 172.20.132.133:6001 | Working    |                                               |
| 61666565-3261-6361-3239-663534373438 | 172.20.149.131:6001 | Working    | account:ba537a2b_43e7_4a2c_a6fe_b945278ef41a; |
| 62343135-3136-3437-3661-353239383339 | 172.20.144.131:6001 | Working    | account:ba537a2b_43e7_4a2c_a6fe_b945278ef41a; |
| 65363231-3433-3463-3339-336564666237 | 172.20.150.3:6001   | Working    |                                               |
| 31343430-3266-6231-3763-626161636362 | 172.20.129.4:6001   | Working    |                                               |
+--------------------------------------+---------------------+------------+-----------------------------------------------+
5 rows in set (0.03 sec)
```

**What this PR does / why we need it:**

Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
