### PR TITLE
feat: delete draining timeout pod and watch claim on pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ test: api-test unit
 
 # Run unit tests
 unit: generate fmt vet manifests
-	go test ./pkg/... -coverprofile cover.out
+	CGO_ENABLED=0 go test ./pkg/... -coverprofile cover.out
 
 api-test:
 	cd api && make test

--- a/api/core/v1alpha1/cnclaim_helper.go
+++ b/api/core/v1alpha1/cnclaim_helper.go
@@ -1,0 +1,23 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+func (c *CNClaim) IsReady() bool {
+	return c.Status.Phase == CNClaimPhaseBound || c.Status.Phase == CNClaimPhaseOutdated
+}
+
+func (c *CNClaim) IsUpdated() bool {
+	return c.Status.Phase == CNClaimPhaseBound
+}

--- a/api/core/v1alpha1/cnclaim_types.go
+++ b/api/core/v1alpha1/cnclaim_types.go
@@ -25,6 +25,8 @@ const (
 	CNClaimPhaseBound   CNClaimPhase = "Bound"
 	CNClaimPhaseLost    CNClaimPhase = "Lost"
 
+	CNClaimPhaseOutdated CNClaimPhase = "Outdated"
+
 	ClaimOwnerNameLabel = "matrixorigin.io/claim-owner"
 )
 

--- a/pkg/controllers/cnclaim/controller.go
+++ b/pkg/controllers/cnclaim/controller.go
@@ -146,7 +146,7 @@ func (r *Actor) doClaimCN(ctx *recon.Context[*v1alpha1.CNClaim], orphans []corev
 		return nil, errors.Wrap(err, "error list idle Pods")
 	}
 
-	slices.SortFunc(idleCNs, priorityFunc(c))
+	sortCNByPriority(c, idleCNs)
 	for i := range idleCNs {
 		pod := &idleCNs[i]
 		pod.Labels[v1alpha1.CNPodPhaseLabel] = v1alpha1.CNPodPhaseBound
@@ -291,6 +291,10 @@ func toStoreStatus(cn *metadata.CNService) v1alpha1.CNStoreStatus {
 		WorkState:              int32(cn.WorkState),
 		Labels:                 ls,
 	}
+}
+
+func sortCNByPriority(c *v1alpha1.CNClaim, pods []corev1.Pod) {
+	slices.SortFunc(pods, priorityFunc(c))
 }
 
 func priorityFunc(c *v1alpha1.CNClaim) func(a, b corev1.Pod) int {

--- a/pkg/controllers/cnclaim/controller_test.go
+++ b/pkg/controllers/cnclaim/controller_test.go
@@ -1,0 +1,92 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cnclaim
+
+import (
+	"github.com/matrixorigin/matrixone-operator/api/core/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"math/rand"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_sortCNByPriority(t *testing.T) {
+	tests := []struct {
+		name  string
+		c     *v1alpha1.CNClaim
+		pods  []corev1.Pod
+		order []string
+	}{{
+		name: "basic",
+		c: &v1alpha1.CNClaim{
+			Spec: v1alpha1.CNClaimSpec{
+				OwnerName: pointer.String("set1"),
+			},
+		},
+		pods: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "not-claimed-but-older",
+					Labels: map[string]string{
+						v1alpha1.CNPodPhaseLabel: v1alpha1.CNPodPhaseIdle,
+					},
+					CreationTimestamp: metav1.Unix(0, 0),
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "previously-claimed",
+					Labels: map[string]string{
+						v1alpha1.CNPodPhaseLabel:     v1alpha1.CNPodPhaseIdle,
+						v1alpha1.ClaimOwnerNameLabel: "set1",
+					},
+					CreationTimestamp: metav1.Unix(10, 0),
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "previously-claimed-by-other-set",
+					Labels: map[string]string{
+						v1alpha1.CNPodPhaseLabel:     v1alpha1.CNPodPhaseIdle,
+						v1alpha1.ClaimOwnerNameLabel: "set2",
+					},
+					CreationTimestamp: metav1.Unix(10, 0),
+				},
+			},
+		},
+		order: []string{
+			"previously-claimed",
+			"not-claimed-but-older",
+			"previously-claimed-by-other-set",
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rand.Shuffle(len(tt.pods), func(i, j int) {
+				tt.pods[i], tt.pods[j] = tt.pods[j], tt.pods[i]
+			})
+			sortCNByPriority(tt.c, tt.pods)
+			g := NewGomegaWithT(t)
+			var res []string
+			for _, po := range tt.pods {
+				res = append(res, po.Name)
+			}
+			g.Expect(res).To(Equal(tt.order))
+		})
+	}
+}

