### PR TITLE
feat: vendor kruise chart

### DIFF
--- a/charts/kruise/.helmignore
+++ b/charts/kruise/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/kruise/Chart.yaml
+++ b/charts/kruise/Chart.yaml
@@ -1,0 +1,24 @@
+annotations:
+  artifacthub.io/changes: |
+    - "[Changed]: https://github.com/openkruise/kruise/blob/master/CHANGELOG.md"
+    - "[Changed]: Support extra environment variables in the manager DaemonSet"
+apiVersion: v1
+appVersion: 1.4.0
+description: Helm chart for kruise components
+home: https://openkruise.io
+icon: https://openkruise.io/img/openkruise-logo-bg.jpg
+keywords:
+- openkruise
+- kubernetes
+- kruise
+- workload
+- statefulset
+- sidecar
+- job
+- deployment
+- cloneset
+kubeVersion: '>= 1.16.0-0'
+name: kruise
+sources:
+- https://github.com/openkruise/kruise
+version: 1.4.0

--- a/charts/kruise/README.md
+++ b/charts/kruise/README.md
@@ -1,0 +1,89 @@
+# Kruise v1.4.0
+
+## Configuration
+
+The following table lists the configurable parameters of the kruise chart and their default values.
+
+| Parameter                                 | Description                                                  | Default                       |
+| ----------------------------------------- | ------------------------------------------------------------ | ----------------------------- |
+| `featureGates`                            | Feature gates for Kruise, empty string means all enabled     | ` `                           |
+| `installation.namespace`                  | namespace for kruise installation                            | `kruise-system`               |
+| `installation.createNamespace`            | Whether to create the installation.namespace                 | `true`                        |
+| `manager.log.level`                       | Log level that kruise-manager printed                        | `4`                           |
+| `manager.replicas`                        | Replicas of kruise-controller-manager deployment             | `2`                           |
+| `manager.image.repository`                | Repository for kruise-manager image                          | `openkruise/kruise-manager`   |
+| `manager.image.tag`                       | Tag for kruise-manager image                                 | `v1.4.0`                      |
+| `manager.resources.limits.cpu`            | CPU resource limit of kruise-manager container               | `200m`                        |
+| `manager.resources.limits.memory`         | Memory resource limit of kruise-manager container            | `512Mi`                       |
+| `manager.resources.requests.cpu`          | CPU resource request of kruise-manager container             | `100m`                        |
+| `manager.resources.requests.memory`       | Memory resource request of kruise-manager container          | `256Mi`                       |
+| `manager.metrics.port`                    | Port of metrics served                                       | `8080`                        |
+| `manager.webhook.port`                    | Port of webhook served                                       | `9443`                        |
+| `manager.pprofAddr`                       | Address of pprof served                                      | `localhost:8090`              |
+| `manager.nodeAffinity`                    | Node affinity policy for kruise-manager pod                  | `{}`                          |
+| `manager.nodeSelector`                    | Node labels for kruise-manager pod                           | `{}`                          |
+| `manager.tolerations`                     | Tolerations for kruise-manager pod                           | `[]`                          |
+| `daemon.extraEnvs`                        | Extra environment variables that will be pass onto pods      | `[]`                          |
+| `daemon.log.level`                        | Log level that kruise-daemon printed                         | `4`                           |
+| `daemon.port`                             | Port of metrics and healthz that kruise-daemon served        | `10221`                       |
+| `daemon.pprofAddr`                        | Address of pprof served                                      | `localhost:10222`             |
+| `daemon.resources.limits.cpu`             | CPU resource limit of kruise-daemon container                | `50m`                         |
+| `daemon.resources.limits.memory`          | Memory resource limit of kruise-daemon container             | `128Mi`                       |
+| `daemon.resources.requests.cpu`           | CPU resource request of kruise-daemon container              | `0`                           |
+| `daemon.resources.requests.memory`        | Memory resource request of kruise-daemon container           | `0`                           |
+| `daemon.affinity`                         | Affinity policy for kruise-daemon pod                        | `{}`                          |
+| `daemon.socketLocation`                   | Location of the container manager control socket             | `/var/run`                    |
+| `daemon.socketFile`                       | Specify the socket file name in `socketLocation` (if you are not using containerd/docker/pouch/cri-o) | ` ` |
+| `webhookConfiguration.failurePolicy.pods` | The failurePolicy for pods in mutating webhook configuration | `Ignore`                      |
+| `webhookConfiguration.timeoutSeconds`     | The timeoutSeconds for all webhook configuration             | `30`                          |
+| `crds.managed`                            | Kruise will not install CRDs with chart if this is false     | `true`                        |
+| `manager.resyncPeriod`                    | Resync period of informer kruise-manager, defaults no resync | `0`                           |
+| `manager.hostNetwork`                     | Whether kruise-manager pod should run with hostnetwork       | `false`                       |
+| `imagePullSecrets`                        | The list of image pull secrets for kruise image              | `false`                       |
+| `enableKubeCacheMutationDetector`         | Whether to enable KUBE_CACHE_MUTATION_DETECTOR               | `false`                       |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+### Optional: feature-gate
+
+Feature-gate controls some influential features in Kruise:
+
+| Name                   | Description                                                  | Default | Effect (if closed)                   |
+| ---------------------- | ------------------------------------------------------------ | ------- | --------------------------------------
+| `PodWebhook`           | Whether to open a webhook for Pod **create**                 | `true`  | SidecarSet/KruisePodReadinessGate disabled    |
+| `KruiseDaemon`         | Whether to deploy `kruise-daemon` DaemonSet                  | `true`  | ImagePulling/ContainerRecreateRequest disabled |
+| `DaemonWatchingPod`    | Should each `kruise-daemon` watch pods on the same node      | `true`  | For in-place update with same imageID or env from labels/annotations |
+| `CloneSetShortHash`    | Enables CloneSet controller only set revision hash name to pod label | `false` | CloneSet name can not be longer than 54 characters |
+| `KruisePodReadinessGate` | Enables Kruise webhook to inject 'KruisePodReady' readiness-gate to all Pods during creation | `false` | The readiness-gate will only be injected to Pods created by Kruise workloads |
+| `PreDownloadImageForInPlaceUpdate` | Enables CloneSet controller to create ImagePullJobs to pre-download images for in-place update | `true` | No image pre-download for in-place update |
+| `CloneSetPartitionRollback` | Enables CloneSet controller to rollback Pods to currentRevision when number of updateRevision pods is bigger than (replicas - partition) | `false` | CloneSet will only update Pods to updateRevision |
+| `ResourcesDeletionProtection` | Enables protection for resources deletion              | `true` | No protection for resources deletion |
+| `TemplateNoDefaults` | Whether to disable defaults injection for pod/pvc template in workloads | `false` | Should not close this feature if it has open |
+| `PodUnavailableBudgetDeleteGate` | Enables PodUnavailableBudget for pod deletion, eviction           | `true` | No protection for pod deletion, eviction |
+| `PodUnavailableBudgetUpdateGate` | Enables PodUnavailableBudget for pod.Spec update                  | `false` | No protection for in-place update |
+| `WorkloadSpread`                 | Enables WorkloadSpread to manage multi-domain and elastic deploy  | `true` | WorkloadSpread disabled |
+| `InPlaceUpdateEnvFromMetadata`   | Enables Kruise to in-place update a container in Pod when its env from labels/annotations changed and pod is in-place updating | `true` | Only container image can be in-place update |
+| `StatefulSetAutoDeletePVC`       | Enables policies controlling deletion of PVCs created by a StatefulSet  | `true` | No deletion of PVCs by StatefulSet |
+| `PreDownloadImageForDaemonSetUpdate`       | Enables DaemonSet controller to create ImagePullJobs to pre-download images for in-place update  | `false` | No image pre-download for in-place update |
+| `PodProbeMarkerGate`   | Whether to turn on PodProbeMarker ability  | `true` | PodProbeMarker disabled |
+| `SidecarSetPatchPodMetadataDefaultsAllowed`   | Allow SidecarSet patch any annotations to Pod Object | `false` | Annotations are not allowed to patch randomly and need to be configured via SidecarSet_PatchPodMetadata_WhiteList |
+| `SidecarTerminator`   | SidecarTerminator enables SidecarTerminator to stop sidecar containers when all main containers exited | `false` | SidecarTerminator disabled |
+| `CloneSetEventHandlerOptimization`   | CloneSetEventHandlerOptimization enable optimization for cloneset-controller to reduce the queuing frequency cased by pod update | `false` | optimization for cloneset-controller to reduce the queuing frequency cased by pod update disabled |
+
+If you want to configure the feature-gate, just set the parameter when install or upgrade. Such as:
+
+```bash
+$ helm install kruise https://... --set featureGates="ResourcesDeletionProtection=true\,PreDownloadImageForInPlaceUpdate=true"
+...
+```
+
+If you want to enable all feature-gates, set the parameter as `featureGates=AllAlpha=true`.
+
+### Optional: the local image for China
+
+If you are in China and have problem to pull image from official DockerHub, you can use the registry hosted on Alibaba Cloud:
+
+```bash
+$ helm install kruise https://... --set  manager.image.repository=openkruise-registry.cn-hangzhou.cr.aliyuncs.com/openkruise/kruise-manager
+...
+```

