### PR TITLE
feature: support `serviceAnnotations` for proxy set

### DIFF
--- a/api/core/v1alpha1/proxy_types.go
+++ b/api/core/v1alpha1/proxy_types.go
@@ -29,6 +29,10 @@ type ProxySetSpec struct {
 	// +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
+	// ServiceAnnotations are the annotations for the proxy service
+	// +optional
+	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
+
 	// NodePort specifies the node port to use when ServiceType is NodePort or LoadBalancer,
 	// reconciling will fail if the node port is not available.
 	// +optional

--- a/api/core/v1alpha1/zz_generated.deepcopy.go
+++ b/api/core/v1alpha1/zz_generated.deepcopy.go
@@ -2051,6 +2051,13 @@ func (in *ProxySetList) DeepCopyObject() runtime.Object {
 func (in *ProxySetSpec) DeepCopyInto(out *ProxySetSpec) {
 	*out = *in
 	in.PodSet.DeepCopyInto(&out.PodSet)
+	if in.ServiceAnnotations != nil {
+		in, out := &in.ServiceAnnotations, &out.ServiceAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.NodePort != nil {
 		in, out := &in.NodePort, &out.NodePort
 		*out = new(int32)

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_matrixoneclusters.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_matrixoneclusters.yaml
@@ -1255,6 +1255,12 @@ spec:
                       tag is a valid semantic version, operator will treat the MO
                       as unknown version and will not apply any version-specific reconciliations
                     type: string
+                  serviceAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: ServiceAnnotations are the annotations for the proxy
+                      service
+                    type: object
                   serviceArgs:
                     description: 'ServiceArgs define command line options for process,
                       used by logset/cnset/dnset service. NOTE: user should not define

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_proxysets.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_proxysets.yaml
@@ -155,6 +155,12 @@ spec:
                   semantic version, operator will treat the MO as unknown version
                   and will not apply any version-specific reconciliations
                 type: string
+              serviceAnnotations:
+                additionalProperties:
+                  type: string
+                description: ServiceAnnotations are the annotations for the proxy
+                  service
+                type: object
               serviceArgs:
                 description: 'ServiceArgs define command line options for process,
                   used by logset/cnset/dnset service. NOTE: user should not define

--- a/deploy/crds/core.matrixorigin.io_matrixoneclusters.yaml
+++ b/deploy/crds/core.matrixorigin.io_matrixoneclusters.yaml
@@ -1255,6 +1255,12 @@ spec:
                       tag is a valid semantic version, operator will treat the MO
                       as unknown version and will not apply any version-specific reconciliations
                     type: string
+                  serviceAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: ServiceAnnotations are the annotations for the proxy
+                      service
+                    type: object
                   serviceArgs:
                     description: 'ServiceArgs define command line options for process,
                       used by logset/cnset/dnset service. NOTE: user should not define

--- a/deploy/crds/core.matrixorigin.io_proxysets.yaml
+++ b/deploy/crds/core.matrixorigin.io_proxysets.yaml
@@ -155,6 +155,12 @@ spec:
                   semantic version, operator will treat the MO as unknown version
                   and will not apply any version-specific reconciliations
                 type: string
+              serviceAnnotations:
+                additionalProperties:
+                  type: string
+                description: ServiceAnnotations are the annotations for the proxy
+                  service
+                type: object
               serviceArgs:
                 description: 'ServiceArgs define command line options for process,
                   used by logset/cnset/dnset service. NOTE: user should not define

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -1051,6 +1051,7 @@ _Appears in:_
 | --- | --- |
 | `PodSet` _[PodSet](#podset)_ |  |
 | `serviceType` _[ServiceType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#servicetype-v1-core)_ | ServiceType is the service type of proxy service |
+| `serviceAnnotations` _object (keys:string, values:string)_ | ServiceAnnotations are the annotations for the proxy service |
 | `nodePort` _integer_ | NodePort specifies the node port to use when ServiceType is NodePort or LoadBalancer, reconciling will fail if the node port is not available. |
 
 

--- a/pkg/controllers/cnset/resource.go
+++ b/pkg/controllers/cnset/resource.go
@@ -18,11 +18,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"text/template"
+
 	"github.com/matrixorigin/controller-runtime/pkg/util"
 	kruisev1alpha1 "github.com/openkruise/kruise-api/apps/v1alpha1"
 	"golang.org/x/exp/slices"
-	"strconv"
-	"text/template"
 
 	"github.com/matrixorigin/matrixone-operator/api/core/v1alpha1"
 	"github.com/matrixorigin/matrixone-operator/pkg/controllers/common"
@@ -125,10 +126,15 @@ func syncService(cn *v1alpha1.CNSet, svc *corev1.Service) {
 			svc.Spec.Ports[portIndex].NodePort = *cn.Spec.NodePort
 		}
 	}
-	svc.Annotations = cn.Spec.ServiceAnnotations
+
 	if svc.Annotations == nil {
 		svc.Annotations = map[string]string{}
 	}
+	// add CNSet.CNSetSpec.ServiceAnnotations to service.Annotations
+	for key, value := range cn.Spec.ServiceAnnotations {
+		svc.Annotations[key] = value
+	}
+
 	if cn.Spec.GetExportToPrometheus() {
 		svc.Annotations[common.PrometheusScrapeAnno] = "true"
 		svc.Annotations[common.PrometheusPortAnno] = strconv.Itoa(common.MetricsPort)

--- a/pkg/controllers/proxyset/resource.go
+++ b/pkg/controllers/proxyset/resource.go
@@ -128,12 +128,14 @@ func syncSvc(proxy *v1alpha1.ProxySet, svc *corev1.Service) {
 			svc.Spec.Ports[portIndex].NodePort = *proxy.Spec.NodePort
 		}
 	}
-	// add ProxySetSpec.ServiceAnnotations to service.Annotations
-	svc.Annotations = proxy.Spec.ServiceAnnotations
+
 	if svc.Annotations == nil {
 		svc.Annotations = map[string]string{}
 	}
-
+	// add ProxySet.ProxySetSpec.ServiceAnnotations to service.Annotations
+	for key, value := range proxy.Spec.ServiceAnnotations {
+		svc.Annotations[key] = value
+	}
 	if proxy.Spec.GetExportToPrometheus() {
 		svc.Annotations[common.PrometheusScrapeAnno] = "true"
 		svc.Annotations[common.PrometheusPortAnno] = strconv.Itoa(common.MetricsPort)

--- a/pkg/controllers/proxyset/resource.go
+++ b/pkg/controllers/proxyset/resource.go
@@ -17,6 +17,9 @@ package proxyset
 import (
 	"bytes"
 	"fmt"
+	"strconv"
+	"text/template"
+
 	recon "github.com/matrixorigin/controller-runtime/pkg/reconciler"
 	"github.com/matrixorigin/matrixone-operator/api/core/v1alpha1"
 	"github.com/matrixorigin/matrixone-operator/pkg/controllers/common"
@@ -26,8 +29,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"strconv"
-	"text/template"
 )
 
 const (
@@ -127,6 +128,12 @@ func syncSvc(proxy *v1alpha1.ProxySet, svc *corev1.Service) {
 			svc.Spec.Ports[portIndex].NodePort = *proxy.Spec.NodePort
 		}
 	}
+	// add ProxySetSpec.ServiceAnnotations to service.Annotations
+	svc.Annotations = proxy.Spec.ServiceAnnotations
+	if svc.Annotations == nil {
+		svc.Annotations = map[string]string{}
+	}
+
 	if proxy.Spec.GetExportToPrometheus() {
 		svc.Annotations[common.PrometheusScrapeAnno] = "true"
 		svc.Annotations[common.PrometheusPortAnno] = strconv.Itoa(common.MetricsPort)


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #

**What this PR does / why we need it:**

CI测试大部分将会由cn+dn+log转为proxy+cn+dn+log，目前机房中通过在mo cluster的yaml里面指定cn service的annotation来指定lb的ip，转为proxy之后无法通过以上方式指定lb的ip，故在operator的proxy set中增加对ServiceAnnotations字段的支持

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