--- a/pkg/controllers/cnpool/controller_test.go
+++ b/pkg/controllers/cnpool/controller_test.go
@@ -1,0 +1,93 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cnpool
+
+import (
+	"github.com/matrixorigin/matrixone-operator/api/core/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"math/rand"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_sortPodByDeletionOrder(t *testing.T) {
+	tests := []struct {
+		name  string
+		pods  []*corev1.Pod
+		order []string
+	}{{
+		name: "basic",
+		pods: []*corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "idle-new",
+					Labels: map[string]string{
+						v1alpha1.CNPodPhaseLabel: v1alpha1.CNPodPhaseIdle,
+					},
+					CreationTimestamp: metav1.Unix(10, 0),
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "unknown",
+					Labels: map[string]string{
+						v1alpha1.CNPodPhaseLabel: v1alpha1.CNPodPhaseUnknown,
+					},
+					CreationTimestamp: metav1.Unix(10, 0),
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "idle-old",
+					Labels: map[string]string{
+						v1alpha1.CNPodPhaseLabel: v1alpha1.CNPodPhaseIdle,
+					},
+					CreationTimestamp: metav1.Unix(0, 0),
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "terminating",
+					Labels: map[string]string{
+						v1alpha1.CNPodPhaseLabel: v1alpha1.CNPodPhaseTerminating,
+					},
+					CreationTimestamp: metav1.Unix(10, 0),
+				},
+			},
+		},
+		order: []string{
+			"terminating",
+			"unknown",
+			"idle-new",
+			"idle-old",
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rand.Shuffle(len(tt.pods), func(i, j int) {
+				tt.pods[i], tt.pods[j] = tt.pods[j], tt.pods[i]
+			})
+			sortPodByDeletionOrder(tt.pods)
+			g := NewGomegaWithT(t)
+			var res []string
+			for _, po := range tt.pods {
+				res = append(res, po.Name)
+			}
+			g.Expect(res).To(Equal(tt.order))
+		})
+	}
+}

--- a/pkg/controllers/cnstore/pooling.go
+++ b/pkg/controllers/cnstore/pooling.go
@@ -65,7 +65,11 @@ func (c *withCNSet) poolingCNReconcile(ctx *recon.Context[*corev1.Pod]) error {
 			return errors.Wrap(err, "error get store connection count")
 		}
 		if count == 0 {
-			return c.patchPhase(ctx, v1alpha1.CNPodPhaseIdle)
+			return ctx.Patch(pod, func() error {
+				delete(pod.Annotations, common.ReclaimedAt)
+				pod.Labels[v1alpha1.CNPodPhaseLabel] = v1alpha1.CNPodPhaseIdle
+				return nil
+			})
 		}
 		return recon.ErrReSync("store is still draining", retryInterval)
 	case v1alpha1.CNPodPhaseBound, v1alpha1.CNPodPhaseIdle:

--- a/pkg/controllers/cnstore/pooling.go
+++ b/pkg/controllers/cnstore/pooling.go
@@ -17,11 +17,13 @@ package cnstore
 import (
 	"context"
 	recon "github.com/matrixorigin/controller-runtime/pkg/reconciler"
+	"github.com/matrixorigin/controller-runtime/pkg/util"
 	"github.com/matrixorigin/matrixone-operator/api/core/v1alpha1"
 	"github.com/matrixorigin/matrixone-operator/pkg/controllers/common"
 	"github.com/matrixorigin/matrixone-operator/pkg/hacli"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"time"
 )
 
@@ -47,7 +49,7 @@ func (c *withCNSet) poolingCNReconcile(ctx *recon.Context[*corev1.Pod]) error {
 		// recycle the pod
 		timeStr, ok := pod.Annotations[common.ReclaimedAt]
 		if !ok {
-			// legacy pod, simply timeout
+			// legacy pod, simply return it to the pool
 			return c.patchPhase(ctx, v1alpha1.CNPodPhaseIdle)
 		}
 		parsed, err := time.Parse(time.RFC3339, timeStr)
@@ -55,7 +57,8 @@ func (c *withCNSet) poolingCNReconcile(ctx *recon.Context[*corev1.Pod]) error {
 			return errors.Wrapf(err, "error parsing start time %s", timeStr)
 		}
 		if time.Since(parsed) > recycleTimeout {
-			return c.patchPhase(ctx, v1alpha1.CNPodPhaseIdle)
+			ctx.Log.Info("drain pool pod timeout, delete it to avoid workload intervention")
+			return util.Ignore(apierrors.IsNotFound, ctx.Delete(pod))
 		}
 		count, err := common.GetStoreConnection(pod)
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

This PR introduce two changes:

1. Draining Pod will be deleted if draining timed out, to avoid workload intervention;
2. pool controller will watch claims refers to the pool to achieve more responsive reconciliation

**What this PR does / why we need it:**

Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
