### PR TITLE
feat: support skip creating webhook resource when helm install

### DIFF
--- a/charts/matrixone-operator/Chart.yaml
+++ b/charts/matrixone-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: matrixone-operator
 description: Matrixone Kubernetes Operator
 type: application
-version: 1.2.0-alpha.5
+version: 1.2.0-alpha.6
 appVersion: 0.1.0
 kubeVersion: ">=1.19.0-0"
 icon: https://raw.githubusercontent.com/matrixorigin/artwork/main/docs/overview/logo.png

--- a/charts/matrixone-operator/templates/deployment.yaml
+++ b/charts/matrixone-operator/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.createResource }}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls
@@ -10,6 +11,7 @@ metadata:
     "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
 {{ ( include "matrixone-operator.gen-certs" . ) | indent 2 }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -85,7 +87,11 @@ spec:
       volumes:
       - name: certs
         secret:
+        {{- if .Values.webhook.createResource }}
           secretName: {{ template "matrixone-operator.name" . }}-certs
+        {{- else }}
+          secretName: {{ .Values.webhook.secretName }}
+        {{- end }}
       - name: config
         configMap:
           name: {{ template "matrixone-operator.name" . }}-cm

--- a/charts/matrixone-operator/templates/webhook.yaml
+++ b/charts/matrixone-operator/templates/webhook.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.createResource }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -235,3 +236,4 @@ webhooks:
     resources:
     - proxysets
   sideEffects: None
+{{- end}}

--- a/charts/matrixone-operator/values.yaml
+++ b/charts/matrixone-operator/values.yaml
@@ -19,6 +19,11 @@ backupRestore:
 # to a private registry
 globalRegistryPrefix: ""
 
+webhook:
+  createResource: true
+  # set secret if createResource=false
+  secretName: ""
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
### **User description**
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes # https://github.com/matrixorigin/MO-Cloud/issues/3911

**What this PR does / why we need it:**

user can deploy webhook resoruce separately, for security reason

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available


___

### **PR Type**
enhancement


___

### **Description**
- Added support to conditionally skip the creation of the webhook resource during Helm installation by introducing a new `webhook.createResource` flag.
- Updated the Helm chart version to 1.2.0-alpha.6.
- This enhancement allows users to deploy the webhook resource separately for security reasons.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chart.yaml</strong><dd><code>Update Helm chart version to 1.2.0-alpha.6</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/matrixone-operator/Chart.yaml

- Updated the chart version from 1.2.0-alpha.5 to 1.2.0-alpha.6.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone-operator/pull/537/files#diff-3015fff6a7a4f3cfcbbf215597d15b90b7b1bcdac8611b1a9b2544984bacab1c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Add webhook resource creation flag in values.yaml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/matrixone-operator/values.yaml

<li>Introduced a new <code>webhook.createResource</code> flag with default value <code>true</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone-operator/pull/537/files#diff-9452f700bfd40b82a6de7ad74609a14422174436c8ac58a1f1155e9753fa5ec3">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webhook.yaml</strong><dd><code>Add conditional creation for webhook resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/matrixone-operator/templates/webhook.yaml

<li>Added conditional logic to create webhook resource.<br> <li> Wrapped the webhook configuration with a conditional check.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone-operator/pull/537/files#diff-ae99b90719c25a4ffc40ba517e779b3c8d3b892725dee821a85faddc7a769ccc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