--- a/charts/kruise/templates/_helpers.tpl
+++ b/charts/kruise/templates/_helpers.tpl
@@ -1,0 +1,96 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kruise.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kruise.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kruise.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Lookup existing immutatble resources
+*/}}
+{{- define "webhookServiceSpec" -}}
+{{- $service := lookup "v1" "Service" .Values.installation.namespace "kruise-webhook-service" -}}
+{{- if $service -}}
+{{ if $service.spec.clusterIP -}}
+clusterIP: {{ $service.spec.clusterIP }}
+{{- end }}
+{{ if $service.spec.clusterIPs -}}
+clusterIPs:
+  {{ $service.spec.clusterIPs }}
+{{- end }}
+{{ if $service.spec.ipFamilyPolicy -}}
+ipFamilyPolicy: {{ $service.spec.ipFamilyPolicy }}
+{{- end }}
+{{ if $service.spec.ipFamilies -}}
+ipFamilies:
+  {{ $service.spec.ipFamilies }}
+{{- end }}
+{{ if $service.spec.type -}}
+type: {{ $service.spec.type }}
+{{- end }}
+{{ if $service.spec.ipFamily -}}
+ipFamily: {{ $service.spec.ipFamily }}
+{{- end }}
+{{- end -}}
+ports:
+- port: 443
+  targetPort: {{ .Values.manager.webhook.port }}
+selector:
+  control-plane: controller-manager
+{{- end -}}
+
+{{- define "webhookSecretData" -}}
+{{- $secret := lookup "v1" "Secret" .Values.installation.namespace "kruise-webhook-certs" -}}
+{{- if $secret -}}
+data:
+{{- range $k, $v := $secret.data }}
+  {{ $k }}: {{ $v }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "serviceAccountManager" -}}
+{{- $sa := lookup "v1" "ServiceAccount" .Values.installation.namespace "kruise-manager" -}}
+{{- if $sa -}}
+secrets:
+{{- range $v := $sa.secrets }}
+- name: {{ $v.name }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "serviceAccountDaemon" -}}
+{{- $sa := lookup "v1" "ServiceAccount" .Values.installation.namespace "kruise-daemon" -}}
+{{- if $sa -}}
+secrets:
+{{- range $v := $sa.secrets }}
+- name: {{ $v.name }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/kruise/templates/apps.kruise.io_advancedcronjobs.yaml
+++ b/charts/kruise/templates/apps.kruise.io_advancedcronjobs.yaml
@@ -1,0 +1,279 @@
+{{- if .Values.crds.managed }}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: advancedcronjobs.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: AdvancedCronJob
+    listKind: AdvancedCronJobList
+    plural: advancedcronjobs
+    shortNames:
+    - acj
+    singular: advancedcronjob
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The schedule of advanced cron job.
+      jsonPath: .spec.schedule
+      name: Schedule
+      type: string
+    - description: Type of cron job.
+      jsonPath: .status.type
+      name: Type
+      type: string
+    - description: The last time at which job was scheduled.
+      jsonPath: .status.lastScheduleTime
+      name: LastScheduleTime
+      type: date
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC.
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AdvancedCronJob is the Schema for the advancedcronjobs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AdvancedCronJobSpec defines the desired state of AdvancedCronJob
+            properties:
+              concurrencyPolicy:
+                description: 'Specifies how to treat concurrent executions of a Job.
+                  Valid values are: - "Allow" (default): allows CronJobs to run concurrently;
+                  - "Forbid": forbids concurrent runs, skipping next run if previous
+                  run hasn''t finished yet; - "Replace": cancels currently running
+                  job and replaces it with a new one'
+                enum:
+                - Allow
+                - Forbid
+                - Replace
+                type: string
+              failedJobsHistoryLimit:
+                description: The number of failed finished jobs to retain. This is
+                  a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              paused:
+                description: Paused will pause the cron job.
+                type: boolean
+              schedule:
+                description: The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+                minLength: 0
+                type: string
+              startingDeadlineSeconds:
+                description: Optional deadline in seconds for starting the job if
+                  it misses scheduled time for any reason.  Missed jobs executions
+                  will be counted as failed ones.
+                format: int64
+                type: integer
+              successfulJobsHistoryLimit:
+                description: The number of successful finished jobs to retain. This
+                  is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              template:
+                description: Specifies the job that will be created when executing
+                  a CronJob.
+                properties:
+                  broadcastJobTemplate:
+                    description: Specifies the broadcastjob that will be created when
+                      executing a BroadcastCronJob.
+                    properties:
+                      metadata:
+                        description: Standard object's metadata of the jobs created
+                          from this template.
+                        type: object
+                      spec:
+                        description: Specification of the desired behavior of the
+                          broadcastjob.
+                        properties:
+                          completionPolicy:
+                            description: CompletionPolicy indicates the completion
+                              policy of the job. Default is Always CompletionPolicyType.
+                            properties:
+                              activeDeadlineSeconds:
+                                description: ActiveDeadlineSeconds specifies the duration
+                                  in seconds relative to the startTime that the job
+                                  may be active before the system tries to terminate
+                                  it; value must be positive integer. Only works for
+                                  Always type.
+                                format: int64
+                                type: integer
+                              ttlSecondsAfterFinished:
+                                description: ttlSecondsAfterFinished limits the lifetime
+                                  of a Job that has finished execution (either Complete
+                                  or Failed). If this field is set, ttlSecondsAfterFinished
+                                  after the Job finishes, it is eligible to be automatically
+                                  deleted. When the Job is being deleted, its lifecycle
+                                  guarantees (e.g. finalizers) will be honored. If
+                                  this field is unset, the Job won't be automatically
+                                  deleted. If this field is set to zero, the Job becomes
+                                  eligible to be deleted immediately after it finishes.
+                                  This field is alpha-level and is only honored by
+                                  servers that enable the TTLAfterFinished feature.
+                                  Only works for Always type
+                                format: int32
+                                type: integer
+                              type:
+                                description: Type indicates the type of the CompletionPolicy.
+                                  Default is Always.
+                                type: string
+                            type: object
+                          failurePolicy:
+                            description: FailurePolicy indicates the behavior of the
+                              job, when failed pod is found.
+                            properties:
+                              restartLimit:
+                                description: RestartLimit specifies the number of
+                                  retries before marking the pod failed.
+                                format: int32
+                                type: integer
+                              type:
+                                description: Type indicates the type of FailurePolicyType.
+                                  Default is FailurePolicyTypeFailFast.
+                                type: string
+                            type: object
+                          parallelism:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Parallelism specifies the maximum desired
+                              number of pods the job should run at any given time.
+                              The actual number of pods running in steady state will
+                              be less than this number when the work left to do is
+                              less than max parallelism. Not setting this value means
+                              no limit.
+                            x-kubernetes-int-or-string: true
+                          paused:
+                            description: Paused will pause the job.
+                            type: boolean
+                          template:
+                            description: Template describes the pod that will be created
+                              when executing a job.
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - template
+                        type: object
+                    type: object
+                  jobTemplate:
+                    description: Specifies the job that will be created when executing
+                      a CronJob.
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              timeZone:
+                description: The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
+                  If not specified, this will default to the time zone of the kruise-controller-manager
+                  process.
+                type: string
+            required:
+            - schedule
+            - template
+            type: object
+          status:
+            description: AdvancedCronJobStatus defines the observed state of AdvancedCronJob
+            properties:
+              active:
+                description: A list of pointers to currently running jobs.
+                items:
+                  description: 'ObjectReference contains enough information to let
+                    you inspect or modify the referred object. --- New uses of this
+                    type are discouraged because of difficulty describing its usage
+                    when embedded in APIs.  1. Ignored fields.  It includes many fields
+                    which are not generally honored.  For instance, ResourceVersion
+                    and FieldPath are both very rarely valid in actual usage.  2.
+                    Invalid usage help.  It is impossible to add specific help for
+                    individual usage.  In most embedded usages, there are particular     restrictions
+                    like, "must refer only to types A and B" or "UID not honored"
+                    or "name must be restricted".     Those cannot be well described
+                    when embedded.  3. Inconsistent validation.  Because the usages
+                    are different, the validation rules are different by usage, which
+                    makes it hard for users to predict what will happen.  4. The fields
+                    are both imprecise and overly precise.  Kind is not a precise
+                    mapping to a URL. This can produce ambiguity     during interpretation
+                    and require a REST mapping.  In most cases, the dependency is
+                    on the group,resource tuple     and the version of the actual
+                    struct is irrelevant.  5. We cannot easily change it.  Because
+                    this type is embedded in many locations, updates to this type     will
+                    affect numerous schemas.  Don''t make new APIs embed an underspecified
+                    API type they do not control. Instead of using this type, create
+                    a locally provided and used type that is well-focused on your
+                    reference. For example, ServiceReferences for admission registration:
+                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                    .'
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              lastScheduleTime:
+                description: Information when was the last time the job was successfully
+                  scheduled.
+                format: date-time
+                type: string
+              type:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/kruise/templates/apps.kruise.io_broadcastjobs.yaml
+++ b/charts/kruise/templates/apps.kruise.io_broadcastjobs.yaml
@@ -1,0 +1,211 @@
+{{- if .Values.crds.managed }}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: broadcastjobs.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: BroadcastJob
+    listKind: BroadcastJobList
+    plural: broadcastjobs
+    shortNames:
+    - bcj
+    singular: broadcastjob
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The desired number of pods. This is typically equal to the number
+        of nodes satisfied to run pods.
+      jsonPath: .status.desired
+      name: Desired
+      type: integer
+    - description: The number of actively running pods.
+      jsonPath: .status.active
+      name: Active
+      type: integer
+    - description: The number of pods which reached phase Succeeded.
+      jsonPath: .status.succeeded
+      name: Succeeded
+      type: integer
+    - description: The number of pods which reached phase Failed.
+      jsonPath: .status.failed
+      name: Failed
+      type: integer
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC.
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: BroadcastJob is the Schema for the broadcastjobs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BroadcastJobSpec defines the desired state of BroadcastJob
+            properties:
+              completionPolicy:
+                description: CompletionPolicy indicates the completion policy of the
+                  job. Default is Always CompletionPolicyType.
+                properties:
+                  activeDeadlineSeconds:
+                    description: ActiveDeadlineSeconds specifies the duration in seconds
+                      relative to the startTime that the job may be active before
+                      the system tries to terminate it; value must be positive integer.
+                      Only works for Always type.
+                    format: int64
+                    type: integer
+                  ttlSecondsAfterFinished:
+                    description: ttlSecondsAfterFinished limits the lifetime of a
+                      Job that has finished execution (either Complete or Failed).
+                      If this field is set, ttlSecondsAfterFinished after the Job
+                      finishes, it is eligible to be automatically deleted. When the
+                      Job is being deleted, its lifecycle guarantees (e.g. finalizers)
+                      will be honored. If this field is unset, the Job won't be automatically
+                      deleted. If this field is set to zero, the Job becomes eligible
+                      to be deleted immediately after it finishes. This field is alpha-level
+                      and is only honored by servers that enable the TTLAfterFinished
+                      feature. Only works for Always type
+                    format: int32
+                    type: integer
+                  type:
+                    description: Type indicates the type of the CompletionPolicy.
+                      Default is Always.
+                    type: string
+                type: object
+              failurePolicy:
+                description: FailurePolicy indicates the behavior of the job, when
+                  failed pod is found.
+                properties:
+                  restartLimit:
+                    description: RestartLimit specifies the number of retries before
+                      marking the pod failed.
+                    format: int32
+                    type: integer
+                  type:
+                    description: Type indicates the type of FailurePolicyType. Default
+                      is FailurePolicyTypeFailFast.
+                    type: string
+                type: object
+              parallelism:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Parallelism specifies the maximum desired number of pods
+                  the job should run at any given time. The actual number of pods
+                  running in steady state will be less than this number when the work
+                  left to do is less than max parallelism. Not setting this value
+                  means no limit.
+                x-kubernetes-int-or-string: true
+              paused:
+                description: Paused will pause the job.
+                type: boolean
+              template:
+                description: Template describes the pod that will be created when
+                  executing a job.
+                x-kubernetes-preserve-unknown-fields: true
+            required:
+            - template
+            type: object
+          status:
+            description: BroadcastJobStatus defines the observed state of BroadcastJob
+            properties:
+              active:
+                description: The number of actively running pods.
+                format: int32
+                type: integer
+              completionTime:
+                description: Represents time when the job was completed. It is not
+                  guaranteed to be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
+                format: date-time
+                type: string
+              conditions:
+                description: The latest available observations of an object's current
+                  state.
+                items:
+                  description: JobCondition describes current state of a job.
+                  properties:
+                    lastProbeTime:
+                      description: Last time the condition was checked.
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transit from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: (brief) reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of job condition, Complete or Failed.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              desired:
+                description: The desired number of pods, this is typically equal to
+                  the number of nodes satisfied to run pods.
+                format: int32
+                type: integer
+              failed:
+                description: The number of pods which reached phase Failed.
+                format: int32
+                type: integer
+              phase:
+                description: The phase of the job.
+                type: string
+              startTime:
+                description: Represents time when the job was acknowledged by the
+                  job controller. It is not guaranteed to be set in happens-before
+                  order across separate operations. It is represented in RFC3339 form
+                  and is in UTC.
+                format: date-time
+                type: string
+              succeeded:
+                description: The number of pods which reached phase Succeeded.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/kruise/templates/apps.kruise.io_clonesets.yaml
+++ b/charts/kruise/templates/apps.kruise.io_clonesets.yaml
@@ -1,0 +1,535 @@
+{{- if .Values.crds.managed }}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: clonesets.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: CloneSet
+    listKind: CloneSetList
+    plural: clonesets
+    shortNames:
+    - clone
+    singular: cloneset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The desired number of pods.
+      jsonPath: .spec.replicas
+      name: DESIRED
+      type: integer
+    - description: The number of pods updated.
+      jsonPath: .status.updatedReplicas
+      name: UPDATED
+      type: integer
+    - description: The number of pods updated and ready.
+      jsonPath: .status.updatedReadyReplicas
+      name: UPDATED_READY
+      type: integer
+    - description: The number of pods ready.
+      jsonPath: .status.readyReplicas
+      name: READY
+      type: integer
+    - description: The number of currently all pods.
+      jsonPath: .status.replicas
+      name: TOTAL
+      type: integer
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC.
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    - description: The containers of currently cloneset.
+      jsonPath: .spec.template.spec.containers[*].name
+      name: CONTAINERS
+      priority: 1
+      type: string
+    - description: The images of currently cloneset.
+      jsonPath: .spec.template.spec.containers[*].image
+      name: IMAGES
+      priority: 1
+      type: string
+    - description: The selector of currently cloneset.
+      jsonPath: .status.labelSelector
+      name: SELECTOR
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CloneSet is the Schema for the clonesets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CloneSetSpec defines the desired state of CloneSet
+            properties:
+              lifecycle:
+                description: Lifecycle defines the lifecycle hooks for Pods pre-available(pre-normal),
+                  pre-delete, in-place update.
+                properties:
+                  inPlaceUpdate:
+                    description: InPlaceUpdate is the hook before Pod to update and
+                      after Pod has been updated.
+                    properties:
+                      finalizersHandler:
+                        items:
+                          type: string
+                        type: array
+                      labelsHandler:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Currently,
+                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
+                          hook. Default to false.'
+                        type: boolean
+                    type: object
+                  preDelete:
+                    description: PreDelete is the hook before Pod to be deleted.
+                    properties:
+                      finalizersHandler:
+                        items:
+                          type: string
+                        type: array
+                      labelsHandler:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Currently,
+                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
+                          hook. Default to false.'
+                        type: boolean
+                    type: object
+                  preNormal:
+                    description: PreNormal is the hook after Pod to be created and
+                      ready to be Normal.
+                    properties:
+                      finalizersHandler:
+                        items:
+                          type: string
+                        type: array
+                      labelsHandler:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Currently,
+                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
+                          hook. Default to false.'
+                        type: boolean
+                    type: object
+                type: object
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created pod
+                  should be ready without any of its container crashing, for it to
+                  be considered available. Defaults to 0 (pod will be considered available
+                  as soon as it is ready)
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the desired number of replicas of the given
+                  Template. These are replicas in the sense that they are instantiations
+                  of the same Template. If unspecified, defaults to 1.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: RevisionHistoryLimit is the maximum number of revisions
+                  that will be maintained in the CloneSet's revision history. The
+                  revision history consists of all revisions not represented by a
+                  currently applied CloneSetSpec version. The default value is 10.
+                format: int32
+                type: integer
+              scaleStrategy:
+                description: ScaleStrategy indicates the ScaleStrategy that will be
+                  employed to create and delete Pods in the CloneSet.
+                properties:
+                  disablePVCReuse:
+                    description: Indicate if cloneSet will reuse already existed pvc
+                      to rebuild a new pod
+                    type: boolean
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: The maximum number of pods that can be unavailable
+                      for scaled pods. This field can control the changes rate of
+                      replicas for CloneSet so as to minimize the impact for users'
+                      service. The scale will fail if the number of unavailable pods
+                      were greater than this MaxUnavailable at scaling up. MaxUnavailable
+                      works only when scaling up.
+                    x-kubernetes-int-or-string: true
+                  podsToDelete:
+                    description: PodsToDelete is the names of Pod should be deleted.
+                      Note that this list will be truncated for non-existing pod names.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              selector:
+                description: 'Selector is a label query over pods that should match
+                  the replica count. It must match the pod template''s labels. More
+                  info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              template:
+                description: Template describes the pods that will be created.
+                x-kubernetes-preserve-unknown-fields: true
+              updateStrategy:
+                description: UpdateStrategy indicates the UpdateStrategy that will
+                  be employed to update Pods in the CloneSet when a revision is made
+                  to Template.
+                properties:
+                  inPlaceUpdateStrategy:
+                    description: InPlaceUpdateStrategy contains strategies for in-place
+                      update.
+                    properties:
+                      gracePeriodSeconds:
+                        description: GracePeriodSeconds is the timespan between set
+                          Pod status to not-ready and update images in Pod spec when
+                          in-place update a Pod.
+                        format: int32
+                        type: integer
+                    type: object
+                  maxSurge:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'The maximum number of pods that can be scheduled
+                      above the desired replicas during update or specified delete.
+                      Value can be an absolute number (ex: 5) or a percentage of desired
+                      pods (ex: 10%). Absolute number is calculated from percentage
+                      by rounding up. Defaults to 0.'
+                    x-kubernetes-int-or-string: true
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'The maximum number of pods that can be unavailable
+                      during update or scale. Value can be an absolute number (ex:
+                      5) or a percentage of desired pods (ex: 10%). Absolute number
+                      is calculated from percentage by rounding up by default. When
+                      maxSurge > 0, absolute number is calculated from percentage
+                      by rounding down. Defaults to 20%.'
+                    x-kubernetes-int-or-string: true
+                  partition:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'Partition is the desired number of pods in old revisions.
+                      Value can be an absolute number (ex: 5) or a percentage of desired
+                      pods (ex: 10%). Absolute number is calculated from percentage
+                      by rounding up by default. It means when partition is set during
+                      pods updating, (replicas - partition value) number of pods will
+                      be updated. Default value is 0.'
+                    x-kubernetes-int-or-string: true
+                  paused:
+                    description: Paused indicates that the CloneSet is paused. Default
+                      value is false
+                    type: boolean
+                  priorityStrategy:
+                    description: Priorities are the rules for calculating the priority
+                      of updating pods. Each pod to be updated, will pass through
+                      these terms and get a sum of weights.
+                    properties:
+                      orderPriority:
+                        description: 'Order priority terms, pods will be sorted by
+                          the value of orderedKey. For example: ``` orderPriority:
+                          - orderedKey: key1 - orderedKey: key2 ``` First, all pods
+                          which have key1 in labels will be sorted by the value of
+                          key1. Then, the left pods which have no key1 but have key2
+                          in labels will be sorted by the value of key2 and put behind
+                          those pods have key1.'
+                        items:
+                          description: UpdatePriorityOrderTerm defines order priority.
+                          properties:
+                            orderedKey:
+                              description: Calculate priority by value of this key.
+                                Values of this key, will be sorted by GetInt(val).
+                                GetInt method will find the last int in value, such
+                                as getting 5 in value '5', getting 10 in value 'sts-10'.
+                              type: string
+                          required:
+                          - orderedKey
+                          type: object
+                        type: array
+                      weightPriority:
+                        description: Weight priority terms, pods will be sorted by
+                          the sum of all terms weight.
+                        items:
+                          description: UpdatePriorityWeightTerm defines weight priority.
+                          properties:
+                            matchSelector:
+                              description: MatchSelector is used to select by pod's
+                                labels.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                matchExpressions, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - matchSelector
+                          - weight
+                          type: object
+                        type: array
+                    type: object
+                  scatterStrategy:
+                    description: ScatterStrategy defines the scatter rules to make
+                      pods been scattered when update. This will avoid pods with the
+                      same key-value to be updated in one batch. - Note that pods
+                      will be scattered after priority sort. So, although priority
+                      strategy and scatter strategy can be applied together, we suggest
+                      to use either one of them. - If scatterStrategy is used, we
+                      suggest to just use one term. Otherwise, the update order can
+                      be hard to understand.
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - key
+                      - value
+                      type: object
+                    type: array
+                  type:
+                    description: Type indicates the type of the CloneSetUpdateStrategy.
+                      Default is ReCreate.
+                    type: string
+                type: object
+              volumeClaimTemplates:
+                description: VolumeClaimTemplates is a list of claims that pods are
+                  allowed to reference. Note that PVC will be deleted when its pod
+                  has been deleted.
+                x-kubernetes-preserve-unknown-fields: true
+            required:
+            - selector
+            - template
+            type: object
+          status:
+            description: CloneSetStatus defines the observed state of CloneSet
+            properties:
+              availableReplicas:
+                description: AvailableReplicas is the number of Pods created by the
+                  CloneSet controller that have a Ready Condition for at least minReadySeconds.
+                format: int32
+                type: integer
+              collisionCount:
+                description: CollisionCount is the count of hash collisions for the
+                  CloneSet. The CloneSet controller uses this field as a collision
+                  avoidance mechanism when it needs to create the name for the newest
+                  ControllerRevision.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions represents the latest available observations
+                  of a CloneSet's current state.
+                items:
+                  description: CloneSetCondition describes the state of a CloneSet
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of CloneSet condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentRevision:
+                description: currentRevision, if not empty, indicates the current
+                  revision version of the CloneSet.
+                type: string
+              expectedUpdatedReplicas:
+                description: ExpectedUpdatedReplicas is the number of Pods that should
+                  be updated by CloneSet controller. This field is calculated via
+                  Replicas - Partition.
+                format: int32
+                type: integer
+              labelSelector:
+                description: LabelSelector is label selectors for query over pods
+                  that should match the replica count used by HPA.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this CloneSet. It corresponds to the CloneSet's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: ReadyReplicas is the number of Pods created by the CloneSet
+                  controller that have a Ready Condition.
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the number of Pods created by the CloneSet
+                  controller.
+                format: int32
+                type: integer
+              updateRevision:
+                description: UpdateRevision, if not empty, indicates the latest revision
+                  of the CloneSet.
+                type: string
+              updatedReadyReplicas:
+                description: UpdatedReadyReplicas is the number of Pods created by
+                  the CloneSet controller from the CloneSet version indicated by updateRevision
+                  and have a Ready Condition.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: UpdatedReplicas is the number of Pods created by the
+                  CloneSet controller from the CloneSet version indicated by updateRevision.
+                format: int32
+                type: integer
+            required:
+            - availableReplicas
+            - readyReplicas
+            - replicas
+            - updatedReadyReplicas
+            - updatedReplicas
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.labelSelector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/kruise/templates/apps.kruise.io_containerrecreaterequests.yaml
+++ b/charts/kruise/templates/apps.kruise.io_containerrecreaterequests.yaml
@@ -1,0 +1,337 @@
+{{- if .Values.crds.managed }}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: containerrecreaterequests.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: ContainerRecreateRequest
+    listKind: ContainerRecreateRequestList
+    plural: containerrecreaterequests
+    shortNames:
+    - crr
+    singular: containerrecreaterequest
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Phase of this ContainerRecreateRequest.
+      jsonPath: .status.phase
+      name: PHASE
+      type: string
+    - description: Pod name of this ContainerRecreateRequest.
+      jsonPath: .spec.podName
+      name: POD
+      type: string
+    - description: Pod name of this ContainerRecreateRequest.
+      jsonPath: .metadata.labels.crr\.apps\.kruise\.io/node-name
+      name: NODE
+      type: string
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC.
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ContainerRecreateRequest is the Schema for the containerrecreaterequests
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ContainerRecreateRequestSpec defines the desired state of
+              ContainerRecreateRequest
+            properties:
+              activeDeadlineSeconds:
+                description: ActiveDeadlineSeconds is the deadline duration of this
+                  ContainerRecreateRequest.
+                format: int64
+                type: integer
+              containers:
+                description: Containers contains the containers that need to recreate
+                  in the Pod.
+                items:
+                  description: ContainerRecreateRequestContainer defines the container
+                    that need to recreate.
+                  properties:
+                    name:
+                      description: Name of the container that need to recreate. It
+                        must be existing in the real pod.Spec.Containers.
+                      type: string
+                    ports:
+                      description: Ports is synced from the real container in Pod
+                        spec during this ContainerRecreateRequest creating. Populated
+                        by the system. Read-only.
+                      items:
+                        description: ContainerPort represents a network port in a
+                          single container.
+                        properties:
+                          containerPort:
+                            description: Number of port to expose on the pod's IP
+                              address. This must be a valid port number, 0 < x < 65536.
+                            format: int32
+                            type: integer
+                          hostIP:
+                            description: What host IP to bind the external port to.
+                            type: string
+                          hostPort:
+                            description: Number of port to expose on the host. If
+                              specified, this must be a valid port number, 0 < x <
+                              65536. If HostNetwork is specified, this must match
+                              ContainerPort. Most containers do not need this.
+                            format: int32
+                            type: integer
+                          name:
+                            description: If specified, this must be an IANA_SVC_NAME
+                              and unique within the pod. Each named port in a pod
+                              must have a unique name. Name for the port that can
+                              be referred to by services.
+                            type: string
+                          protocol:
+                            default: TCP
+                            description: Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
+                            type: string
+                        required:
+                        - containerPort
+                        type: object
+                      type: array
+                    preStop:
+                      description: PreStop is synced from the real container in Pod
+                        spec during this ContainerRecreateRequest creating. Populated
+                        by the system. Read-only.
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    statusContext:
+                      description: StatusContext is synced from the real Pod status
+                        during this ContainerRecreateRequest creating. Populated by
+                        the system. Read-only.
+                      properties:
+                        containerID:
+                          description: Container's ID in the format 'docker://<container_id>'.
+                          type: string
+                        restartCount:
+                          description: The number of times the container has been
+                            restarted, currently based on the number of dead containers
+                            that have not yet been removed. Note that this is calculated
+                            from dead containers. But those containers are subject
+                            to garbage collection. This value will get capped at 5
+                            by GC.
+                          format: int32
+                          type: integer
+                      required:
+                      - containerID
+                      - restartCount
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              podName:
+                description: PodName is name of the Pod that owns the recreated containers.
+                type: string
+              strategy:
+                description: Strategy defines strategies for containers recreation.
+                properties:
+                  failurePolicy:
+                    description: FailurePolicy decides whether to continue if one
+                      container fails to recreate
+                    type: string
+                  forceRecreate:
+                    description: ForceRecreate indicates whether to force kill the
+                      container even if the previous container is starting.
+                    type: boolean
+                  minStartedSeconds:
+                    description: Minimum number of seconds for which a newly created
+                      container should be started and ready without any of its container
+                      crashing, for it to be considered Succeeded. Defaults to 0 (container
+                      will be considered Succeeded as soon as it is started and ready)
+                    format: int32
+                    type: integer
+                  orderedRecreate:
+                    description: OrderedRecreate indicates whether to recreate the
+                      next container only if the previous one has recreated completely.
+                    type: boolean
+                  terminationGracePeriodSeconds:
+                    description: TerminationGracePeriodSeconds is the optional duration
+                      in seconds to wait the container terminating gracefully. Value
+                      must be non-negative integer. The value zero indicates delete
+                      immediately. If this value is nil, we will use pod.Spec.TerminationGracePeriodSeconds
+                      as default value.
+                    format: int64
+                    type: integer
+                  unreadyGracePeriodSeconds:
+                    description: UnreadyGracePeriodSeconds is the optional duration
+                      in seconds to mark Pod as not ready over this duration before
+                      executing preStop hook and stopping the container.
+                    format: int64
+                    type: integer
+                type: object
+              ttlSecondsAfterFinished:
+                description: TTLSecondsAfterFinished is the TTL duration after this
+                  ContainerRecreateRequest has completed.
+                format: int32
+                type: integer
+            required:
+            - containers
+            - podName
+            type: object
+          status:
+            description: ContainerRecreateRequestStatus defines the observed state
+              of ContainerRecreateRequest
+            properties:
+              completionTime:
+                description: Represents time when the ContainerRecreateRequest was
+                  completed. It is not guaranteed to be set in happens-before order
+                  across separate operations. It is represented in RFC3339 form and
+                  is in UTC.
+                format: date-time
+                type: string
+              containerRecreateStates:
+                description: ContainerRecreateStates contains the recreation states
+                  of the containers.
+                items:
+                  description: ContainerRecreateRequestContainerRecreateState contains
+                    the recreation state of the container.
+                  properties:
+                    isKilled:
+                      description: Containers are killed by kruise daemon
+                      type: boolean
+                    message:
+                      description: A human readable message indicating details about
+                        this state.
+                      type: string
+                    name:
+                      description: Name of the container.
+                      type: string
+                    phase:
+                      description: Phase indicates the recreation phase of the container.
+                      type: string
+                  required:
+                  - name
+                  - phase
+                  type: object
+                type: array
+              message:
+                description: A human readable message indicating details about this
+                  ContainerRecreateRequest.
+                type: string
+              phase:
+                description: Phase of this ContainerRecreateRequest, e.g. Pending,
+                  Recreating, Completed
+                type: string
+            required:
+            - phase
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/kruise/templates/apps.kruise.io_daemonsets.yaml
+++ b/charts/kruise/templates/apps.kruise.io_daemonsets.yaml
@@ -1,0 +1,452 @@
+{{- if .Values.crds.managed }}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: daemonsets.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: DaemonSet
+    listKind: DaemonSetList
+    plural: daemonsets
+    shortNames:
+    - daemon
+    - ads
+    singular: daemonset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The desired number of pods.
+      jsonPath: .status.desiredNumberScheduled
+      name: DESIRED
+      type: integer
+    - description: The current number of pods.
+      jsonPath: .status.currentNumberScheduled
+      name: CURRENT
+      type: integer
+    - description: The ready number of pods.
+      jsonPath: .status.numberReady
+      name: READY
+      type: integer
+    - description: The updated number of pods.
+      jsonPath: .status.updatedNumberScheduled
+      name: UP-TO-DATE
+      type: integer
+    - description: The updated number of pods.
+      jsonPath: .status.numberAvailable
+      name: AVAILABLE
+      type: integer
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC.
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    - description: The containers of currently  daemonset.
+      jsonPath: .spec.template.spec.containers[*].name
+      name: CONTAINERS
+      priority: 1
+      type: string
+    - description: The images of currently advanced daemonset.
+      jsonPath: .spec.template.spec.containers[*].image
+      name: IMAGES
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DaemonSet is the Schema for the daemonsets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DaemonSetSpec defines the desired state of DaemonSet
+            properties:
+              burstReplicas:
+                anyOf:
+                - type: integer
+                - type: string
+                description: BurstReplicas is a rate limiter for booting pods on a
+                  lot of pods. The default value is 250
+                x-kubernetes-int-or-string: true
+              lifecycle:
+                description: Lifecycle defines the lifecycle hooks for Pods pre-delete,
+                  in-place update. Currently, we only support pre-delete hook for
+                  Advanced DaemonSet.
+                properties:
+                  inPlaceUpdate:
+                    description: InPlaceUpdate is the hook before Pod to update and
+                      after Pod has been updated.
+                    properties:
+                      finalizersHandler:
+                        items:
+                          type: string
+                        type: array
+                      labelsHandler:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Currently,
+                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
+                          hook. Default to false.'
+                        type: boolean
+                    type: object
+                  preDelete:
+                    description: PreDelete is the hook before Pod to be deleted.
+                    properties:
+                      finalizersHandler:
+                        items:
+                          type: string
+                        type: array
+                      labelsHandler:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Currently,
+                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
+                          hook. Default to false.'
+                        type: boolean
+                    type: object
+                  preNormal:
+                    description: PreNormal is the hook after Pod to be created and
+                      ready to be Normal.
+                    properties:
+                      finalizersHandler:
+                        items:
+                          type: string
+                        type: array
+                      labelsHandler:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Currently,
+                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
+                          hook. Default to false.'
+                        type: boolean
+                    type: object
+                type: object
+              minReadySeconds:
+                description: The minimum number of seconds for which a newly created
+                  DaemonSet pod should be ready without any of its container crashing,
+                  for it to be considered available. Defaults to 0 (pod will be considered
+                  available as soon as it is ready).
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: The number of old history to retain to allow rollback.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                  Defaults to 10.
+                format: int32
+                type: integer
+              selector:
+                description: 'A label query over pods that are managed by the daemon
+                  set. Must match in order to be controlled. It must match the pod
+                  template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              template:
+                description: 'An object that describes the pod that will be created.
+                  The DaemonSet will create exactly one copy of this pod on every
+                  node that matches the template''s node selector (or on every node
+                  if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template'
+                x-kubernetes-preserve-unknown-fields: true
+              updateStrategy:
+                description: An update strategy to replace existing DaemonSet pods
+                  with new pods.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if type
+                      = "RollingUpdate".
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of nodes with an existing
+                          available DaemonSet pod that can have an updated DaemonSet
+                          pod during during an update. Value can be an absolute number
+                          (ex: 5) or a percentage of desired pods (ex: 10%). This
+                          can not be 0 if MaxUnavailable is 0. Absolute number is
+                          calculated from percentage by rounding up to a minimum of
+                          1. Default value is 0. Example: when this is set to 30%,
+                          at most 30% of the total number of nodes that should be
+                          running the daemon pod (i.e. status.desiredNumberScheduled)
+                          can have their a new pod created before the old pod is marked
+                          as deleted. The update starts by launching new pods on 30%
+                          of nodes. Once an updated pod is available (Ready for at
+                          least minReadySeconds) the old DaemonSet pod on that node
+                          is marked deleted. If the old pod becomes unavailable for
+                          any reason (Ready transitions to false, is evicted, or is
+                          drained) an updated pod is immediatedly created on that
+                          node without considering surge limits. Allowing surge implies
+                          the possibility that the resources consumed by the daemonset
+                          on any given node can double if the readiness check fails,
+                          and so resource intensive daemonsets should take into account
+                          that they may cause evictions during disruption. This is
+                          beta field and enabled/disabled by DaemonSetUpdateSurge
+                          feature gate.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of DaemonSet pods that can
+                          be unavailable during the update. Value can be an absolute
+                          number (ex: 5) or a percentage of total number of DaemonSet
+                          pods at the start of the update (ex: 10%). Absolute number
+                          is calculated from percentage by rounding up. This cannot
+                          be 0 if MaxSurge is 0 Default value is 1. Example: when
+                          this is set to 30%, at most 30% of the total number of nodes
+                          that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                          can have their pods stopped for an update at any given time.
+                          The update starts by stopping at most 30% of those DaemonSet
+                          pods and then brings up new DaemonSet pods in their place.
+                          Once the new pods are available, it then proceeds onto other
+                          DaemonSet pods, thus ensuring that at least 70% of original
+                          number of DaemonSet pods are available at all times during
+                          the update.'
+                        x-kubernetes-int-or-string: true
+                      partition:
+                        description: The number of DaemonSet pods remained to be old
+                          version. Default value is 0. Maximum value is status.DesiredNumberScheduled,
+                          which means no pod will be updated.
+                        format: int32
+                        type: integer
+                      paused:
+                        description: Indicates that the daemon set is paused and will
+                          not be processed by the daemon set controller.
+                        type: boolean
+                      rollingUpdateType:
+                        description: Type is to specify which kind of rollingUpdate.
+                        type: string
+                      selector:
+                        description: A label query over nodes that are managed by
+                          the daemon set RollingUpdate. Must match in order to be
+                          controlled. It must match the node's labels.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                    type: object
+                  type:
+                    description: Type of daemon set update. Can be "RollingUpdate"
+                      or "OnDelete". Default is RollingUpdate.
+                    type: string
+                type: object
+            required:
+            - selector
+            - template
+            type: object
+          status:
+            description: DaemonSetStatus defines the observed state of DaemonSet
+            properties:
+              collisionCount:
+                description: Count of hash collisions for the DaemonSet. The DaemonSet
+                  controller uses this field as a collision avoidance mechanism when
+                  it needs to create the name for the newest ControllerRevision.
+                format: int32
+                type: integer
+              conditions:
+                description: Represents the latest available observations of a DaemonSet's
+                  current state.
+                items:
+                  description: DaemonSetCondition describes the state of a DaemonSet
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of DaemonSet condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentNumberScheduled:
+                description: 'The number of nodes that are running at least 1 daemon
+                  pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                format: int32
+                type: integer
+              daemonSetHash:
+                description: DaemonSetHash is the controller-revision-hash, which
+                  represents the latest version of the DaemonSet.
+                type: string
+              desiredNumberScheduled:
+                description: 'The total number of nodes that should be running the
+                  daemon pod (including nodes correctly running the daemon pod). More
+                  info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                format: int32
+                type: integer
+              numberAvailable:
+                description: The number of nodes that should be running the daemon
+                  pod and have one or more of the daemon pod running and available
+                  (ready for at least spec.minReadySeconds)
+                format: int32
+                type: integer
+              numberMisscheduled:
+                description: 'The number of nodes that are running the daemon pod,
+                  but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                format: int32
+                type: integer
+              numberReady:
+                description: The number of nodes that should be running the daemon
+                  pod and have one or more of the daemon pod running and ready.
+                format: int32
+                type: integer
+              numberUnavailable:
+                description: The number of nodes that should be running the daemon
+                  pod and have none of the daemon pod running and available (ready
+                  for at least spec.minReadySeconds)
+                format: int32
+                type: integer
+              observedGeneration:
+                description: The most recent generation observed by the daemon set
+                  controller.
+                format: int64
+                type: integer
+              updatedNumberScheduled:
+                description: The total number of nodes that are running updated daemon
+                  pod
+                format: int32
+                type: integer
+            required:
+            - currentNumberScheduled
+            - daemonSetHash
+            - desiredNumberScheduled
+            - numberMisscheduled
+            - numberReady
+            - updatedNumberScheduled
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/kruise/templates/apps.kruise.io_imagepulljobs.yaml
+++ b/charts/kruise/templates/apps.kruise.io_imagepulljobs.yaml
@@ -1,0 +1,301 @@
+{{- if .Values.crds.managed }}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: imagepulljobs.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: ImagePullJob
+    listKind: ImagePullJobList
+    plural: imagepulljobs
+    singular: imagepulljob
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Number of all nodes matched by this job
+      jsonPath: .status.desired
+      name: TOTAL
+      type: integer
+    - description: Number of image pull task active
+      jsonPath: .status.active
+      name: ACTIVE
+      type: integer
+    - description: Number of image pull task succeeded
+      jsonPath: .status.succeeded
+      name: SUCCEED
+      type: integer
+    - description: Number of image pull tasks failed
+      jsonPath: .status.failed
+      name: FAILED
+      type: integer
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC.
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    - description: Summary of status when job is failed
+      jsonPath: .status.message
+      name: MESSAGE
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ImagePullJob is the Schema for the imagepulljobs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ImagePullJobSpec defines the desired state of ImagePullJob
+            properties:
+              completionPolicy:
+                description: CompletionPolicy indicates the completion policy of the
+                  job. Default is Always CompletionPolicyType.
+                properties:
+                  activeDeadlineSeconds:
+                    description: ActiveDeadlineSeconds specifies the duration in seconds
+                      relative to the startTime that the job may be active before
+                      the system tries to terminate it; value must be positive integer.
+                      Only works for Always type.
+                    format: int64
+                    type: integer
+                  ttlSecondsAfterFinished:
+                    description: ttlSecondsAfterFinished limits the lifetime of a
+                      Job that has finished execution (either Complete or Failed).
+                      If this field is set, ttlSecondsAfterFinished after the Job
+                      finishes, it is eligible to be automatically deleted. When the
+                      Job is being deleted, its lifecycle guarantees (e.g. finalizers)
+                      will be honored. If this field is unset, the Job won't be automatically
+                      deleted. If this field is set to zero, the Job becomes eligible
+                      to be deleted immediately after it finishes. This field is alpha-level
+                      and is only honored by servers that enable the TTLAfterFinished
+                      feature. Only works for Always type
+                    format: int32
+                    type: integer
+                  type:
+                    description: Type indicates the type of the CompletionPolicy.
+                      Default is Always.
+                    type: string
+                type: object
+              image:
+                description: Image is the image to be pulled by the job
+                type: string
+              parallelism:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Parallelism is the requested parallelism, it can be set
+                  to any non-negative value. If it is unspecified, it defaults to
+                  1. If it is specified as 0, then the Job is effectively paused until
+                  it is increased.
+                x-kubernetes-int-or-string: true
+              podSelector:
+                description: PodSelector is a query over pods that should pull image
+                  on nodes of these pods. Mutually exclusive with Selector.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              pullPolicy:
+                description: PullPolicy is an optional field to set parameters of
+                  the pulling task. If not specified, the system will use the default
+                  values.
+                properties:
+                  backoffLimit:
+                    description: Specifies the number of retries before marking the
+                      pulling task failed. Defaults to 3
+                    format: int32
+                    type: integer
+                  timeoutSeconds:
+                    description: Specifies the timeout of the pulling task. Defaults
+                      to 600
+                    format: int32
+                    type: integer
+                type: object
+              pullSecrets:
+                description: ImagePullSecrets is an optional list of references to
+                  secrets in the same namespace to use for pulling the image. If specified,
+                  these secrets will be passed to individual puller implementations
+                  for them to use.  For example, in the case of docker, only DockerConfig
+                  type secrets are honored.
+                items:
+                  type: string
+                type: array
+              sandboxConfig:
+                description: SandboxConfig support attach metadata in PullImage CRI
+                  interface during ImagePulljobs
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              selector:
+                description: Selector is a query over nodes that should match the
+                  job. nil to match all nodes.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                  names:
+                    description: Names specify a set of nodes to execute the job.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - completionPolicy
+            - image
+            type: object
+          status:
+            description: ImagePullJobStatus defines the observed state of ImagePullJob
+            properties:
+              active:
+                description: The number of actively running pulling tasks.
+                format: int32
+                type: integer
+              completionTime:
+                description: Represents time when the job was completed. It is not
+                  guaranteed to be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
+                format: date-time
+                type: string
+              desired:
+                description: The desired number of pulling tasks, this is typically
+                  equal to the number of nodes satisfied.
+                format: int32
+                type: integer
+              failed:
+                description: The number of pulling tasks  which reached phase Failed.
+                format: int32
+                type: integer
+              failedNodes:
+                description: The nodes that failed to pull the image.
+                items:
+                  type: string
+                type: array
+              message:
+                description: The text prompt for job running status.
+                type: string
+              startTime:
+                description: Represents time when the job was acknowledged by the
+                  job controller. It is not guaranteed to be set in happens-before
+                  order across separate operations. It is represented in RFC3339 form
+                  and is in UTC.
+                format: date-time
+                type: string
+              succeeded:
+                description: The number of pulling tasks which reached phase Succeeded.
+                format: int32
+                type: integer
+            required:
+            - desired
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/kruise/templates/apps.kruise.io_nodeimages.yaml
+++ b/charts/kruise/templates/apps.kruise.io_nodeimages.yaml
@@ -1,0 +1,349 @@
+{{- if .Values.crds.managed }}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: nodeimages.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: NodeImage
+    listKind: NodeImageList
+    plural: nodeimages
+    singular: nodeimage
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Number of all images on this node
+      jsonPath: .status.desired
+      name: DESIRED
+      type: integer
+    - description: Number of image pull task active
+      jsonPath: .status.pulling
+      name: PULLING
+      type: integer
+    - description: Number of image pull task succeeded
+      jsonPath: .status.succeeded
+      name: SUCCEED
+      type: integer
+    - description: Number of image pull tasks failed
+      jsonPath: .status.failed
+      name: FAILED
+      type: integer
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC.
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NodeImage is the Schema for the nodeimages API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NodeImageSpec defines the desired state of NodeImage
+            properties:
+              images:
+                additionalProperties:
+                  description: ImageSpec defines the pulling spec of an image
+                  properties:
+                    pullSecrets:
+                      description: PullSecrets is an optional list of references to
+                        secrets in the same namespace to use for pulling the image.
+                        If specified, these secrets will be passed to individual puller
+                        implementations for them to use.  For example, in the case
+                        of docker, only DockerConfig type secrets are honored.
+                      items:
+                        description: ReferenceObject comprises a resource name, with
+                          a mandatory namespace, rendered as "<namespace>/<name>".
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                      type: array
+                    sandboxConfig:
+                      description: SandboxConfig support attach metadata in PullImage
+                        CRI interface during ImagePulljobs
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    tags:
+                      description: Tags is a list of versions of this image
+                      items:
+                        description: ImageTagSpec defines the pulling spec of an image
+                          tag
+                        properties:
+                          createdAt:
+                            description: Specifies the create time of this tag
+                            format: date-time
+                            type: string
+                          ownerReferences:
+                            description: List of objects depended by this object.
+                              If this image is managed by a controller, then an entry
+                              in this list will point to this controller.
+                            items:
+                              description: 'ObjectReference contains enough information
+                                to let you inspect or modify the referred object.
+                                --- New uses of this type are discouraged because
+                                of difficulty describing its usage when embedded in
+                                APIs.  1. Ignored fields.  It includes many fields
+                                which are not generally honored.  For instance, ResourceVersion
+                                and FieldPath are both very rarely valid in actual
+                                usage.  2. Invalid usage help.  It is impossible to
+                                add specific help for individual usage.  In most embedded
+                                usages, there are particular     restrictions like,
+                                "must refer only to types A and B" or "UID not honored"
+                                or "name must be restricted".     Those cannot be
+                                well described when embedded.  3. Inconsistent validation.  Because
+                                the usages are different, the validation rules are
+                                different by usage, which makes it hard for users
+                                to predict what will happen.  4. The fields are both
+                                imprecise and overly precise.  Kind is not a precise
+                                mapping to a URL. This can produce ambiguity     during
+                                interpretation and require a REST mapping.  In most
+                                cases, the dependency is on the group,resource tuple     and
+                                the version of the actual struct is irrelevant.  5.
+                                We cannot easily change it.  Because this type is
+                                embedded in many locations, updates to this type     will
+                                affect numerous schemas.  Don''t make new APIs embed
+                                an underspecified API type they do not control. Instead
+                                of using this type, create a locally provided and
+                                used type that is well-focused on your reference.
+                                For example, ServiceReferences for admission registration:
+                                https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                                .'
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent.
+                                  type: string
+                                fieldPath:
+                                  description: 'If referring to a piece of an object
+                                    instead of an entire object, this string should
+                                    contain a valid JSON/Go field access statement,
+                                    such as desiredState.manifest.containers[2]. For
+                                    example, if the object reference is to a container
+                                    within a pod, this would take on a value like:
+                                    "spec.containers{name}" (where "name" refers to
+                                    the name of the container that triggered the event)
+                                    or if no container name is specified "spec.containers[2]"
+                                    (container with index 2 in this pod). This syntax
+                                    is chosen only to have some well-defined way of
+                                    referencing a part of an object. TODO: this design
+                                    is not final and this field is subject to change
+                                    in the future.'
+                                  type: string
+                                kind:
+                                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                namespace:
+                                  description: 'Namespace of the referent. More info:
+                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                  type: string
+                                resourceVersion:
+                                  description: 'Specific resourceVersion to which
+                                    this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                  type: string
+                                uid:
+                                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                  type: string
+                              type: object
+                            type: array
+                          pullPolicy:
+                            description: PullPolicy is an optional field to set parameters
+                              of the pulling task. If not specified, the system will
+                              use the default values.
+                            properties:
+                              activeDeadlineSeconds:
+                                description: ActiveDeadlineSeconds specifies the duration
+                                  in seconds relative to the startTime that the task
+                                  may be active before the system tries to terminate
+                                  it; value must be positive integer. if not specified,
+                                  the system will never terminate it.
+                                format: int64
+                                type: integer
+                              backoffLimit:
+                                description: Specifies the number of retries before
+                                  marking the pulling task failed. Defaults to 3
+                                format: int32
+                                type: integer
+                              timeoutSeconds:
+                                description: Specifies the timeout of the pulling
+                                  task. Defaults to 600
+                                format: int32
+                                type: integer
+                              ttlSecondsAfterFinished:
+                                description: TTLSecondsAfterFinished limits the lifetime
+                                  of a pulling task that has finished execution (either
+                                  Complete or Failed). If this field is set, ttlSecondsAfterFinished
+                                  after the task finishes, it is eligible to be automatically
+                                  deleted. If this field is unset, the task won't
+                                  be automatically deleted. If this field is set to
+                                  zero, the task becomes eligible to be deleted immediately
+                                  after it finishes.
+                                format: int32
+                                type: integer
+                            type: object
+                          tag:
+                            description: Specifies the image tag
+                            type: string
+                          version:
+                            description: "An opaque value that represents the internal
+                              version of this tag that can be used by clients to determine
+                              when objects have changed. May be used for optimistic
+                              concurrency, change detection, and the watch operation
+                              on a resource or set of resources. Clients must treat
+                              these values as opaque and passed unmodified back to
+                              the server. \n Populated by the system. Read-only. Value
+                              must be treated as opaque by clients and ."
+                            format: int64
+                            type: integer
+                        required:
+                        - tag
+                        type: object
+                      type: array
+                  required:
+                  - tags
+                  type: object
+                description: Specifies images to be pulled on this node It can not
+                  be more than 256 for each NodeImage
+                type: object
+            type: object
+          status:
+            description: NodeImageStatus defines the observed state of NodeImage
+            properties:
+              desired:
+                description: The desired number of pulling tasks, this is typically
+                  equal to the number of images in spec.
+                format: int32
+                type: integer
+              failed:
+                description: The number of pulling tasks  which reached phase Failed.
+                format: int32
+                type: integer
+              firstSyncStatus:
+                description: The first of all job has finished on this node. When
+                  a node is added to the cluster, we want to know the time when the
+                  node's image pulling is completed, and use it to trigger the operation
+                  of the upper system.
+                properties:
+                  message:
+                    type: string
+                  status:
+                    description: SyncStatusPhase defines the node status
+                    type: string
+                  syncAt:
+                    format: date-time
+                    type: string
+                type: object
+              imageStatuses:
+                additionalProperties:
+                  description: ImageStatus defines the pulling status of an image
+                  properties:
+                    tags:
+                      description: Represents statuses of pulling tasks on this node
+                      items:
+                        description: ImageTagStatus defines the pulling status of
+                          an image tag
+                        properties:
+                          completionTime:
+                            description: Represents time when the pulling task was
+                              completed. It is not guaranteed to be set in happens-before
+                              order across separate operations. It is represented
+                              in RFC3339 form and is in UTC.
+                            format: date-time
+                            type: string
+                          imageID:
+                            description: Represents the ID of this image.
+                            type: string
+                          message:
+                            description: Represents the summary information of this
+                              node
+                            type: string
+                          phase:
+                            description: Represents the image pulling task phase.
+                            type: string
+                          progress:
+                            description: Represents the pulling progress of this tag,
+                              which is between 0-100. There is no guarantee of monotonic
+                              consistency, and it may be a rollback due to retry during
+                              pulling.
+                            format: int32
+                            type: integer
+                          startTime:
+                            description: Represents time when the pulling task was
+                              acknowledged by the image puller. It is not guaranteed
+                              to be set in happens-before order across separate operations.
+                              It is represented in RFC3339 form and is in UTC.
+                            format: date-time
+                            type: string
+                          tag:
+                            description: Represents the image tag.
+                            type: string
+                          version:
+                            description: Represents the internal version of this tag
+                              that the daemon handled.
+                            format: int64
+                            type: integer
+                        required:
+                        - phase
+                        - tag
+                        type: object
+                      type: array
+                  required:
+                  - tags
+                  type: object
+                description: all statuses of active image pulling tasks
+                type: object
+              pulling:
+                description: The number of pulling tasks which are not finished.
+                format: int32
+                type: integer
+              succeeded:
+                description: The number of pulling tasks which reached phase Succeeded.
+                format: int32
+                type: integer
+            required:
+            - desired
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/kruise/templates/apps.kruise.io_nodepodprobes.yaml
+++ b/charts/kruise/templates/apps.kruise.io_nodepodprobes.yaml
@@ -1,0 +1,273 @@
+{{- if .Values.crds.managed }}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: nodepodprobes.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: NodePodProbe
+    listKind: NodePodProbeList
+    plural: nodepodprobes
+    singular: nodepodprobe
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NodePodProbe is the Schema for the NodePodProbe API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NodePodProbeSpec defines the desired state of NodePodProbe
+            properties:
+              podProbes:
+                items:
+                  properties:
+                    name:
+                      description: pod name
+                      type: string
+                    namespace:
+                      description: pod namespace
+                      type: string
+                    probes:
+                      description: Custom container probe, supports Exec, Tcp, and
+                        returns the result to Pod yaml
+                      items:
+                        properties:
+                          containerName:
+                            description: container name
+                            type: string
+                          name:
+                            description: Name is podProbeMarker.Name#probe.Name
+                            type: string
+                          probe:
+                            description: container probe spec
+                            properties:
+                              exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                  a realistic TCP lifecycle hook'
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                        required:
+                        - containerName
+                        - name
+                        - probe
+                        type: object
+                      type: array
+                    uid:
+                      description: pod uid
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - uid
+                  type: object
+                type: array
+            type: object
+          status:
+            properties:
+              podProbeStatuses:
+                description: pod probe results
+                items:
+                  properties:
+                    name:
+                      description: pod name
+                      type: string
+                    namespace:
+                      description: pod namespace
+                      type: string
+                    probeStates:
+                      description: pod probe result
+                      items:
+                        properties:
+                          lastProbeTime:
+                            description: Last time we probed the condition.
+                            format: date-time
+                            type: string
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from
+                              one status to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: If Status=True, Message records the return
+                              result of Probe. If Status=False, Message records Probe's
+                              error message
+                            type: string
+                          name:
+                            description: Name is podProbeMarker.Name#probe.Name
+                            type: string
+                          state:
+                            description: container probe exec state, True or False
+                            type: string
+                        required:
+                        - name
+                        - state
+                        type: object
+                      type: array
+                    uid:
+                      description: pod uid
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - uid
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/kruise/templates/apps.kruise.io_persistentpodstates.yaml
+++ b/charts/kruise/templates/apps.kruise.io_persistentpodstates.yaml
@@ -1,0 +1,158 @@
+{{- if .Values.crds.managed }}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: persistentpodstates.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: PersistentPodState
+    listKind: PersistentPodStateList
+    plural: persistentpodstates
+    singular: persistentpodstate
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PersistentPodState is the Schema for the PersistentPodState API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PersistentPodStateSpec defines the desired state of PersistentPodState
+            properties:
+              persistentPodAnnotations:
+                description: Persist the annotations information of the pods that
+                  need to be saved
+                items:
+                  properties:
+                    key:
+                      type: string
+                  required:
+                  - key
+                  type: object
+                type: array
+              persistentPodStateRetentionPolicy:
+                description: PersistentPodStateRetentionPolicy describes the policy
+                  used for PodState. The default policy of 'WhenScaled' causes when
+                  scale down statefulSet, deleting it.
+                type: string
+              preferredPersistentTopology:
+                description: Pod rebuilt topology preferred for node labels, with
+                  xx weight for example  kubernetes.io/hostname, failure-domain.beta.kubernetes.io/zone
+                items:
+                  properties:
+                    preference:
+                      properties:
+                        nodeTopologyKeys:
+                          description: A list of node selector requirements by node's
+                            labels.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - nodeTopologyKeys
+                      type: object
+                    weight:
+                      format: int32
+                      type: integer
+                  required:
+                  - preference
+                  - weight
+                  type: object
+                type: array
+              requiredPersistentTopology:
+                description: Pod rebuilt topology required for node labels for example
+                  kubernetes.io/hostname, failure-domain.beta.kubernetes.io/zone
+                properties:
+                  nodeTopologyKeys:
+                    description: A list of node selector requirements by node's labels.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - nodeTopologyKeys
+                type: object
+              targetRef:
+                description: TargetReference contains enough information to let you
+                  identify an workload for PersistentPodState Selector and TargetReference
+                  are mutually exclusive, TargetReference is priority to take effect
+                  current only support StatefulSet
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+            required:
+            - targetRef
+            type: object
+          status:
+            properties:
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this PersistentPodState. It corresponds to the PersistentPodState's
+                  generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              podStates:
+                additionalProperties:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: pod persistent annotations
+                      type: object
+                    nodeName:
+                      description: pod.spec.nodeName
+                      type: string
+                    nodeTopologyLabels:
+                      additionalProperties:
+                        type: string
+                      description: node topology labels key=value for example kubernetes.io/hostname=node-1
+                      type: object
+                  type: object
+                description: 'When the pod is ready, record some status information
+                  of the pod, such as: labels, annotations, topologies, etc. map[string]PodState
+                  -> map[Pod.Name]PodState'
+                type: object
+            required:
+            - observedGeneration
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/kruise/templates/apps.kruise.io_podprobemarkers.yaml
+++ b/charts/kruise/templates/apps.kruise.io_podprobemarkers.yaml
@@ -1,0 +1,306 @@
+{{- if .Values.crds.managed }}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: podprobemarkers.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: PodProbeMarker
+    listKind: PodProbeMarkerList
+    plural: podprobemarkers
+    singular: podprobemarker
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PodProbeMarker is the Schema for the PodProbeMarker API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PodProbeMarkerSpec defines the desired state of PodProbeMarker
+            properties:
+              probes:
+                description: Custom container probe, current only support Exec().
+                  Probe Result will record in Pod.Status.Conditions, and condition.type=probe.name.
+                  condition.status=True indicates probe success condition.status=False
+                  indicates probe fails
+                items:
+                  properties:
+                    containerName:
+                      description: container name
+                      type: string
+                    markerPolicy:
+                      description: 'According to the execution result of ContainerProbe,
+                        perform specific actions, such as: patch Pod labels, annotations,
+                        ReadinessGate Condition It cannot be null at the same time
+                        as PodConditionType.'
+                      items:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Patch annotations pod.annotations
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Patch Labels pod.labels
+                            type: object
+                          state:
+                            description: 'probe status, True or False For example:
+                              State=Succeeded, annotations[controller.kubernetes.io/pod-deletion-cost]
+                              = ''10''. State=Failed, annotations[controller.kubernetes.io/pod-deletion-cost]
+                              = ''-10''. In addition, if State=Failed is not defined,
+                              Exec execution fails, and the annotations[controller.kubernetes.io/pod-deletion-cost]
+                              will be Deleted'
+                            type: string
+                        required:
+                        - state
+                        type: object
+                      type: array
+                    name:
+                      description: probe name, unique within the Pod(Even between
+                        different containers, they cannot be the same)
+                      type: string
+                    podConditionType:
+                      description: If it is not empty, the Probe execution result
+                        will be recorded on the Pod condition. It cannot be null at
+                        the same time as MarkerPolicy. For example PodConditionType=game.kruise.io/healthy,
+                        pod.status.condition.type = game.kruise.io/healthy. When probe
+                        is Succeeded, pod.status.condition.status = True. Otherwise,
+                        when the probe fails to execute, pod.status.condition.status
+                        = False.
+                      type: string
+                    probe:
+                      description: container probe spec
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness and startup. Minimum value
+                            is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure. The grace
+                            period is the duration in seconds after the processes
+                            running in the pod are sent a termination signal and the
+                            time when the processes are forcibly halted with a kill
+                            signal. Set this value longer than the expected cleanup
+                            time for your process. If this value is nil, the pod's
+                            terminationGracePeriodSeconds will be used. Otherwise,
+                            this value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates
+                            stop immediately via the kill signal (no opportunity to
+                            shut down). This is a beta field and requires enabling
+                            ProbeTerminationGracePeriod feature gate. Minimum value
+                            is 1. spec.terminationGracePeriodSeconds is used if unset.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          format: int32
+                          type: integer
+                      type: object
+                  required:
+                  - containerName
+                  - name
+                  - probe
+                  type: object
+                type: array
+              selector:
+                description: 'Selector is a label query over pods that should exec
+                  custom probe It must match the pod template''s labels. More info:
+                  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+            required:
+            - probes
+            - selector
+            type: object
+          status:
+            properties:
+              matchedPods:
+                description: matched Pods
+                format: int64
+                type: integer
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this PodProbeMarker. It corresponds to the PodProbeMarker's
+                  generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+            required:
+            - observedGeneration
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/kruise/templates/apps.kruise.io_resourcedistribution.yaml
+++ b/charts/kruise/templates/apps.kruise.io_resourcedistribution.yaml
@@ -1,0 +1,182 @@
+{{- if .Values.crds.managed }}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: resourcedistributions.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: ResourceDistribution
+    listKind: ResourceDistributionList
+    plural: resourcedistributions
+    shortNames:
+    - distributor
+    singular: resourcedistribution
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: The desired number of desired distribution and syncs.
+      jsonPath: .status.desired
+      name: TOTAL
+      type: integer
+    - description: The number of successful distribution and syncs.
+      jsonPath: .status.succeeded
+      name: SUCCEED
+      type: integer
+    - description: The number of failed distributions and syncs.
+      jsonPath: .status.failed
+      name: FAILED
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ResourceDistribution is the Schema for the resourcedistributions API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ResourceDistributionSpec defines the desired state of ResourceDistribution.
+            properties:
+              resource:
+                description: Resource must be the complete yaml that users want to distribute.
+                type: object
+                x-kubernetes-embedded-resource: true
+                x-kubernetes-preserve-unknown-fields: true
+              targets:
+                description: Targets defines the namespaces that users want to distribute to.
+                properties:
+                  allNamespaces:
+                    description: If AllNamespaces is true, Resource will be distributed to the all namespaces (except some forbidden namespaces, such as "kube-system" and "kube-public").
+                    type: boolean
+                  excludedNamespaces:
+                    description: If ExcludedNamespaces is not empty, Resource will never be distributed to the listed namespaces. ExcludedNamespaces has the highest priority.
+                    properties:
+                      list:
+                        items:
+                          description: ResourceDistributionNamespace contains a namespace name
+                          properties:
+                            name:
+                              description: Namespace name
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  includedNamespaces:
+                    description: If IncludedNamespaces is not empty, Resource will be distributed to the listed namespaces.
+                    properties:
+                      list:
+                        items:
+                          description: ResourceDistributionNamespace contains a namespace name
+                          properties:
+                            name:
+                              description: Namespace name
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  namespaceLabelSelector:
+                    description: If NamespaceLabelSelector is not empty, Resource will be distributed to the matched namespaces.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                type: object
+            required:
+            - resource
+            - targets
+            type: object
+          status:
+            description: ResourceDistributionStatus defines the observed state of ResourceDistribution. ResourceDistributionStatus is recorded by kruise, users' modification is invalid and meaningless.
+            properties:
+              conditions:
+                description: Conditions describe the condition when Resource creating, updating and deleting.
+                items:
+                  description: ResourceDistributionCondition allows a row to be marked with additional information.
+                  properties:
+                    failedNamespace:
+                      description: FailedNamespaces describe all failed namespaces when Status is False
+                      items:
+                        type: string
+                      type: array
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    reason:
+                      description: Reason describe human readable message indicating details about last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of ResourceDistributionCondition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              desired:
+                description: Desired represents the number of total target namespaces.
+                format: int32
+                type: integer
+              failed:
+                description: Failed represents the number of failed distributions.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                format: int64
+                type: integer
+              succeeded:
+                description: Succeeded represents the number of successful distributions.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/kruise/templates/apps.kruise.io_sidecarsets.yaml
+++ b/charts/kruise/templates/apps.kruise.io_sidecarsets.yaml
@@ -1,0 +1,487 @@
+{{- if .Values.crds.managed }}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: sidecarsets.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: SidecarSet
+    listKind: SidecarSetList
+    plural: sidecarsets
+    singular: sidecarset
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: The number of pods matched.
+      jsonPath: .status.matchedPods
+      name: MATCHED
+      type: integer
+    - description: The number of pods matched and updated.
+      jsonPath: .status.updatedPods
+      name: UPDATED
+      type: integer
+    - description: The number of pods matched and ready.
+      jsonPath: .status.readyPods
+      name: READY
+      type: integer
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC.
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SidecarSet is the Schema for the sidecarsets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SidecarSetSpec defines the desired state of SidecarSet
+            properties:
+              containers:
+                description: Containers is the list of sidecar containers to be injected
+                  into the selected pod
+                items:
+                  description: SidecarContainer defines the container of Sidecar
+                  properties:
+                    podInjectPolicy:
+                      description: The rules that injected SidecarContainer into Pod.spec.containers,
+                        not takes effect in initContainers If BeforeAppContainer,
+                        the SidecarContainer will be injected in front of the pod.spec.containers
+                        otherwise it will be injected into the back. default BeforeAppContainerType
+                      type: string
+                    shareVolumePolicy:
+                      description: If ShareVolumePolicy is enabled, the sidecar container
+                        will share the other container's VolumeMounts in the pod(don't
+                        contains the injected sidecar container).
+                      properties:
+                        type:
+                          type: string
+                      type: object
+                    transferEnv:
+                      description: TransferEnv will transfer env info from other container
+                        SourceContainerName is pod.spec.container[x].name; EnvName
+                        is pod.spec.container[x].Env.name
+                      items:
+                        properties:
+                          envName:
+                            type: string
+                          envNames:
+                            items:
+                              type: string
+                            type: array
+                          sourceContainerName:
+                            type: string
+                          sourceContainerNameFrom:
+                            properties:
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    upgradeStrategy:
+                      description: 'sidecarContainer upgrade strategy, include: ColdUpgrade,
+                        HotUpgrade'
+                      properties:
+                        hotUpgradeEmptyImage:
+                          description: when HotUpgrade, HotUpgradeEmptyImage is used
+                            to complete the hot upgrading process HotUpgradeEmptyImage
+                            is consistent of sidecar container in Command, Args, Liveness
+                            probe, etc. but it does no actual work.
+                          type: string
+                        upgradeType:
+                          description: when sidecar container is stateless, use ColdUpgrade
+                            otherwise HotUpgrade are more HotUpgrade. examples for
+                            istio envoy container is suitable for HotUpgrade default
+                            is ColdUpgrade
+                          type: string
+                      type: object
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
+              imagePullSecrets:
+                description: List of the names of secrets required by pulling sidecar
+                  container images
+                items:
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                type: array
+              initContainers:
+                description: InitContainers is the list of init containers to be injected
+                  into the selected pod We will inject those containers by their name
+                  in ascending order We only inject init containers when a new pod
+                  is created, it does not apply to any existing pod
+                items:
+                  description: SidecarContainer defines the container of Sidecar
+                  properties:
+                    podInjectPolicy:
+                      description: The rules that injected SidecarContainer into Pod.spec.containers,
+                        not takes effect in initContainers If BeforeAppContainer,
+                        the SidecarContainer will be injected in front of the pod.spec.containers
+                        otherwise it will be injected into the back. default BeforeAppContainerType
+                      type: string
+                    shareVolumePolicy:
+                      description: If ShareVolumePolicy is enabled, the sidecar container
+                        will share the other container's VolumeMounts in the pod(don't
+                        contains the injected sidecar container).
+                      properties:
+                        type:
+                          type: string
+                      type: object
+                    transferEnv:
+                      description: TransferEnv will transfer env info from other container
+                        SourceContainerName is pod.spec.container[x].name; EnvName
+                        is pod.spec.container[x].Env.name
+                      items:
+                        properties:
+                          envName:
+                            type: string
+                          envNames:
+                            items:
+                              type: string
+                            type: array
+                          sourceContainerName:
+                            type: string
+                          sourceContainerNameFrom:
+                            properties:
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    upgradeStrategy:
+                      description: 'sidecarContainer upgrade strategy, include: ColdUpgrade,
+                        HotUpgrade'
+                      properties:
+                        hotUpgradeEmptyImage:
+                          description: when HotUpgrade, HotUpgradeEmptyImage is used
+                            to complete the hot upgrading process HotUpgradeEmptyImage
+                            is consistent of sidecar container in Command, Args, Liveness
+                            probe, etc. but it does no actual work.
+                          type: string
+                        upgradeType:
+                          description: when sidecar container is stateless, use ColdUpgrade
+                            otherwise HotUpgrade are more HotUpgrade. examples for
+                            istio envoy container is suitable for HotUpgrade default
+                            is ColdUpgrade
+                          type: string
+                      type: object
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
+              injectionStrategy:
+                description: InjectionStrategy describe the strategy when sidecarset
+                  is injected into pods
+                properties:
+                  paused:
+                    description: Paused indicates that SidecarSet will suspend injection
+                      into Pods If Paused is true, the sidecarSet will not be injected
+                      to newly created Pods, but the injected sidecar container remains
+                      updating and running. default is false
+                    type: boolean
+                  revision:
+                    description: Revision can help users rolling update SidecarSet
+                      safely. If users set this filed, SidecarSet will try to inject
+                      specific revision according to different policies.
+                    properties:
+                      customVersion:
+                        description: CustomVersion corresponds to label 'apps.kruise.io/sidecarset-custom-version'
+                          of (History) SidecarSet. SidecarSet will select the specific
+                          ControllerRevision via this CustomVersion, and then restore
+                          the history SidecarSet to inject specific version of the
+                          sidecar to pods.
+                        type: string
+                      policy:
+                        description: Policy describes the behavior of revision injection.
+                          Defaults to Always.
+                        type: string
+                      revisionName:
+                        description: RevisionName corresponds to a specific ControllerRevision
+                          name of SidecarSet that you want to inject to Pods.
+                        type: string
+                    type: object
+                type: object
+              namespace:
+                description: Namespace sidecarSet will only match the pods in the
+                  namespace otherwise, match pods in all namespaces(in cluster)
+                type: string
+              patchPodMetadata:
+                description: SidecarSet support to inject & in-place update metadata
+                  in pod.
+                items:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: annotations
+                      type: object
+                    patchPolicy:
+                      description: labels map[string]string `json:"labels,omitempty"`
+                        patch pod metadata policy, Default is "Retain"
+                      type: string
+                  type: object
+                type: array
+              revisionHistoryLimit:
+                description: RevisionHistoryLimit indicates the maximum quantity of
+                  stored revisions about the SidecarSet. default value is 10
+                format: int32
+                type: integer
+              selector:
+                description: selector is a label query over pods that should be injected
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              updateStrategy:
+                description: The sidecarset updateStrategy to use to replace existing
+                  pods with new ones.
+                properties:
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'The maximum number of SidecarSet pods that can be
+                      unavailable during the update. Value can be an absolute number
+                      (ex: 5) or a percentage of total number of SidecarSet pods at
+                      the start of the update (ex: 10%). Absolute number is calculated
+                      from percentage by rounding up. This cannot be 0. Default value
+                      is 1.'
+                    x-kubernetes-int-or-string: true
+                  partition:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Partition is the desired number of pods in old revisions.
+                      It means when partition is set during pods updating, (replicas
+                      - partition) number of pods will be updated. Default value is
+                      0.
+                    x-kubernetes-int-or-string: true
+                  paused:
+                    description: Paused indicates that the SidecarSet is paused to
+                      update the injected pods, but it don't affect the webhook inject
+                      sidecar container into the newly created pods. default is false
+                    type: boolean
+                  scatterStrategy:
+                    description: ScatterStrategy defines the scatter rules to make
+                      pods been scattered when update. This will avoid pods with the
+                      same key-value to be updated in one batch. - Note that pods
+                      will be scattered after priority sort. So, although priority
+                      strategy and scatter strategy can be applied together, we suggest
+                      to use either one of them. - If scatterStrategy is used, we
+                      suggest to just use one term. Otherwise, the update order can
+                      be hard to understand.
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - key
+                      - value
+                      type: object
+                    type: array
+                  selector:
+                    description: If selector is not nil, this upgrade will only update
+                      the selected pods.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                  type:
+                    description: Type is NotUpdate, the SidecarSet don't update the
+                      injected pods, it will only inject sidecar container into the
+                      newly created pods. Type is RollingUpdate, the SidecarSet will
+                      update the injected pods to the latest version on RollingUpdate
+                      Strategy. default is RollingUpdate
+                    type: string
+                type: object
+              volumes:
+                description: List of volumes that can be mounted by sidecar containers
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            description: SidecarSetStatus defines the observed state of SidecarSet
+            properties:
+              collisionCount:
+                description: CollisionCount is the count of hash collisions for the
+                  SidecarSet. The SidecarSet controller uses this field as a collision
+                  avoidance mechanism when it needs to create the name for the newest
+                  ControllerRevision.
+                format: int32
+                type: integer
+              latestRevision:
+                description: LatestRevision, if not empty, indicates the latest controllerRevision
+                  name of the SidecarSet.
+                type: string
+              matchedPods:
+                description: matchedPods is the number of Pods whose labels are matched
+                  with this SidecarSet's selector and are created after sidecarset
+                  creates
+                format: int32
+                type: integer
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this SidecarSet. It corresponds to the SidecarSet's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              readyPods:
+                description: readyPods is the number of matched Pods that have a ready
+                  condition
+                format: int32
+                type: integer
+              updatedPods:
+                description: updatedPods is the number of matched Pods that are injected
+                  with the latest SidecarSet's containers
+                format: int32
+                type: integer
+              updatedReadyPods:
+                description: updatedReadyPods is the number of matched pods that updated
+                  and ready
+                format: int32
+                type: integer
+            required:
+            - matchedPods
+            - readyPods
+            - updatedPods
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/kruise/templates/apps.kruise.io_statefulsets.yaml
+++ b/charts/kruise/templates/apps.kruise.io_statefulsets.yaml
@@ -1,0 +1,1012 @@
+{{- if .Values.crds.managed }}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  name: statefulsets.apps.kruise.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: kruise-webhook-service
+          namespace: {{ .Values.installation.namespace }}
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: apps.kruise.io
+  names:
+    kind: StatefulSet
+    listKind: StatefulSetList
+    plural: statefulsets
+    shortNames:
+    - sts
+    - asts
+    singular: statefulset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The desired number of pods.
+      jsonPath: .spec.replicas
+      name: DESIRED
+      type: integer
+    - description: The number of currently all pods.
+      jsonPath: .status.replicas
+      name: CURRENT
+      type: integer
+    - description: The number of pods updated.
+      jsonPath: .status.updatedReplicas
+      name: UPDATED
+      type: integer
+    - description: The number of pods ready.
+      jsonPath: .status.readyReplicas
+      name: READY
+      type: integer
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC.
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    - description: The containers of currently advanced statefulset.
+      jsonPath: .spec.template.spec.containers[*].name
+      name: CONTAINERS
+      priority: 1
+      type: string
+    - description: The images of currently advanced statefulset.
+      jsonPath: .spec.template.spec.containers[*].image
+      name: IMAGES
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: StatefulSet is the Schema for the statefulsets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StatefulSetSpec defines the desired state of StatefulSet
+            properties:
+              podManagementPolicy:
+                description: podManagementPolicy controls how pods are created during
+                  initial scale up, when replacing pods on nodes, or when scaling
+                  down. The default policy is `OrderedReady`, where pods are created
+                  in increasing order (pod-0, then pod-1, etc) and the controller
+                  will wait until each pod is ready before continuing. When scaling
+                  down, the pods are removed in the opposite order. The alternative
+                  policy is `Parallel` which will create pods in parallel to match
+                  the desired scale without waiting, and on scale down will delete
+                  all pods at once.
+                type: string
+              replicas:
+                description: 'replicas is the desired number of replicas of the given
+                  Template. These are replicas in the sense that they are instantiations
+                  of the same Template, but individual replicas also have a consistent
+                  identity. If unspecified, defaults to 1. TODO: Consider a rename
+                  of this field.'
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: revisionHistoryLimit is the maximum number of revisions
+                  that will be maintained in the StatefulSet's revision history. The
+                  revision history consists of all revisions not represented by a
+                  currently applied StatefulSetSpec version. The default value is
+                  10.
+                format: int32
+                type: integer
+              selector:
+                description: 'selector is a label query over pods that should match
+                  the replica count. It must match the pod template''s labels. More
+                  info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              serviceName:
+                description: 'serviceName is the name of the service that governs
+                  this StatefulSet. This service must exist before the StatefulSet,
+                  and is responsible for the network identity of the set. Pods get
+                  DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local
+                  where "pod-specific-string" is managed by the StatefulSet controller.'
+                type: string
+              template:
+                description: template is the object that describes the pod that will
+                  be created if insufficient replicas are detected. Each pod stamped
+                  out by the StatefulSet will fulfill this Template, but have a unique
+                  identity from the rest of the StatefulSet.
+                x-kubernetes-preserve-unknown-fields: true
+              updateStrategy:
+                description: updateStrategy indicates the StatefulSetUpdateStrategy
+                  that will be employed to update Pods in the StatefulSet when a revision
+                  is made to Template.
+                properties:
+                  rollingUpdate:
+                    description: RollingUpdate is used to communicate parameters when
+                      Type is RollingUpdateStatefulSetStrategyType.
+                    properties:
+                      inPlaceUpdateStrategy:
+                        description: InPlaceUpdateStrategy contains strategies for
+                          in-place update.
+                        properties:
+                          gracePeriodSeconds:
+                            description: GracePeriodSeconds is the timespan between
+                              set Pod status to not-ready and update images in Pod
+                              spec when in-place update a Pod.
+                            format: int32
+                            type: integer
+                        type: object
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of pods that can be unavailable
+                          during the update. Value can be an absolute number (ex:
+                          5) or a percentage of desired pods (ex: 10%). Absolute number
+                          is calculated from percentage by rounding down. Also, maxUnavailable
+                          can just be allowed to work with Parallel podManagementPolicy.
+                          Defaults to 1.'
+                        x-kubernetes-int-or-string: true
+                      minReadySeconds:
+                        description: MinReadySeconds indicates how long will the pod
+                          be considered ready after it's updated. MinReadySeconds
+                          works with both OrderedReady and Parallel podManagementPolicy.
+                          It affects the pod scale up speed when the podManagementPolicy
+                          is set to be OrderedReady. Combined with MaxUnavailable,
+                          it affects the pod update speed regardless of podManagementPolicy.
+                          Default value is 0, max is 300.
+                        format: int32
+                        type: integer
+                      partition:
+                        description: 'Partition indicates the ordinal at which the
+                          StatefulSet should be partitioned by default. But if unorderedUpdate
+                          has been set:   - Partition indicates the number of pods
+                          with non-updated revisions when rolling update.   - It means
+                          controller will update $(replicas - partition) number of
+                          pod. Default value is 0.'
+                        format: int32
+                        type: integer
+                      paused:
+                        description: Paused indicates that the StatefulSet is paused.
+                          Default value is false
+                        type: boolean
+                      podUpdatePolicy:
+                        description: PodUpdatePolicy indicates how pods should be
+                          updated Default value is "ReCreate"
+                        type: string
+                      unorderedUpdate:
+                        description: UnorderedUpdate contains strategies for non-ordered
+                          update. If it is not nil, pods will be updated with non-ordered
+                          sequence. Noted that UnorderedUpdate can only be allowed
+                          to work with Parallel podManagementPolicy
+                        properties:
+                          priorityStrategy:
+                            description: Priorities are the rules for calculating
+                              the priority of updating pods. Each pod to be updated,
+                              will pass through these terms and get a sum of weights.
+                            properties:
+                              orderPriority:
+                                description: 'Order priority terms, pods will be sorted
+                                  by the value of orderedKey. For example: ``` orderPriority:
+                                  - orderedKey: key1 - orderedKey: key2 ``` First,
+                                  all pods which have key1 in labels will be sorted
+                                  by the value of key1. Then, the left pods which
+                                  have no key1 but have key2 in labels will be sorted
+                                  by the value of key2 and put behind those pods have
+                                  key1.'
+                                items:
+                                  description: UpdatePriorityOrderTerm defines order
+                                    priority.
+                                  properties:
+                                    orderedKey:
+                                      description: Calculate priority by value of
+                                        this key. Values of this key, will be sorted
+                                        by GetInt(val). GetInt method will find the
+                                        last int in value, such as getting 5 in value
+                                        '5', getting 10 in value 'sts-10'.
+                                      type: string
+                                  required:
+                                  - orderedKey
+                                  type: object
+                                type: array
+                              weightPriority:
+                                description: Weight priority terms, pods will be sorted
+                                  by the sum of all terms weight.
+                                items:
+                                  description: UpdatePriorityWeightTerm defines weight
+                                    priority.
+                                  properties:
+                                    matchSelector:
+                                      description: MatchSelector is used to select
+                                        by pod's labels.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding matchExpressions, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - matchSelector
+                                  - weight
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                  type:
+                    description: Type indicates the type of the StatefulSetUpdateStrategy.
+                      Default is RollingUpdate.
+                    type: string
+                type: object
+              volumeClaimTemplates:
+                description: 'volumeClaimTemplates is a list of claims that pods are
+                  allowed to reference. The StatefulSet controller is responsible
+                  for mapping network identities to claims in a way that maintains
+                  the identity of a pod. Every claim in this list must have at least
+                  one matching (by name) volumeMount in one container in the template.
+                  A claim in this list takes precedence over any volumes in the template,
+                  with the same name. TODO: Define the behavior if a claim already
+                  exists with the same name.'
+                x-kubernetes-preserve-unknown-fields: true
+            required:
+            - selector
+            - template
+            type: object
+          status:
+            description: StatefulSetStatus defines the observed state of StatefulSet
+            properties:
+              availableReplicas:
+                description: AvailableReplicas is the number of Pods created by the
+                  StatefulSet controller that have been ready for minReadySeconds.
+                format: int32
+                type: integer
+              collisionCount:
+                description: collisionCount is the count of hash collisions for the
+                  StatefulSet. The StatefulSet controller uses this field as a collision
+                  avoidance mechanism when it needs to create the name for the newest
+                  ControllerRevision.
+                format: int32
+                type: integer
+              conditions:
+                description: Represents the latest available observations of a statefulset's
+                  current state.
+                items:
+                  description: StatefulSetCondition describes the state of a statefulset
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of statefulset condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentReplicas:
+                description: currentReplicas is the number of Pods created by the
+                  StatefulSet controller from the StatefulSet version indicated by
+                  currentRevision.
+                format: int32
+                type: integer
+              currentRevision:
+                description: currentRevision, if not empty, indicates the version
+                  of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+                type: string
+              labelSelector:
+                description: LabelSelector is label selectors for query over pods
+                  that should match the replica count used by HPA.
+                type: string
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this StatefulSet. It corresponds to the StatefulSet's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas is the number of Pods created by the StatefulSet
+                  controller that have a Ready Condition.
+                format: int32
+                type: integer
+              replicas:
+                description: replicas is the number of Pods created by the StatefulSet
+                  controller.
+                format: int32
+                type: integer
+              updateRevision:
+                description: updateRevision, if not empty, indicates the version of
+                  the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+                type: string
+              updatedReplicas:
+                description: updatedReplicas is the number of Pods created by the
+                  StatefulSet controller from the StatefulSet version indicated by
+                  updateRevision.
+                format: int32
+                type: integer
+            required:
+            - availableReplicas
+            - currentReplicas
+            - readyReplicas
+            - replicas
+            - updatedReplicas
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.labelSelector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: The desired number of pods.
+      jsonPath: .spec.replicas
+      name: DESIRED
+      type: integer
+    - description: The number of currently all pods.
+      jsonPath: .status.replicas
+      name: CURRENT
+      type: integer
+    - description: The number of pods updated.
+      jsonPath: .status.updatedReplicas
+      name: UPDATED
+      type: integer
+    - description: The number of pods ready.
+      jsonPath: .status.readyReplicas
+      name: READY
+      type: integer
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC.
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    - description: The containers of currently advanced statefulset.
+      jsonPath: .spec.template.spec.containers[*].name
+      name: CONTAINERS
+      priority: 1
+      type: string
+    - description: The images of currently advanced statefulset.
+      jsonPath: .spec.template.spec.containers[*].image
+      name: IMAGES
+      priority: 1
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: StatefulSet is the Schema for the statefulsets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StatefulSetSpec defines the desired state of StatefulSet
+            properties:
+              lifecycle:
+                description: Lifecycle defines the lifecycle hooks for Pods pre-delete,
+                  in-place update.
+                properties:
+                  inPlaceUpdate:
+                    description: InPlaceUpdate is the hook before Pod to update and
+                      after Pod has been updated.
+                    properties:
+                      finalizersHandler:
+                        items:
+                          type: string
+                        type: array
+                      labelsHandler:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Currently,
+                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
+                          hook. Default to false.'
+                        type: boolean
+                    type: object
+                  preDelete:
+                    description: PreDelete is the hook before Pod to be deleted.
+                    properties:
+                      finalizersHandler:
+                        items:
+                          type: string
+                        type: array
+                      labelsHandler:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Currently,
+                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
+                          hook. Default to false.'
+                        type: boolean
+                    type: object
+                  preNormal:
+                    description: PreNormal is the hook after Pod to be created and
+                      ready to be Normal.
+                    properties:
+                      finalizersHandler:
+                        items:
+                          type: string
+                        type: array
+                      labelsHandler:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      markPodNotReady:
+                        description: 'MarkPodNotReady = true means: - Pod will be
+                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to ''Ready'' at Updated state if
+                          it was set to ''NotReady'' at preparingUpdate state. Currently,
+                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
+                          hook. Default to false.'
+                        type: boolean
+                    type: object
+                type: object
+              persistentVolumeClaimRetentionPolicy:
+                description: PersistentVolumeClaimRetentionPolicy describes the policy
+                  used for PVCs created from the StatefulSet VolumeClaimTemplates.
+                  This requires the StatefulSetAutoDeletePVC feature gate to be enabled,
+                  which is alpha.
+                properties:
+                  whenDeleted:
+                    description: WhenDeleted specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      deleted. The default policy of `Retain` causes PVCs to not be
+                      affected by StatefulSet deletion. The `Delete` policy causes
+                      those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: WhenScaled specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      scaled down. The default policy of `Retain` causes PVCs to not
+                      be affected by a scaledown. The `Delete` policy causes the associated
+                      PVCs for any excess pods above the replica count to be deleted.
+                    type: string
+                type: object
+              podManagementPolicy:
+                description: podManagementPolicy controls how pods are created during
+                  initial scale up, when replacing pods on nodes, or when scaling
+                  down. The default policy is `OrderedReady`, where pods are created
+                  in increasing order (pod-0, then pod-1, etc) and the controller
+                  will wait until each pod is ready before continuing. When scaling
+                  down, the pods are removed in the opposite order. The alternative
+                  policy is `Parallel` which will create pods in parallel to match
+                  the desired scale without waiting, and on scale down will delete
+                  all pods at once.
+                type: string
+              replicas:
+                description: 'replicas is the desired number of replicas of the given
+                  Template. These are replicas in the sense that they are instantiations
+                  of the same Template, but individual replicas also have a consistent
+                  identity. If unspecified, defaults to 1. TODO: Consider a rename
+                  of this field.'
+                format: int32
+                type: integer
+              reserveOrdinals:
+                description: 'reserveOrdinals controls the ordinal numbers that should
+                  be reserved, and the replicas will always be the expectation number
+                  of running Pods. For a sts with replicas=3 and its Pods in [0, 1,
+                  2]: - If you want to migrate Pod-1 and reserve this ordinal, just
+                  set spec.reserveOrdinal to [1].   Then controller will delete Pod-1
+                  and create Pod-3 (existing Pods will be [0, 2, 3]) - If you just
+                  want to delete Pod-1, you should set spec.reserveOrdinal to [1]
+                  and spec.replicas to 2.   Then controller will delete Pod-1 (existing
+                  Pods will be [0, 2])'
+                items:
+                  type: integer
+                type: array
+              revisionHistoryLimit:
+                description: revisionHistoryLimit is the maximum number of revisions
+                  that will be maintained in the StatefulSet's revision history. The
+                  revision history consists of all revisions not represented by a
+                  currently applied StatefulSetSpec version. The default value is
+                  10.
+                format: int32
+                type: integer
+              scaleStrategy:
+                description: scaleStrategy indicates the StatefulSetScaleStrategy
+                  that will be employed to scale Pods in the StatefulSet.
+                properties:
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'The maximum number of pods that can be unavailable
+                      during scaling. Value can be an absolute number (ex: 5) or a
+                      percentage of desired pods (ex: 10%). Absolute number is calculated
+                      from percentage by rounding down. It can just be allowed to
+                      work with Parallel podManagementPolicy.'
+                    x-kubernetes-int-or-string: true
+                type: object
+              selector:
+                description: 'selector is a label query over pods that should match
+                  the replica count. It must match the pod template''s labels. More
+                  info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              serviceName:
+                description: 'serviceName is the name of the service that governs
+                  this StatefulSet. This service must exist before the StatefulSet,
+                  and is responsible for the network identity of the set. Pods get
+                  DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local
+                  where "pod-specific-string" is managed by the StatefulSet controller.'
+                type: string
+              template:
+                description: template is the object that describes the pod that will
+                  be created if insufficient replicas are detected. Each pod stamped
+                  out by the StatefulSet will fulfill this Template, but have a unique
+                  identity from the rest of the StatefulSet.
+                x-kubernetes-preserve-unknown-fields: true
+              updateStrategy:
+                description: updateStrategy indicates the StatefulSetUpdateStrategy
+                  that will be employed to update Pods in the StatefulSet when a revision
+                  is made to Template.
+                properties:
+                  rollingUpdate:
+                    description: RollingUpdate is used to communicate parameters when
+                      Type is RollingUpdateStatefulSetStrategyType.
+                    properties:
+                      inPlaceUpdateStrategy:
+                        description: InPlaceUpdateStrategy contains strategies for
+                          in-place update.
+                        properties:
+                          gracePeriodSeconds:
+                            description: GracePeriodSeconds is the timespan between
+                              set Pod status to not-ready and update images in Pod
+                              spec when in-place update a Pod.
+                            format: int32
+                            type: integer
+                        type: object
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of pods that can be unavailable
+                          during the update. Value can be an absolute number (ex:
+                          5) or a percentage of desired pods (ex: 10%). Absolute number
+                          is calculated from percentage by rounding down. Also, maxUnavailable
+                          can just be allowed to work with Parallel podManagementPolicy.
+                          Defaults to 1.'
+                        x-kubernetes-int-or-string: true
+                      minReadySeconds:
+                        description: MinReadySeconds indicates how long will the pod
+                          be considered ready after it's updated. MinReadySeconds
+                          works with both OrderedReady and Parallel podManagementPolicy.
+                          It affects the pod scale up speed when the podManagementPolicy
+                          is set to be OrderedReady. Combined with MaxUnavailable,
+                          it affects the pod update speed regardless of podManagementPolicy.
+                          Default value is 0, max is 300.
+                        format: int32
+                        type: integer
+                      partition:
+                        description: 'Partition indicates the ordinal at which the
+                          StatefulSet should be partitioned by default. But if unorderedUpdate
+                          has been set:   - Partition indicates the number of pods
+                          with non-updated revisions when rolling update.   - It means
+                          controller will update $(replicas - partition) number of
+                          pod. Default value is 0.'
+                        format: int32
+                        type: integer
+                      paused:
+                        description: Paused indicates that the StatefulSet is paused.
+                          Default value is false
+                        type: boolean
+                      podUpdatePolicy:
+                        description: PodUpdatePolicy indicates how pods should be
+                          updated Default value is "ReCreate"
+                        type: string
+                      unorderedUpdate:
+                        description: UnorderedUpdate contains strategies for non-ordered
+                          update. If it is not nil, pods will be updated with non-ordered
+                          sequence. Noted that UnorderedUpdate can only be allowed
+                          to work with Parallel podManagementPolicy
+                        properties:
+                          priorityStrategy:
+                            description: Priorities are the rules for calculating
+                              the priority of updating pods. Each pod to be updated,
+                              will pass through these terms and get a sum of weights.
+                            properties:
+                              orderPriority:
+                                description: 'Order priority terms, pods will be sorted
+                                  by the value of orderedKey. For example: ``` orderPriority:
+                                  - orderedKey: key1 - orderedKey: key2 ``` First,
+                                  all pods which have key1 in labels will be sorted
+                                  by the value of key1. Then, the left pods which
+                                  have no key1 but have key2 in labels will be sorted
+                                  by the value of key2 and put behind those pods have
+                                  key1.'
+                                items:
+                                  description: UpdatePriorityOrderTerm defines order
+                                    priority.
+                                  properties:
+                                    orderedKey:
+                                      description: Calculate priority by value of
+                                        this key. Values of this key, will be sorted
+                                        by GetInt(val). GetInt method will find the
+                                        last int in value, such as getting 5 in value
+                                        '5', getting 10 in value 'sts-10'.
+                                      type: string
+                                  required:
+                                  - orderedKey
+                                  type: object
+                                type: array
+                              weightPriority:
+                                description: Weight priority terms, pods will be sorted
+                                  by the sum of all terms weight.
+                                items:
+                                  description: UpdatePriorityWeightTerm defines weight
+                                    priority.
+                                  properties:
+                                    matchSelector:
+                                      description: MatchSelector is used to select
+                                        by pod's labels.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding matchExpressions, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - matchSelector
+                                  - weight
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                  type:
+                    description: Type indicates the type of the StatefulSetUpdateStrategy.
+                      Default is RollingUpdate.
+                    type: string
+                type: object
+              volumeClaimTemplates:
+                description: 'volumeClaimTemplates is a list of claims that pods are
+                  allowed to reference. The StatefulSet controller is responsible
+                  for mapping network identities to claims in a way that maintains
+                  the identity of a pod. Every claim in this list must have at least
+                  one matching (by name) volumeMount in one container in the template.
+                  A claim in this list takes precedence over any volumes in the template,
+                  with the same name. TODO: Define the behavior if a claim already
+                  exists with the same name.'
+                x-kubernetes-preserve-unknown-fields: true
+            required:
+            - selector
+            - template
+            type: object
+          status:
+            description: StatefulSetStatus defines the observed state of StatefulSet
+            properties:
+              availableReplicas:
+                description: AvailableReplicas is the number of Pods created by the
+                  StatefulSet controller that have been ready for minReadySeconds.
+                format: int32
+                type: integer
+              collisionCount:
+                description: collisionCount is the count of hash collisions for the
+                  StatefulSet. The StatefulSet controller uses this field as a collision
+                  avoidance mechanism when it needs to create the name for the newest
+                  ControllerRevision.
+                format: int32
+                type: integer
+              conditions:
+                description: Represents the latest available observations of a statefulset's
+                  current state.
+                items:
+                  description: StatefulSetCondition describes the state of a statefulset
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of statefulset condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentReplicas:
+                description: currentReplicas is the number of Pods created by the
+                  StatefulSet controller from the StatefulSet version indicated by
+                  currentRevision.
+                format: int32
+                type: integer
+              currentRevision:
+                description: currentRevision, if not empty, indicates the version
+                  of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+                type: string
+              labelSelector:
+                description: LabelSelector is label selectors for query over pods
+                  that should match the replica count used by HPA.
+                type: string
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this StatefulSet. It corresponds to the StatefulSet's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas is the number of Pods created by the StatefulSet
+                  controller that have a Ready Condition.
+                format: int32
+                type: integer
+              replicas:
+                description: replicas is the number of Pods created by the StatefulSet
+                  controller.
+                format: int32
+                type: integer
+              updateRevision:
+                description: updateRevision, if not empty, indicates the version of
+                  the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+                type: string
+              updatedReadyReplicas:
+                description: updatedReadyReplicas is the number of updated Pods created
+                  by the StatefulSet controller that have a Ready Condition.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: updatedReplicas is the number of Pods created by the
+                  StatefulSet controller from the StatefulSet version indicated by
+                  updateRevision.
+                format: int32
+                type: integer
+            required:
+            - availableReplicas
+            - currentReplicas
+            - readyReplicas
+            - replicas
+            - updatedReplicas
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.labelSelector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/kruise/templates/apps.kruise.io_uniteddeployments.yaml
+++ b/charts/kruise/templates/apps.kruise.io_uniteddeployments.yaml
@@ -1,0 +1,1248 @@
+{{- if .Values.crds.managed }}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: uniteddeployments.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: UnitedDeployment
+    listKind: UnitedDeploymentList
+    plural: uniteddeployments
+    shortNames:
+    - ud
+    singular: uniteddeployment
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The desired number of pods.
+      jsonPath: .spec.replicas
+      name: DESIRED
+      type: integer
+    - description: The number of currently all pods.
+      jsonPath: .status.replicas
+      name: CURRENT
+      type: integer
+    - description: The number of pods updated.
+      jsonPath: .status.updatedReplicas
+      name: UPDATED
+      type: integer
+    - description: The number of pods ready.
+      jsonPath: .status.readyReplicas
+      name: READY
+      type: integer
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC.
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: UnitedDeployment is the Schema for the uniteddeployments API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UnitedDeploymentSpec defines the desired state of UnitedDeployment.
+            properties:
+              replicas:
+                description: Replicas is the total desired replicas of all the subsets.
+                  If unspecified, defaults to 1.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: Indicates the number of histories to be conserved. If
+                  unspecified, defaults to 10.
+                format: int32
+                type: integer
+              selector:
+                description: Selector is a label query over pods that should match
+                  the replica count. It must match the pod template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              template:
+                description: Template describes the subset that will be created.
+                properties:
+                  advancedStatefulSetTemplate:
+                    description: AdvancedStatefulSet template
+                    properties:
+                      metadata:
+                        x-kubernetes-preserve-unknown-fields: true
+                      spec:
+                        description: StatefulSetSpec defines the desired state of
+                          StatefulSet
+                        properties:
+                          lifecycle:
+                            description: Lifecycle defines the lifecycle hooks for
+                              Pods pre-delete, in-place update.
+                            properties:
+                              inPlaceUpdate:
+                                description: InPlaceUpdate is the hook before Pod
+                                  to update and after Pod has been updated.
+                                properties:
+                                  finalizersHandler:
+                                    items:
+                                      type: string
+                                    type: array
+                                  labelsHandler:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: -
+                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
+                                      state. - Pod will be restored to ''Ready'' at
+                                      Updated state if it was set to ''NotReady''
+                                      at preparingUpdate state. Currently, MarkPodNotReady
+                                      only takes effect on InPlaceUpdate & PreDelete
+                                      hook. Default to false.'
+                                    type: boolean
+                                type: object
+                              preDelete:
+                                description: PreDelete is the hook before Pod to be
+                                  deleted.
+                                properties:
+                                  finalizersHandler:
+                                    items:
+                                      type: string
+                                    type: array
+                                  labelsHandler:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: -
+                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
+                                      state. - Pod will be restored to ''Ready'' at
+                                      Updated state if it was set to ''NotReady''
+                                      at preparingUpdate state. Currently, MarkPodNotReady
+                                      only takes effect on InPlaceUpdate & PreDelete
+                                      hook. Default to false.'
+                                    type: boolean
+                                type: object
+                              preNormal:
+                                description: PreNormal is the hook after Pod to be
+                                  created and ready to be Normal.
+                                properties:
+                                  finalizersHandler:
+                                    items:
+                                      type: string
+                                    type: array
+                                  labelsHandler:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: -
+                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
+                                      state. - Pod will be restored to ''Ready'' at
+                                      Updated state if it was set to ''NotReady''
+                                      at preparingUpdate state. Currently, MarkPodNotReady
+                                      only takes effect on InPlaceUpdate & PreDelete
+                                      hook. Default to false.'
+                                    type: boolean
+                                type: object
+                            type: object
+                          persistentVolumeClaimRetentionPolicy:
+                            description: PersistentVolumeClaimRetentionPolicy describes
+                              the policy used for PVCs created from the StatefulSet
+                              VolumeClaimTemplates. This requires the StatefulSetAutoDeletePVC
+                              feature gate to be enabled, which is alpha.
+                            properties:
+                              whenDeleted:
+                                description: WhenDeleted specifies what happens to
+                                  PVCs created from StatefulSet VolumeClaimTemplates
+                                  when the StatefulSet is deleted. The default policy
+                                  of `Retain` causes PVCs to not be affected by StatefulSet
+                                  deletion. The `Delete` policy causes those PVCs
+                                  to be deleted.
+                                type: string
+                              whenScaled:
+                                description: WhenScaled specifies what happens to
+                                  PVCs created from StatefulSet VolumeClaimTemplates
+                                  when the StatefulSet is scaled down. The default
+                                  policy of `Retain` causes PVCs to not be affected
+                                  by a scaledown. The `Delete` policy causes the associated
+                                  PVCs for any excess pods above the replica count
+                                  to be deleted.
+                                type: string
+                            type: object
+                          podManagementPolicy:
+                            description: podManagementPolicy controls how pods are
+                              created during initial scale up, when replacing pods
+                              on nodes, or when scaling down. The default policy is
+                              `OrderedReady`, where pods are created in increasing
+                              order (pod-0, then pod-1, etc) and the controller will
+                              wait until each pod is ready before continuing. When
+                              scaling down, the pods are removed in the opposite order.
+                              The alternative policy is `Parallel` which will create
+                              pods in parallel to match the desired scale without
+                              waiting, and on scale down will delete all pods at once.
+                            type: string
+                          replicas:
+                            description: 'replicas is the desired number of replicas
+                              of the given Template. These are replicas in the sense
+                              that they are instantiations of the same Template, but
+                              individual replicas also have a consistent identity.
+                              If unspecified, defaults to 1. TODO: Consider a rename
+                              of this field.'
+                            format: int32
+                            type: integer
+                          reserveOrdinals:
+                            description: 'reserveOrdinals controls the ordinal numbers
+                              that should be reserved, and the replicas will always
+                              be the expectation number of running Pods. For a sts
+                              with replicas=3 and its Pods in [0, 1, 2]: - If you
+                              want to migrate Pod-1 and reserve this ordinal, just
+                              set spec.reserveOrdinal to [1].   Then controller will
+                              delete Pod-1 and create Pod-3 (existing Pods will be
+                              [0, 2, 3]) - If you just want to delete Pod-1, you should
+                              set spec.reserveOrdinal to [1] and spec.replicas to
+                              2.   Then controller will delete Pod-1 (existing Pods
+                              will be [0, 2])'
+                            items:
+                              type: integer
+                            type: array
+                          revisionHistoryLimit:
+                            description: revisionHistoryLimit is the maximum number
+                              of revisions that will be maintained in the StatefulSet's
+                              revision history. The revision history consists of all
+                              revisions not represented by a currently applied StatefulSetSpec
+                              version. The default value is 10.
+                            format: int32
+                            type: integer
+                          scaleStrategy:
+                            description: scaleStrategy indicates the StatefulSetScaleStrategy
+                              that will be employed to scale Pods in the StatefulSet.
+                            properties:
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'The maximum number of pods that can
+                                  be unavailable during scaling. Value can be an absolute
+                                  number (ex: 5) or a percentage of desired pods (ex:
+                                  10%). Absolute number is calculated from percentage
+                                  by rounding down. It can just be allowed to work
+                                  with Parallel podManagementPolicy.'
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          selector:
+                            description: 'selector is a label query over pods that
+                              should match the replica count. It must match the pod
+                              template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          serviceName:
+                            description: 'serviceName is the name of the service that
+                              governs this StatefulSet. This service must exist before
+                              the StatefulSet, and is responsible for the network
+                              identity of the set. Pods get DNS/hostnames that follow
+                              the pattern: pod-specific-string.serviceName.default.svc.cluster.local
+                              where "pod-specific-string" is managed by the StatefulSet
+                              controller.'
+                            type: string
+                          template:
+                            description: template is the object that describes the
+                              pod that will be created if insufficient replicas are
+                              detected. Each pod stamped out by the StatefulSet will
+                              fulfill this Template, but have a unique identity from
+                              the rest of the StatefulSet.
+                            x-kubernetes-preserve-unknown-fields: true
+                          updateStrategy:
+                            description: updateStrategy indicates the StatefulSetUpdateStrategy
+                              that will be employed to update Pods in the StatefulSet
+                              when a revision is made to Template.
+                            properties:
+                              rollingUpdate:
+                                description: RollingUpdate is used to communicate
+                                  parameters when Type is RollingUpdateStatefulSetStrategyType.
+                                properties:
+                                  inPlaceUpdateStrategy:
+                                    description: InPlaceUpdateStrategy contains strategies
+                                      for in-place update.
+                                    properties:
+                                      gracePeriodSeconds:
+                                        description: GracePeriodSeconds is the timespan
+                                          between set Pod status to not-ready and
+                                          update images in Pod spec when in-place
+                                          update a Pod.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  maxUnavailable:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: 'The maximum number of pods that
+                                      can be unavailable during the update. Value
+                                      can be an absolute number (ex: 5) or a percentage
+                                      of desired pods (ex: 10%). Absolute number is
+                                      calculated from percentage by rounding down.
+                                      Also, maxUnavailable can just be allowed to
+                                      work with Parallel podManagementPolicy. Defaults
+                                      to 1.'
+                                    x-kubernetes-int-or-string: true
+                                  minReadySeconds:
+                                    description: MinReadySeconds indicates how long
+                                      will the pod be considered ready after it's
+                                      updated. MinReadySeconds works with both OrderedReady
+                                      and Parallel podManagementPolicy. It affects
+                                      the pod scale up speed when the podManagementPolicy
+                                      is set to be OrderedReady. Combined with MaxUnavailable,
+                                      it affects the pod update speed regardless of
+                                      podManagementPolicy. Default value is 0, max
+                                      is 300.
+                                    format: int32
+                                    type: integer
+                                  partition:
+                                    description: 'Partition indicates the ordinal
+                                      at which the StatefulSet should be partitioned
+                                      by default. But if unorderedUpdate has been
+                                      set:   - Partition indicates the number of pods
+                                      with non-updated revisions when rolling update.   -
+                                      It means controller will update $(replicas -
+                                      partition) number of pod. Default value is 0.'
+                                    format: int32
+                                    type: integer
+                                  paused:
+                                    description: Paused indicates that the StatefulSet
+                                      is paused. Default value is false
+                                    type: boolean
+                                  podUpdatePolicy:
+                                    description: PodUpdatePolicy indicates how pods
+                                      should be updated Default value is "ReCreate"
+                                    type: string
+                                  unorderedUpdate:
+                                    description: UnorderedUpdate contains strategies
+                                      for non-ordered update. If it is not nil, pods
+                                      will be updated with non-ordered sequence. Noted
+                                      that UnorderedUpdate can only be allowed to
+                                      work with Parallel podManagementPolicy
+                                    properties:
+                                      priorityStrategy:
+                                        description: Priorities are the rules for
+                                          calculating the priority of updating pods.
+                                          Each pod to be updated, will pass through
+                                          these terms and get a sum of weights.
+                                        properties:
+                                          orderPriority:
+                                            description: 'Order priority terms, pods
+                                              will be sorted by the value of orderedKey.
+                                              For example: ``` orderPriority: - orderedKey:
+                                              key1 - orderedKey: key2 ``` First, all
+                                              pods which have key1 in labels will
+                                              be sorted by the value of key1. Then,
+                                              the left pods which have no key1 but
+                                              have key2 in labels will be sorted by
+                                              the value of key2 and put behind those
+                                              pods have key1.'
+                                            items:
+                                              description: UpdatePriorityOrderTerm
+                                                defines order priority.
+                                              properties:
+                                                orderedKey:
+                                                  description: Calculate priority
+                                                    by value of this key. Values of
+                                                    this key, will be sorted by GetInt(val).
+                                                    GetInt method will find the last
+                                                    int in value, such as getting
+                                                    5 in value '5', getting 10 in
+                                                    value 'sts-10'.
+                                                  type: string
+                                              required:
+                                              - orderedKey
+                                              type: object
+                                            type: array
+                                          weightPriority:
+                                            description: Weight priority terms, pods
+                                              will be sorted by the sum of all terms
+                                              weight.
+                                            items:
+                                              description: UpdatePriorityWeightTerm
+                                                defines weight priority.
+                                              properties:
+                                                matchSelector:
+                                                  description: MatchSelector is used
+                                                    to select by pod's labels.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                weight:
+                                                  description: Weight associated with
+                                                    matching the corresponding matchExpressions,
+                                                    in the range 1-100.
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - matchSelector
+                                              - weight
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                type: object
+                              type:
+                                description: Type indicates the type of the StatefulSetUpdateStrategy.
+                                  Default is RollingUpdate.
+                                type: string
+                            type: object
+                          volumeClaimTemplates:
+                            description: 'volumeClaimTemplates is a list of claims
+                              that pods are allowed to reference. The StatefulSet
+                              controller is responsible for mapping network identities
+                              to claims in a way that maintains the identity of a
+                              pod. Every claim in this list must have at least one
+                              matching (by name) volumeMount in one container in the
+                              template. A claim in this list takes precedence over
+                              any volumes in the template, with the same name. TODO:
+                              Define the behavior if a claim already exists with the
+                              same name.'
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - selector
+                        - template
+                        type: object
+                    required:
+                    - spec
+                    type: object
+                  cloneSetTemplate:
+                    description: CloneSet template
+                    properties:
+                      metadata:
+                        x-kubernetes-preserve-unknown-fields: true
+                      spec:
+                        description: CloneSetSpec defines the desired state of CloneSet
+                        properties:
+                          lifecycle:
+                            description: Lifecycle defines the lifecycle hooks for
+                              Pods pre-available(pre-normal), pre-delete, in-place
+                              update.
+                            properties:
+                              inPlaceUpdate:
+                                description: InPlaceUpdate is the hook before Pod
+                                  to update and after Pod has been updated.
+                                properties:
+                                  finalizersHandler:
+                                    items:
+                                      type: string
+                                    type: array
+                                  labelsHandler:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: -
+                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
+                                      state. - Pod will be restored to ''Ready'' at
+                                      Updated state if it was set to ''NotReady''
+                                      at preparingUpdate state. Currently, MarkPodNotReady
+                                      only takes effect on InPlaceUpdate & PreDelete
+                                      hook. Default to false.'
+                                    type: boolean
+                                type: object
+                              preDelete:
+                                description: PreDelete is the hook before Pod to be
+                                  deleted.
+                                properties:
+                                  finalizersHandler:
+                                    items:
+                                      type: string
+                                    type: array
+                                  labelsHandler:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: -
+                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
+                                      state. - Pod will be restored to ''Ready'' at
+                                      Updated state if it was set to ''NotReady''
+                                      at preparingUpdate state. Currently, MarkPodNotReady
+                                      only takes effect on InPlaceUpdate & PreDelete
+                                      hook. Default to false.'
+                                    type: boolean
+                                type: object
+                              preNormal:
+                                description: PreNormal is the hook after Pod to be
+                                  created and ready to be Normal.
+                                properties:
+                                  finalizersHandler:
+                                    items:
+                                      type: string
+                                    type: array
+                                  labelsHandler:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  markPodNotReady:
+                                    description: 'MarkPodNotReady = true means: -
+                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
+                                      state. - Pod will be restored to ''Ready'' at
+                                      Updated state if it was set to ''NotReady''
+                                      at preparingUpdate state. Currently, MarkPodNotReady
+                                      only takes effect on InPlaceUpdate & PreDelete
+                                      hook. Default to false.'
+                                    type: boolean
+                                type: object
+                            type: object
+                          minReadySeconds:
+                            description: Minimum number of seconds for which a newly
+                              created pod should be ready without any of its container
+                              crashing, for it to be considered available. Defaults
+                              to 0 (pod will be considered available as soon as it
+                              is ready)
+                            format: int32
+                            type: integer
+                          replicas:
+                            description: Replicas is the desired number of replicas
+                              of the given Template. These are replicas in the sense
+                              that they are instantiations of the same Template. If
+                              unspecified, defaults to 1.
+                            format: int32
+                            type: integer
+                          revisionHistoryLimit:
+                            description: RevisionHistoryLimit is the maximum number
+                              of revisions that will be maintained in the CloneSet's
+                              revision history. The revision history consists of all
+                              revisions not represented by a currently applied CloneSetSpec
+                              version. The default value is 10.
+                            format: int32
+                            type: integer
+                          scaleStrategy:
+                            description: ScaleStrategy indicates the ScaleStrategy
+                              that will be employed to create and delete Pods in the
+                              CloneSet.
+                            properties:
+                              disablePVCReuse:
+                                description: Indicate if cloneSet will reuse already
+                                  existed pvc to rebuild a new pod
+                                type: boolean
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: The maximum number of pods that can be
+                                  unavailable for scaled pods. This field can control
+                                  the changes rate of replicas for CloneSet so as
+                                  to minimize the impact for users' service. The scale
+                                  will fail if the number of unavailable pods were
+                                  greater than this MaxUnavailable at scaling up.
+                                  MaxUnavailable works only when scaling up.
+                                x-kubernetes-int-or-string: true
+                              podsToDelete:
+                                description: PodsToDelete is the names of Pod should
+                                  be deleted. Note that this list will be truncated
+                                  for non-existing pod names.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          selector:
+                            description: 'Selector is a label query over pods that
+                              should match the replica count. It must match the pod
+                              template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          template:
+                            description: Template describes the pods that will be
+                              created.
+                            x-kubernetes-preserve-unknown-fields: true
+                          updateStrategy:
+                            description: UpdateStrategy indicates the UpdateStrategy
+                              that will be employed to update Pods in the CloneSet
+                              when a revision is made to Template.
+                            properties:
+                              inPlaceUpdateStrategy:
+                                description: InPlaceUpdateStrategy contains strategies
+                                  for in-place update.
+                                properties:
+                                  gracePeriodSeconds:
+                                    description: GracePeriodSeconds is the timespan
+                                      between set Pod status to not-ready and update
+                                      images in Pod spec when in-place update a Pod.
+                                    format: int32
+                                    type: integer
+                                type: object
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'The maximum number of pods that can
+                                  be scheduled above the desired replicas during update
+                                  or specified delete. Value can be an absolute number
+                                  (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  Absolute number is calculated from percentage by
+                                  rounding up. Defaults to 0.'
+                                x-kubernetes-int-or-string: true
+                              maxUnavailable:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'The maximum number of pods that can
+                                  be unavailable during update or scale. Value can
+                                  be an absolute number (ex: 5) or a percentage of
+                                  desired pods (ex: 10%). Absolute number is calculated
+                                  from percentage by rounding up by default. When
+                                  maxSurge > 0, absolute number is calculated from
+                                  percentage by rounding down. Defaults to 20%.'
+                                x-kubernetes-int-or-string: true
+                              partition:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'Partition is the desired number of pods
+                                  in old revisions. Value can be an absolute number
+                                  (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  Absolute number is calculated from percentage by
+                                  rounding up by default. It means when partition
+                                  is set during pods updating, (replicas - partition
+                                  value) number of pods will be updated. Default value
+                                  is 0.'
+                                x-kubernetes-int-or-string: true
+                              paused:
+                                description: Paused indicates that the CloneSet is
+                                  paused. Default value is false
+                                type: boolean
+                              priorityStrategy:
+                                description: Priorities are the rules for calculating
+                                  the priority of updating pods. Each pod to be updated,
+                                  will pass through these terms and get a sum of weights.
+                                properties:
+                                  orderPriority:
+                                    description: 'Order priority terms, pods will
+                                      be sorted by the value of orderedKey. For example:
+                                      ``` orderPriority: - orderedKey: key1 - orderedKey:
+                                      key2 ``` First, all pods which have key1 in
+                                      labels will be sorted by the value of key1.
+                                      Then, the left pods which have no key1 but have
+                                      key2 in labels will be sorted by the value of
+                                      key2 and put behind those pods have key1.'
+                                    items:
+                                      description: UpdatePriorityOrderTerm defines
+                                        order priority.
+                                      properties:
+                                        orderedKey:
+                                          description: Calculate priority by value
+                                            of this key. Values of this key, will
+                                            be sorted by GetInt(val). GetInt method
+                                            will find the last int in value, such
+                                            as getting 5 in value '5', getting 10
+                                            in value 'sts-10'.
+                                          type: string
+                                      required:
+                                      - orderedKey
+                                      type: object
+                                    type: array
+                                  weightPriority:
+                                    description: Weight priority terms, pods will
+                                      be sorted by the sum of all terms weight.
+                                    items:
+                                      description: UpdatePriorityWeightTerm defines
+                                        weight priority.
+                                      properties:
+                                        matchSelector:
+                                          description: MatchSelector is used to select
+                                            by pod's labels.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        weight:
+                                          description: Weight associated with matching
+                                            the corresponding matchExpressions, in
+                                            the range 1-100.
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - matchSelector
+                                      - weight
+                                      type: object
+                                    type: array
+                                type: object
+                              scatterStrategy:
+                                description: ScatterStrategy defines the scatter rules
+                                  to make pods been scattered when update. This will
+                                  avoid pods with the same key-value to be updated
+                                  in one batch. - Note that pods will be scattered
+                                  after priority sort. So, although priority strategy
+                                  and scatter strategy can be applied together, we
+                                  suggest to use either one of them. - If scatterStrategy
+                                  is used, we suggest to just use one term. Otherwise,
+                                  the update order can be hard to understand.
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                type: array
+                              type:
+                                description: Type indicates the type of the CloneSetUpdateStrategy.
+                                  Default is ReCreate.
+                                type: string
+                            type: object
+                          volumeClaimTemplates:
+                            description: VolumeClaimTemplates is a list of claims
+                              that pods are allowed to reference. Note that PVC will
+                              be deleted when its pod has been deleted.
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - selector
+                        - template
+                        type: object
+                    required:
+                    - spec
+                    type: object
+                  deploymentTemplate:
+                    description: Deployment template
+                    properties:
+                      metadata:
+                        x-kubernetes-preserve-unknown-fields: true
+                      spec:
+                        x-kubernetes-preserve-unknown-fields: true
+                    required:
+                    - spec
+                    type: object
+                  statefulSetTemplate:
+                    description: StatefulSet template
+                    properties:
+                      metadata:
+                        x-kubernetes-preserve-unknown-fields: true
+                      spec:
+                        x-kubernetes-preserve-unknown-fields: true
+                    required:
+                    - spec
+                    type: object
+                type: object
+              topology:
+                description: Topology describes the pods distribution detail between
+                  each of subsets.
+                properties:
+                  subsets:
+                    description: Contains the details of each subset. Each element
+                      in this array represents one subset which will be provisioned
+                      and managed by UnitedDeployment.
+                    items:
+                      description: Subset defines the detail of a subset.
+                      properties:
+                        name:
+                          description: Indicates subset name as a DNS_LABEL, which
+                            will be used to generate subset workload name prefix in
+                            the format '<deployment-name>-<subset-name>-'. Name should
+                            be unique between all of the subsets under one UnitedDeployment.
+                          type: string
+                        nodeSelectorTerm:
+                          description: Indicates the node selector to form the subset.
+                            Depending on the node selector, pods provisioned could
+                            be distributed across multiple groups of nodes. A subset's
+                            nodeSelectorTerm is not allowed to be updated.
+                          properties:
+                            matchExpressions:
+                              description: A list of node selector requirements by
+                                node's labels.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: Represents a key's relationship to
+                                      a set of values. Valid operators are In, NotIn,
+                                      Exists, DoesNotExist. Gt, and Lt.
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchFields:
+                              description: A list of node selector requirements by
+                                node's fields.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: Represents a key's relationship to
+                                      a set of values. Valid operators are In, NotIn,
+                                      Exists, DoesNotExist. Gt, and Lt.
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                          type: object
+                        replicas:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: Indicates the number of the pod to be created
+                            under this subset. Replicas could also be percentage like
+                            '10%', which means 10% of UnitedDeployment replicas of
+                            pods will be distributed under this subset. If nil, the
+                            number of replicas in this subset is determined by controller.
+                            Controller will try to keep all the subsets with nil replicas
+                            have average pods.
+                          x-kubernetes-int-or-string: true
+                        tolerations:
+                          description: Indicates the tolerations the pods under this
+                            subset have. A subset's tolerations is not allowed to
+                            be updated.
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect>
+                              using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to
+                                  match. Empty means match all taint effects. When
+                                  specified, allowed values are NoSchedule, PreferNoSchedule
+                                  and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If
+                                  the key is empty, operator must be Exists; this
+                                  combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints
+                                  of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect
+                                  NoExecute, otherwise this field is ignored) tolerates
+                                  the taint. By default, it is not set, which means
+                                  tolerate the taint forever (do not evict). Zero
+                                  and negative values will be treated as 0 (evict
+                                  immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value
+                                  should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              updateStrategy:
+                description: UpdateStrategy indicates the strategy the UnitedDeployment
+                  use to preform the update, when template is changed.
+                properties:
+                  manualUpdate:
+                    description: Includes all of the parameters a Manual update strategy
+                      needs.
+                    properties:
+                      partitions:
+                        additionalProperties:
+                          format: int32
+                          type: integer
+                        description: Indicates number of subset partition.
+                        type: object
+                    type: object
+                  type:
+                    description: Type of UnitedDeployment update strategy. Default
+                      is Manual.
+                    type: string
+                type: object
+            required:
+            - selector
+            type: object
+          status:
+            description: UnitedDeploymentStatus defines the observed state of UnitedDeployment.
+            properties:
+              collisionCount:
+                description: Count of hash collisions for the UnitedDeployment. The
+                  UnitedDeployment controller uses this field as a collision avoidance
+                  mechanism when it needs to create the name for the newest ControllerRevision.
+                format: int32
+                type: integer
+              conditions:
+                description: Represents the latest available observations of a UnitedDeployment's
+                  current state.
+                items:
+                  description: UnitedDeploymentCondition describes current state of
+                    a UnitedDeployment.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of in place set condition.
+                      type: string
+                  type: object
+                type: array
+              currentRevision:
+                description: CurrentRevision, if not empty, indicates the current
+                  version of the UnitedDeployment.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this UnitedDeployment. It corresponds to the UnitedDeployment's
+                  generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: The number of ready replicas.
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              subsetReplicas:
+                additionalProperties:
+                  format: int32
+                  type: integer
+                description: Records the topology detail information of the replicas
+                  of each subset.
+                type: object
+              updateStatus:
+                description: Records the information of update progress.
+                properties:
+                  currentPartitions:
+                    additionalProperties:
+                      format: int32
+                      type: integer
+                    description: Records the current partition.
+                    type: object
+                  updatedRevision:
+                    description: Records the latest revision.
+                    type: string
+                type: object
+              updatedReadyReplicas:
+                description: The number of ready current revision replicas for this
+                  UnitedDeployment.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: The number of pods in current version.
+                format: int32
+                type: integer
+            required:
+            - currentRevision
+            - replicas
+            - updatedReplicas
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/kruise/templates/apps.kruise.io_workloadspreads.yaml
+++ b/charts/kruise/templates/apps.kruise.io_workloadspreads.yaml
@@ -1,0 +1,323 @@
+{{- if .Values.crds.managed }}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: workloadspreads.apps.kruise.io
+spec:
+  group: apps.kruise.io
+  names:
+    kind: WorkloadSpread
+    listKind: WorkloadSpreadList
+    plural: workloadspreads
+    shortNames:
+    - ws
+    singular: workloadspread
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.targetRef.name
+      name: WorkloadName
+      type: string
+    - jsonPath: .spec.targetRef.kind
+      name: WorkloadKind
+      type: string
+    - description: Whether use the adaptive reschedule strategy
+      jsonPath: .spec.scheduleStrategy.type[?(@ == "Adaptive")]
+      name: Adaptive
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: WorkloadSpread is the Schema for the WorkloadSpread API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WorkloadSpreadSpec defines the desired state of WorkloadSpread.
+            properties:
+              scheduleStrategy:
+                description: ScheduleStrategy indicates the strategy the WorkloadSpread used to preform the schedule between each of subsets.
+                properties:
+                  adaptive:
+                    description: Adaptive is used to communicate parameters when Type is AdaptiveWorkloadSpreadScheduleStrategyType.
+                    properties:
+                      disableSimulationSchedule:
+                        description: DisableSimulationSchedule indicates whether to disable the feature of simulation schedule. Default is false. Webhook can take a simple general predicates to check whether Pod can be scheduled into this subset, but it just considers the Node resource and cannot replace scheduler to do richer predicates practically.
+                        type: boolean
+                      rescheduleCriticalSeconds:
+                        description: RescheduleCriticalSeconds indicates how long controller will reschedule a schedule failed Pod to the subset that has redundant capacity after the subset where the Pod lives. If a Pod was scheduled failed and still in a unschedulabe status over RescheduleCriticalSeconds duration, the controller will reschedule it to a suitable subset.
+                        format: int32
+                        type: integer
+                    type: object
+                  type:
+                    description: Type indicates the type of the WorkloadSpreadScheduleStrategy. Default is Fixed
+                    enum:
+                    - Adaptive
+                    - Fixed
+                    - ""
+                    type: string
+                type: object
+              subsets:
+                description: Subsets describes the pods distribution details between each of subsets.
+                items:
+                  description: WorkloadSpreadSubset defines the details of a subset.
+                  properties:
+                    maxReplicas:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: MaxReplicas indicates the desired max replicas of this subset.
+                      x-kubernetes-int-or-string: true
+                    name:
+                      description: Name should be unique between all of the subsets under one WorkloadSpread.
+                      type: string
+                    patch:
+                      description: Patch indicates patching podTemplate to the Pod.
+                      x-kubernetes-preserve-unknown-fields: true
+                    preferredNodeSelectorTerms:
+                      description: Indicates the node preferred selector to form the subset.
+                      items:
+                        description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                        properties:
+                          preference:
+                            description: A node selector term, associated with the corresponding weight.
+                            properties:
+                              matchExpressions:
+                                description: A list of node selector requirements by node's labels.
+                                items:
+                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchFields:
+                                description: A list of node selector requirements by node's fields.
+                                items:
+                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: The label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      type: string
+                                    values:
+                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          weight:
+                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - preference
+                        - weight
+                        type: object
+                      type: array
+                    requiredNodeSelectorTerm:
+                      description: Indicates the node required selector to form the subset.
+                      properties:
+                        matchExpressions:
+                          description: A list of node selector requirements by node's labels.
+                          items:
+                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                              values:
+                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchFields:
+                          description: A list of node selector requirements by node's fields.
+                          items:
+                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                type: string
+                              values:
+                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                      type: object
+                    tolerations:
+                      description: Indicates the tolerations the pods under this subset have.
+                      items:
+                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  type: object
+                type: array
+              targetRef:
+                description: TargetReference is the target workload that WorkloadSpread want to control.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+            required:
+            - subsets
+            - targetRef
+            type: object
+          status:
+            description: WorkloadSpreadStatus defines the observed state of WorkloadSpread.
+            properties:
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed for this WorkloadSpread. It corresponds to the WorkloadSpread's generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              subsetStatuses:
+                description: Contains the status of each subset. Each element in this array represents one subset
+                items:
+                  description: WorkloadSpreadSubsetStatus defines the observed state of subset
+                  properties:
+                    conditions:
+                      description: Conditions is an array of current observed subset conditions.
+                      items:
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from one status to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details about the transition.
+                            type: string
+                          reason:
+                            description: The reason for the condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type of in place set condition.
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    creatingPods:
+                      additionalProperties:
+                        format: date-time
+                        type: string
+                      description: CreatingPods contains information about pods whose creation was processed by the webhook handler but not yet been observed by the WorkloadSpread controller. A pod will be in this map from the time when the webhook handler processed the creation request to the time when the pod is seen by controller. The key in the map is the name of the pod and the value is the time when the webhook handler process the creation request. If the real creation didn't happen and a pod is still in this map, it will be removed from the list automatically by WorkloadSpread controller after some time. If everything goes smooth this map should be empty for the most of the time. Large number of entries in the map may indicate problems with pod creations.
+                      type: object
+                    deletingPods:
+                      additionalProperties:
+                        format: date-time
+                        type: string
+                      description: DeletingPods is similar with CreatingPods and it contains information about pod deletion.
+                      type: object
+                    missingReplicas:
+                      description: MissingReplicas is the number of active replicas belong to this subset not be found. MissingReplicas > 0 indicates the subset is still missing MissingReplicas pods to create MissingReplicas = 0 indicates the subset already has enough pods, there is no need to create MissingReplicas = -1 indicates the subset's MaxReplicas not set, then there is no limit for pods number
+                      format: int32
+                      type: integer
+                    name:
+                      description: Name should be unique between all of the subsets under one WorkloadSpread.
+                      type: string
+                    replicas:
+                      description: Replicas is the most recently observed number of active replicas for subset.
+                      format: int32
+                      type: integer
+                  required:
+                  - missingReplicas
+                  - name
+                  - replicas
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/kruise/templates/manager.yaml
+++ b/charts/kruise/templates/manager.yaml
@@ -1,0 +1,237 @@
+{{- if .Values.installation.createNamespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: {{ .Values.installation.namespace }}
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kruise-webhook-service
+  namespace: {{ .Values.installation.namespace }}
+spec:
+{{ ( include "webhookServiceSpec" . ) | indent 2 }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kruise-webhook-certs
+  namespace: {{ .Values.installation.namespace }}
+{{ ( include "webhookSecretData" . ) }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: kruise-controller-manager
+  namespace: {{ .Values.installation.namespace }}
+spec:
+  replicas: {{ .Values.manager.replicas }}
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  minReadySeconds: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+{{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+      containers:
+        - args:
+            - --enable-leader-election
+            - --metrics-addr=:{{ .Values.manager.metrics.port }}
+            - --health-probe-addr=:{{ .Values.manager.healthProbe.port }}
+            - --logtostderr=true
+            - --leader-election-namespace={{ .Values.installation.namespace }}
+            - --v={{ .Values.manager.log.level }}
+            - --feature-gates={{ .Values.featureGates }}
+            - --sync-period={{ .Values.manager.resyncPeriod }}
+          command:
+            - /manager
+          image: {{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}
+          imagePullPolicy: Always
+          name: manager
+          env:
+{{- if .Values.enableKubeCacheMutationDetector }}
+            - name: KUBE_CACHE_MUTATION_DETECTOR
+              value: "true"
+{{- end }}
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: WEBHOOK_PORT
+              value: "{{ .Values.manager.webhook.port }}"
+            - name: WEBHOOK_CONFIGURATION_FAILURE_POLICY_PODS
+              value: {{ .Values.webhookConfiguration.failurePolicy.pods }}
+          ports:
+            - containerPort: {{ .Values.manager.webhook.port }}
+              name: webhook-server
+              protocol: TCP
+            - containerPort: {{ .Values.manager.metrics.port }}
+              name: metrics
+              protocol: TCP
+            - containerPort: {{ .Values.manager.healthProbe.port }}
+              name: health
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: readyz
+              port: {{ .Values.manager.healthProbe.port }}
+          resources:
+            {{- toYaml .Values.manager.resources | nindent 12 }}
+      hostNetwork: {{ .Values.manager.hostNetwork }}
+      terminationGracePeriodSeconds: 10
+      serviceAccountName:  {{ .Values.manager.serviceAccountName | default "kruise-manager" | quote }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: control-plane
+                  operator: In
+                  values:
+                  - controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+{{- with .Values.manager.nodeAffinity }}
+        nodeAffinity:
+{{ toYaml . | indent 10 }}
+{{- end }}
+
+{{- if .Values.manager.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.manager.nodeSelector | indent 8 }}
+{{- end }}
+
+{{- if .Values.manager.tolerations }}
+      tolerations:
+{{ toYaml .Values.manager.tolerations | indent 8 }}
+{{- end }}
+---
+{{- if not .Values.manager.serviceAccountName }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kruise-manager
+{{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+{{- end }}
+  namespace: {{ .Values.installation.namespace }}
+{{ ( include "serviceAccountManager" . ) }}
+{{- end }}
+---
+{{- if not .Values.daemon.serviceAccountName }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kruise-daemon
+{{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+{{- end }}
+  namespace: {{ .Values.installation.namespace }}
+{{ ( include "serviceAccountDaemon" . ) }}
+{{- end }}
+---
+{{ if contains "KruiseDaemon=false" .Values.featureGates }}{{ else }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kruise-daemon
+  namespace: {{ .Values.installation.namespace }}
+  labels:
+    control-plane: daemon
+spec:
+  selector:
+    matchLabels:
+      control-plane: daemon
+  minReadySeconds: 3
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  template:
+    metadata:
+      labels:
+        control-plane: daemon
+    spec:
+{{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+{{- if .Values.daemon.affinity }}
+      affinity:
+{{ toYaml .Values.daemon.affinity | indent 8 }}
+{{- end }}
+{{- if .Values.daemon.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.daemon.nodeSelector | indent 8 }}
+{{- end }}
+      containers:
+      - command:
+        - /kruise-daemon
+        args:
+        - --logtostderr=true
+        - --v=4
+        - --addr=:{{ .Values.daemon.port }}
+        - --feature-gates={{ .Values.featureGates }}
+        - --socket-file={{ .Values.daemon.socketFile }}
+        image: {{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}
+        imagePullPolicy: Always
+        name: daemon
+        env:
+{{- if .Values.enableKubeCacheMutationDetector }}
+        - name: KUBE_CACHE_MUTATION_DETECTOR
+          value: "true"
+{{- end }}
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        {{- if .Values.daemon.extraEnvs }}
+        {{- toYaml .Values.daemon.extraEnvs | nindent 8 }}
+        {{- end }}
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: {{ .Values.daemon.port }}
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          {{- toYaml .Values.daemon.resources | nindent 12 }}
+        volumeMounts:
+        - mountPath: /hostvarrun
+          name: runtime-socket
+          readOnly: true
+      tolerations:
+      - operator: Exists
+      hostNetwork: true
+      terminationGracePeriodSeconds: 10
+      serviceAccountName: {{ .Values.daemon.serviceAccountName | default "kruise-daemon" | quote }}
+      volumes:
+      - hostPath:
+          path: {{ .Values.daemon.socketLocation }}
+          type: ""
+        name: runtime-socket
+{{- end }}

--- a/charts/kruise/templates/policy.kruise.io_podunavailablebudgets.yaml
+++ b/charts/kruise/templates/policy.kruise.io_podunavailablebudgets.yaml
@@ -1,0 +1,163 @@
+{{- if .Values.crds.managed }}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: podunavailablebudgets.policy.kruise.io
+spec:
+  group: policy.kruise.io
+  names:
+    kind: PodUnavailableBudget
+    listKind: PodUnavailableBudgetList
+    plural: podunavailablebudgets
+    shortNames:
+    - pub
+    singular: podunavailablebudget
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: UnavailableAllowed number of pod unavailable that are currently allowed
+      jsonPath: .status.unavailableAllowed
+      name: Allowed
+      type: integer
+    - description: CurrentAvailable current number of available pods
+      jsonPath: .status.currentAvailable
+      name: Current
+      type: integer
+    - description: DesiredAvailable minimum desired number of available pods
+      jsonPath: .status.desiredAvailable
+      name: Desired
+      type: integer
+    - description: TotalReplicas total number of pods counted by this budget
+      jsonPath: .status.totalReplicas
+      name: Total
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PodUnavailableBudget is the Schema for the podunavailablebudgets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PodUnavailableBudgetSpec defines the desired state of PodUnavailableBudget
+            properties:
+              maxUnavailable:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Delete pod, evict pod or update pod specification is allowed if at most "maxUnavailable" pods selected by "selector" or "targetRef"  are unavailable after the above operation for pod. MaxUnavailable and MinAvailable are mutually exclusive, MaxUnavailable is priority to take effect
+                x-kubernetes-int-or-string: true
+              minAvailable:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Delete pod, evict pod or update pod specification is allowed if at least "minAvailable" pods selected by "selector" or "targetRef" will still be available after the above operation for pod.
+                x-kubernetes-int-or-string: true
+              selector:
+                description: Selector label query over pods managed by the budget
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              targetRef:
+                description: TargetReference contains enough information to let you identify an workload for PodUnavailableBudget Selector and TargetReference are mutually exclusive, TargetReference is priority to take effect
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: Kind of the referent.
+                    type: string
+                  name:
+                    description: Name of the referent.
+                    type: string
+                type: object
+            type: object
+          status:
+            description: PodUnavailableBudgetStatus defines the observed state of PodUnavailableBudget
+            properties:
+              currentAvailable:
+                description: CurrentAvailable current number of available pods
+                format: int32
+                type: integer
+              desiredAvailable:
+                description: DesiredAvailable minimum desired number of available pods
+                format: int32
+                type: integer
+              disruptedPods:
+                additionalProperties:
+                  format: date-time
+                  type: string
+                description: DisruptedPods contains information about pods whose eviction or deletion was processed by the API handler but has not yet been observed by the PodUnavailableBudget.
+                type: object
+              observedGeneration:
+                description: Most recent generation observed when updating this PUB status. UnavailableAllowed and other status information is valid only if observedGeneration equals to PUB's object generation.
+                format: int64
+                type: integer
+              totalReplicas:
+                description: TotalReplicas total number of pods counted by this unavailable budget
+                format: int32
+                type: integer
+              unavailableAllowed:
+                description: UnavailableAllowed number of pod unavailable that are currently allowed
+                format: int32
+                type: integer
+              unavailablePods:
+                additionalProperties:
+                  format: date-time
+                  type: string
+                description: UnavailablePods contains information about pods whose specification changed(inplace-update pod), once pod is available(consistent and ready) again, it will be removed from the list.
+                type: object
+            required:
+            - currentAvailable
+            - desiredAvailable
+            - totalReplicas
+            - unavailableAllowed
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+{{- end }}

--- a/charts/kruise/templates/rbac_role.yaml
+++ b/charts/kruise/templates/rbac_role.yaml
@@ -1,0 +1,770 @@
+{{- if not .Values.manager.serviceAccountName }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kruise-leader-election-role
+  namespace: {{ .Values.installation.namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+{{- end }}
+---
+{{- if not .Values.manager.serviceAccountName }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kruise-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  {{ toYaml .Values.installation.roleListGroups }}
+  resources:
+  - '*'
+  verbs:
+  - list
+- apiGroups:
+  - '*'
+  resources:
+  - '*/scale'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets/status
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - advancedcronjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - advancedcronjobs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - broadcastjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - broadcastjobs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - clonesets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - clonesets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - containerrecreaterequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - containerrecreaterequests/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - daemonsets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - ephemeraljobs
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - ephemeraljobs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - imagepulljobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - imagepulljobs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - nodeimages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - nodeimages/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - nodepodprobes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - nodepodprobes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - persistentpodstates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - persistentpodstates/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - podprobemarkers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - podprobemarkers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - resourcedistributions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - resourcedistributions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - sidecarsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - sidecarsets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - statefulsets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - uniteddeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - uniteddeployments/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - workloadspreads
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - workloadspreads/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/ephemeralcontainers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.kruise.io
+  resources:
+  - podunavailablebudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.kruise.io
+  resources:
+  - podunavailablebudgets/status
+  verbs:
+  - get
+  - patch
+  - update
+{{- end }}
+---
+{{- if not .Values.daemon.serviceAccountName }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kruise-daemon-role
+rules:
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - nodeimages
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - nodeimages/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - containerrecreaterequests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - containerrecreaterequests/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - nodepodprobes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - nodepodprobes/status
+  verbs:
+  - get
+  - patch
+  - update
+{{- end }}
+---
+{{- if not .Values.manager.serviceAccountName }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kruise-leader-election-rolebinding
+  namespace: {{ .Values.installation.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kruise-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: kruise-manager
+    namespace: {{ .Values.installation.namespace }}
+{{- end }}
+---
+{{- if not .Values.manager.serviceAccountName }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kruise-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kruise-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: kruise-manager
+    namespace: {{ .Values.installation.namespace }}
+{{- end }}
+---
+{{- if not .Values.daemon.serviceAccountName }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kruise-daemon-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kruise-daemon-role
+subjects:
+  - kind: ServiceAccount
+    name: kruise-daemon
+    namespace: {{ .Values.installation.namespace }}
+{{- end }}

--- a/charts/kruise/templates/webhookconfiguration.yaml
+++ b/charts/kruise/templates/webhookconfiguration.yaml
@@ -1,0 +1,793 @@
+{{- if .Values.webhookConfiguration.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kruise-mutating-webhook-configuration
+  annotations:
+    template: ""
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /mutate-apps-kruise-io-v1alpha1-advancedcronjob
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: madvancedcronjob.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - advancedcronjobs
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /mutate-apps-kruise-io-v1alpha1-broadcastjob
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: mbroadcastjob.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - broadcastjobs
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /mutate-apps-kruise-io-v1alpha1-cloneset
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: mcloneset.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clonesets
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /mutate-apps-kruise-io-v1alpha1-containerrecreaterequest
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: mcontainerrecreaterequest.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - containerrecreaterequests
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /mutate-apps-kruise-io-v1alpha1-daemonset
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: mdaemonset.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - daemonsets
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /mutate-apps-kruise-io-v1alpha1-imagepulljob
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: mimagepulljob.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - imagepulljobs
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /mutate-apps-kruise-io-v1alpha1-nodeimage
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: mnodeimage.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - nodeimages
+{{ if contains "PodWebhook=false" .Values.featureGates }}{{ else }}
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /mutate-pod
+  failurePolicy: {{ .Values.webhookConfiguration.failurePolicy.pods }}
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: mpod.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: control-plane
+      operator: DoesNotExist
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+{{- end }}
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /mutate-apps-kruise-io-v1alpha1-sidecarset
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: msidecarset.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - sidecarsets
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /mutate-apps-kruise-io-statefulset
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: mstatefulset.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - statefulsets
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /mutate-apps-kruise-io-v1alpha1-uniteddeployment
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: muniteddeployment.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - uniteddeployments
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kruise-validating-webhook-configuration
+  annotations:
+    template: ""
+webhooks:
+{{- if contains "PodWebhook=false" .Values.featureGates }}{{ else }}
+{{- if or (contains "AllAlpha=true" .Values.featureGates) (contains "PodUnavailableBudgetUpdateGate=true" .Values.featureGates) (contains "PodUnavailableBudgetDeleteGate=true" .Values.featureGates) (contains "WorkloadSpread=true" .Values.featureGates) }}
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-pod
+  failurePolicy: {{ .Values.webhookConfiguration.failurePolicy.pods }}
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vpod.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: control-plane
+      operator: DoesNotExist
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+{{- if or (contains "AllAlpha=true" .Values.featureGates) (contains "PodUnavailableBudgetUpdateGate=true" .Values.featureGates) }}
+    - UPDATE
+{{- else }}{{- end }}
+{{- if or (contains "AllAlpha=true" .Values.featureGates) (contains "PodUnavailableBudgetDeleteGate=true" .Values.featureGates) (contains "WorkloadSpread=true" .Values.featureGates) }}
+    - DELETE
+{{- else }}{{- end }}
+    resources:
+    - pods
+{{- else }}{{- end }}
+{{- if or (contains "AllAlpha=true" .Values.featureGates) (contains "PodUnavailableBudgetDeleteGate=true" .Values.featureGates) (contains "WorkloadSpread=true" .Values.featureGates) }}
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-pod
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  name: vpodeviction.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: control-plane
+      operator: DoesNotExist
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods/eviction
+{{- else }}{{- end }}
+{{- end }}
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-apps-kruise-io-v1alpha1-resourcedistribution
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vresourcedistribution.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - resourcedistributions
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-apps-kruise-io-v1alpha1-advancedcronjob
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vadvancedcronjob.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - advancedcronjobs
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-apps-kruise-io-v1alpha1-broadcastjob
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vbroadcastjob.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - broadcastjobs
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-apps-deployment
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vbuiltindeployment.kb.io
+  objectSelector:
+    matchExpressions:
+    - key: policy.kruise.io/delete-protection
+      operator: Exists
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - DELETE
+    resources:
+    - deployments
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-apps-replicaset
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vbuiltinreplicaset.kb.io
+  objectSelector:
+    matchExpressions:
+    - key: policy.kruise.io/delete-protection
+      operator: Exists
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - DELETE
+    resources:
+    - replicasets
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-apps-statefulset
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vbuiltinstatefulset.kb.io
+  objectSelector:
+    matchExpressions:
+    - key: policy.kruise.io/delete-protection
+      operator: Exists
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - DELETE
+    resources:
+    - statefulsets
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-apps-kruise-io-v1alpha1-cloneset
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vcloneset.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - clonesets
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-customresourcedefinition
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vcustomresourcedefinition.kb.io
+  objectSelector:
+    matchExpressions:
+    - key: policy.kruise.io/delete-protection
+      operator: Exists
+  rules:
+  - apiGroups:
+    - apiextensions.k8s.io
+    apiVersions:
+    - v1
+    - v1beta1
+    operations:
+    - DELETE
+    resources:
+    - customresourcedefinitions
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-apps-kruise-io-v1alpha1-daemonset
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vdaemonset.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - daemonsets
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-apps-kruise-io-v1alpha1-imagepulljob
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vimagepulljob.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - imagepulljobs
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-namespace
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vnamespace.kb.io
+  objectSelector:
+    matchExpressions:
+    - key: policy.kruise.io/delete-protection
+      operator: Exists
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - DELETE
+    resources:
+    - namespaces
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-apps-kruise-io-v1alpha1-nodeimage
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vnodeimage.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - nodeimages
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-apps-kruise-io-persistentpodstate
+  failurePolicy: Fail
+  name: vpersistentpodstate.kb.io
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - persistentpodstates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-apps-kruise-io-podprobemarker
+  failurePolicy: Fail
+  name: vpodprobemarker.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - podprobemarkers
+  sideEffects: None
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-policy-kruise-io-podunavailablebudget
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vpodunavailablebudget.kb.io
+  rules:
+  - apiGroups:
+    - policy.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - podunavailablebudgets
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-apps-kruise-io-v1alpha1-sidecarset
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vsidecarset.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - sidecarsets
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-apps-kruise-io-statefulset
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vstatefulset.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - statefulsets
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-apps-kruise-io-v1alpha1-uniteddeployment
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vuniteddeployment.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - uniteddeployments
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kruise-webhook-service
+      namespace: {{ .Values.installation.namespace }}
+      path: /validate-apps-kruise-io-v1alpha1-workloadspread
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+  name: vworkloadspread.kb.io
+  rules:
+  - apiGroups:
+    - apps.kruise.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - workloadspreads
+{{- end}}

--- a/charts/kruise/values.yaml
+++ b/charts/kruise/values.yaml
@@ -1,0 +1,97 @@
+# Default values for kruise.
+
+crds:
+  managed: true
+
+# values for kruise installation
+installation:
+  namespace: kruise-system
+  createNamespace: true
+  roleListGroups:
+    - '*'
+
+featureGates: ""
+
+# KUBE_CACHE_MUTATION_DETECTOR
+enableKubeCacheMutationDetector: false
+
+manager:
+  # settings for log print
+  log:
+    # log level for kruise-manager
+    level: "4"
+
+  replicas: 2
+  image:
+    repository: openkruise/kruise-manager
+    tag: v1.4.0
+  webhook:
+    port: 9876
+  metrics:
+    port: 8080
+  healthProbe:
+    port: 8000
+  pprofAddr: "localhost:8090"
+
+  resyncPeriod: "0"
+
+  # resources of kruise-manager container
+  resources:
+    limits:
+      cpu: 200m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
+  hostNetwork: false
+
+  nodeAffinity: {}
+  nodeSelector: {}
+  tolerations: []
+
+  # set serviceAccountName to set permissions externally
+  serviceAccountName: ""
+
+webhookConfiguration:
+  enabled: true
+  failurePolicy:
+    pods: Ignore
+  timeoutSeconds: 30
+
+daemon:
+  log:
+    # log level for kruise-daemon
+    level: "4"
+
+  port: 10221
+  pprofAddr: "localhost:10222"
+
+  socketLocation: "/var/run"
+  socketFile: ""
+
+  nodeSelector: {}
+  resources:
+    limits:
+      cpu: 50m
+      memory: 128Mi
+    requests:
+      cpu: "0"
+      memory: "0"
+  # set serviceAccountName to set permissions externally
+  serviceAccountName: ""
+
+  # Extra environment variables that will be pass onto pods.
+  # For example, when the daemon is used behind a http proxy, you can set the proxy environment variables here.
+  # This will be appended to the current 'env:' key. You can use any of the kubernetes env
+  # syntax here.
+  extraEnvs: []
+  # - name: HTTP_PROXY
+  #   value: http://my-proxy:8080/
+  # - name: HTTPS_PROXY
+  #   value: http://my-proxy:8080/
+  # - name: NO_PROXY
+  #   value: localhost,0.0.0.0,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
+
+serviceAccount:
+  annotations: {}

--- a/charts/matrixone-operator/values.yaml
+++ b/charts/matrixone-operator/values.yaml
@@ -67,6 +67,7 @@ tolerations: []
 affinity: {}
 
 kruise:
+  enabled: true
   featureGates: "StatefulSetAutoDeletePVC=true,PodUnavailableBudgetDeleteGate=true,PodUnavailableBudgetUpdateGate=true"
   manager:
     image:


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

- part of https://github.com/matrixorigin/MO-Cloud/issues/3911
- part of https://github.com/matrixorigin/MO-Cloud/issues/3859

Vendor kruise chart and make some change:

1. support disable kruise in mo-operator by settting `.kruise.enabled=false` in mo-operator values;
2. support disable webhookconfiguration in kruise by setting `.webhookConfiguration.enabled=false` in kruise values;
3. support use external provisioned SA for kruise-manager by setting `manager.serviceAccountName="foobar"` in kruise values, the ClusterRole and ClusterRoleBinding of kruise-manager will not be created in this case;
4. support use external provisioned SA for kruise-daemon by setting `daemon.serviceAccountName="foobar"` in kruise values, the ClusterRole and ClusterRoleBinding of kruise-daemon will not be created in this case;
5. the secretName kruise used can be override by setting env `SECRET_NAME`

**What this PR does / why we need it:**

Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
