### PR TITLE
fix: cn-pool reclaim should respect storeDrainTimeout

### DIFF
--- a/kind.yaml
+++ b/kind.yaml
@@ -2,3 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 featureGates:
   InPlacePodVerticalScaling: true
+  MemoryQoS: true

--- a/pkg/controllers/cnstore/pooling.go
+++ b/pkg/controllers/cnstore/pooling.go
@@ -27,11 +27,6 @@ import (
 	"time"
 )
 
-const (
-	// TODO(aylei): configurable
-	recycleTimeout = 5 * time.Minute
-)
-
 func (c *withCNSet) poolingCNReconcile(ctx *recon.Context[*corev1.Pod]) error {
 	pod := ctx.Obj
 	uid := v1alpha1.GetCNPodUUID(pod)
@@ -56,7 +51,7 @@ func (c *withCNSet) poolingCNReconcile(ctx *recon.Context[*corev1.Pod]) error {
 		if err != nil {
 			return errors.Wrap(err, 0)
 		}
-		if time.Since(parsed) > recycleTimeout {
+		if time.Since(parsed) > c.cn.Spec.ScalingConfig.GetStoreDrainTimeout() {
 			ctx.Log.Info("drain pool pod timeout, delete it to avoid workload intervention")
 			return util.Ignore(apierrors.IsNotFound, ctx.Delete(pod))
 		}


### PR DESCRIPTION
### **User description**
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

part of: https://github.com/matrixorigin/MO-Cloud/issues/3221

**What this PR does / why we need it:**

Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available


___

### **PR Type**
Bug fix, Configuration changes


___

### **Description**
- Removed hardcoded `recycleTimeout` and replaced it with `GetStoreDrainTimeout` from `ScalingConfig` in `poolingCNReconcile` function.
- Added usage of `GetMinDelayDuration` from `ScalingConfig` for delay duration check.
- Enabled `MemoryQoS` feature gate in `kind.yaml` configuration file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pooling.go</strong><dd><code>Use configurable store drain timeout and delay duration</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/controllers/cnstore/pooling.go

<li>Removed hardcoded <code>recycleTimeout</code> constant.<br> <li> Updated timeout logic to use <code>GetStoreDrainTimeout</code> from <code>ScalingConfig</code>.<br> <li> Added usage of <code>GetMinDelayDuration</code> for delay duration check.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone-operator/pull/505/files#diff-e2549fe15de0514a28cc2275c60a6d0d829dea98cdc15d2a3096f92c2fdbc6a3">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kind.yaml</strong><dd><code>Enable MemoryQoS feature gate in kind configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
kind.yaml

- Enabled `MemoryQoS` feature gate.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone-operator/pull/505/files#diff-c95a739c4105ffb3614757784af51daad2f2d5dc2cfddbeba7ae45032cd427b5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

