### PR TITLE
fix: skip already deleted pod when sync CNPools

### DIFF
--- a/pkg/controllers/cnpool/controller.go
+++ b/pkg/controllers/cnpool/controller.go
@@ -81,19 +81,19 @@ func (r *Actor) Sync(ctx *recon.Context[*v1alpha1.CNPool]) error {
 	var idlePods []*corev1.Pod
 	var terminatingPods []*corev1.Pod
 	if current != nil {
-		pods, err := listCNSetPods(ctx, current)
+		err := iterateCNSetLivePods(ctx, current, func(p *corev1.Pod) error {
+			if podInUse(p) {
+				inUse++
+			} else if p.Labels[v1alpha1.CNPodPhaseLabel] == v1alpha1.CNPodPhaseTerminating {
+				ctx.Log.Info("find pod still in terminating state", "pod", p.Name)
+				terminatingPods = append(terminatingPods, p)
+			} else {
+				idlePods = append(idlePods, p)
+			}
+			return nil
+		})
 		if err != nil {
 			return errors.Wrapf(err, "error list CN pods for %s", current.Name)
-		}
-		for i := range pods {
-			if podInUse(&pods[i]) {
-				inUse++
-			} else if pods[i].Labels[v1alpha1.CNPodPhaseLabel] == v1alpha1.CNPodPhaseTerminating {
-				ctx.Log.Info("find pod still in terminating state", "pod", pods[i].Name)
-				terminatingPods = append(terminatingPods, &pods[i])
-			} else {
-				idlePods = append(idlePods, &pods[i])
-			}
 		}
 	}
 
@@ -170,24 +170,23 @@ func (r *Actor) Sync(ctx *recon.Context[*v1alpha1.CNPool]) error {
 // TODO(aylei): rethink here, operator should try it best to reuse cache
 func (r *Actor) syncLegacySet(ctx *recon.Context[*v1alpha1.CNPool], cnSet *v1alpha1.CNSet) (int32, error) {
 	var replicas int32
-	pods, err := listCNSetPods(ctx, cnSet)
-	if err != nil {
-		return replicas, errors.Wrapf(err, "error list CNSet Pods for %s", cnSet.Name)
-	}
 	var toDelete []string
-	for i := range pods {
-		pod := pods[i]
+	err := iterateCNSetLivePods(ctx, cnSet, func(p *corev1.Pod) error {
 		// TODO(aylei): reclaim timeout logic
-		if podInUse(&pod) {
+		if podInUse(p) {
 			// keep in-use CN but try reclaim the cnclaim
-			if err := r.reclaimLegacyCNClaim(ctx, &pod); err != nil {
-				return replicas, err
+			if err := r.reclaimLegacyCNClaim(ctx, p); err != nil {
+				return err
 			}
 			replicas++
 		} else {
 			// recalim other CN
-			toDelete = append(toDelete, pods[i].Name)
+			toDelete = append(toDelete, p.Name)
 		}
+		return nil
+	})
+	if err != nil {
+		return replicas, errors.Wrapf(err, "error list CNSet Pods for %s", cnSet.Name)
 	}
 	// clean unused CNSet
 	if err := recon.CreateOwnedOrUpdate(ctx, cnSet, func() error {
@@ -243,19 +242,30 @@ func listNominatedClaims(cli recon.KubeClient, pool *v1alpha1.CNPool) ([]v1alpha
 	return claimList.Items, nil
 }
 
-func listCNSetPods(cli recon.KubeClient, cnSet *v1alpha1.CNSet) ([]corev1.Pod, error) {
+// iterateCNSetLivePods iterates all live Pods of the given CNSet, Pods that have been deleted will be skipped
+func iterateCNSetLivePods(cli recon.KubeClient, cnSet *v1alpha1.CNSet, fn func(p *corev1.Pod) error) error {
 	if cnSet.Status.LabelSelector == "" {
-		return nil, nil
+		return nil
 	}
 	ls, err := metav1.ParseToLabelSelector(cnSet.Status.LabelSelector)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing label selector of CNSet, name: %s, selector: %s", cnSet.Name, cnSet.Status.LabelSelector)
+		return errors.Wrapf(err, "error parsing label selector of CNSet, name: %s, selector: %s", cnSet.Name, cnSet.Status.LabelSelector)
 	}
 	podList := &corev1.PodList{}
 	if err := cli.List(podList, client.InNamespace(cnSet.Namespace), client.MatchingLabels(ls.MatchLabels)); err != nil {
-		return nil, errors.Wrapf(err, "error list pods of CNSet %s", cnSet.Name)
+		return errors.Wrapf(err, "error list pods of CNSet %s", cnSet.Name)
 	}
-	return podList.Items, nil
+	for i := range podList.Items {
+		p := &podList.Items[i]
+		if p.DeletionTimestamp != nil {
+			// Pod deleted, skip
+			continue
+		}
+		if err := fn(p); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func buildCNSet(p *v1alpha1.CNPool) (*v1alpha1.CNSet, error) {

--- a/pkg/controllers/cnpool/controller_test.go
+++ b/pkg/controllers/cnpool/controller_test.go
@@ -15,10 +15,21 @@
 package cnpool
 
 import (
+	"context"
+	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
+	"github.com/matrixorigin/controller-runtime/pkg/fake"
 	"github.com/matrixorigin/matrixone-operator/api/core/v1alpha1"
+	"github.com/matrixorigin/matrixone-operator/pkg/utils"
+	kruisev1alpha1 "github.com/openkruise/kruise-api/apps/v1alpha1"
+	kruisev1 "github.com/openkruise/kruise-api/apps/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"math/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
 	"time"
 
@@ -92,4 +103,122 @@ func Test_sortPodByDeletionOrder(t *testing.T) {
 			g.Expect(res).To(Equal(tt.order))
 		})
 	}
+}
+
+func Test_syncLegacySet(t *testing.T) {
+	s := newScheme()
+	tests := []struct {
+		name   string
+		cnSet  *v1alpha1.CNSet
+		client client.Client
+		expect func(g *WithT, cli client.Client, replicas int32, err error)
+	}{
+		{
+			name: "comprehensive",
+			cnSet: &v1alpha1.CNSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Status: v1alpha1.CNSetStatus{
+					LabelSelector: "foo=bar",
+				},
+			},
+			client: fake.KubeClientBuilder().WithScheme(s).WithObjects(
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "unused",
+						Namespace: "test",
+						Labels: map[string]string{
+							"foo":                    "bar",
+							v1alpha1.CNPodPhaseLabel: v1alpha1.CNPodPhaseIdle,
+						},
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "used",
+						Namespace: "test",
+						Labels: map[string]string{
+							"foo":                      "bar",
+							v1alpha1.CNPodPhaseLabel:   v1alpha1.CNPodPhaseBound,
+							v1alpha1.PodClaimedByLabel: "test-claim",
+						},
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "deleted",
+						Namespace: "test",
+						Labels: map[string]string{
+							"foo":                    "bar",
+							v1alpha1.CNPodPhaseLabel: v1alpha1.CNPodPhaseIdle,
+						},
+						DeletionTimestamp: utils.PtrTo(metav1.Now()),
+						Finalizers:        []string{"mock"},
+					},
+				},
+				&v1alpha1.CNClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test-claim",
+					},
+					Status: v1alpha1.CNClaimStatus{
+						Phase: v1alpha1.CNClaimPhaseBound,
+					},
+				},
+			).WithStatusSubresource(&v1alpha1.CNClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "test-claim",
+				},
+				Status: v1alpha1.CNClaimStatus{
+					Phase: v1alpha1.CNClaimPhaseBound,
+				},
+			}).Build(),
+			expect: func(g *WithT, cli client.Client, replicas int32, err error) {
+				g.Expect(err).To(BeNil())
+				g.Expect(replicas).To(Equal(int32(1)))
+				cnClaim := &v1alpha1.CNClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test-claim",
+					},
+				}
+				g.Expect(cli.Get(context.TODO(), client.ObjectKeyFromObject(cnClaim), cnClaim)).To(Succeed())
+				g.Expect(cnClaim.Status.Phase).To(Equal(v1alpha1.CNClaimPhaseOutdated))
+				cnSet := &v1alpha1.CNSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+				}
+				g.Expect(cli.Get(context.TODO(), client.ObjectKeyFromObject(cnSet), cnSet)).To(Succeed())
+				g.Expect(cnSet.Spec.PodsToDelete).To(ConsistOf("unused"))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			mockCtrl := gomock.NewController(t)
+			eventEmitter := fake.NewMockEventEmitter(mockCtrl)
+			ctx := fake.NewContext(&v1alpha1.CNPool{}, tt.client, eventEmitter)
+			r := &Actor{
+				Logger: logr.Discard(),
+			}
+			res, err := r.syncLegacySet(ctx, tt.cnSet)
+			tt.expect(g, tt.client, res, err)
+		})
+	}
+}
+
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(kruisev1.AddToScheme(scheme))
+	utilruntime.Must(kruisev1alpha1.AddToScheme(scheme))
+
+	return scheme
 }


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

ref: https://github.com/matrixorigin/MO-Cloud/issues/2928

**What this PR does / why we need it:**

Skip already deleted Pod when sync CN Pool, leave the deleted pod to terminating controller.

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
