### PR TITLE
feat: support define operator args in helm chart values

### DIFF
--- a/charts/matrixone-operator/Chart.yaml
+++ b/charts/matrixone-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: matrixone-operator
 description: Matrixone Kubernetes Operator
 type: application
-version: 1.2.0-alpha.7
+version: 1.2.0-alpha.8
 appVersion: 0.1.0
 kubeVersion: ">=1.19.0-0"
 icon: https://raw.githubusercontent.com/matrixorigin/artwork/main/docs/overview/logo.png

--- a/charts/matrixone-operator/templates/deployment.yaml
+++ b/charts/matrixone-operator/templates/deployment.yaml
@@ -48,8 +48,10 @@ spec:
           image: {{ include "matrixone-operator.image" . }}
           command:
           - /manager
+          {{- with .Values.args }}
           args:
-          - -leader-elect
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- range $key, $value :=  .Values.env }}

--- a/charts/matrixone-operator/values.yaml
+++ b/charts/matrixone-operator/values.yaml
@@ -78,6 +78,10 @@ kruise:
     image:
       repository: openkruise/kruise-manager
 
+# operator arguments
+args:
+  - -leader-elect
+
 defaultArgs:
   - name: logService
     values:


### PR DESCRIPTION
### **User description**
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes # https://github.com/matrixorigin/MO-Cloud/issues/3911

**What this PR does / why we need it:**

user can define matrixone operator arguments in helm chart values.yaml

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available


___

### **PR Type**
enhancement


___

### **Description**
- Added support for defining operator arguments in the Helm chart `values.yaml`, allowing users to customize operator behavior.
- Updated the Helm chart version to 1.2.0-alpha.8.
- Introduced a new `args` section in `values.yaml` to specify default operator arguments, including `-leader-elect`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chart.yaml</strong><dd><code>Update Helm chart version to 1.2.0-alpha.8</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/matrixone-operator/Chart.yaml

- Updated the chart version from 1.2.0-alpha.7 to 1.2.0-alpha.8.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone-operator/pull/542/files#diff-3015fff6a7a4f3cfcbbf215597d15b90b7b1bcdac8611b1a9b2544984bacab1c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Define operator arguments in Helm values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/matrixone-operator/values.yaml

<li>Introduced a new <code>args</code> section for operator arguments.<br> <li> Added a default argument <code>-leader-elect</code> under <code>args</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone-operator/pull/542/files#diff-9452f700bfd40b82a6de7ad74609a14422174436c8ac58a1f1155e9753fa5ec3">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deployment.yaml</strong><dd><code>Add support for operator arguments in deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/matrixone-operator/templates/deployment.yaml

<li>Added support for defining operator arguments in Helm chart values.<br> <li> Wrapped <code>args</code> with conditional logic to include values if specified.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone-operator/pull/542/files#diff-d4d243b853cda142ba0f4113b21c2119b71a1988e290dd5ef58eb54a71b2e7f2">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

