### PR TITLE
fix: validate semver setting in webhook

### DIFF
--- a/api/core/v1alpha1/semver_test.go
+++ b/api/core/v1alpha1/semver_test.go
@@ -15,8 +15,9 @@
 package v1alpha1
 
 import (
-	"github.com/blang/semver/v4"
 	"testing"
+
+	"github.com/blang/semver/v4"
 
 	. "github.com/onsi/gomega"
 )
@@ -33,6 +34,7 @@ func TestHasMOFeature(t *testing.T) {
 	g.Expect(HasMOFeature(mustParse("v1.1.1"), MOFeaturePipelineInfo)).To(BeFalse())
 	g.Expect(HasMOFeature(mustParse("v1.1.2-rc1"), MOFeaturePipelineInfo)).To(BeTrue())
 	g.Expect(HasMOFeature(mustParse("v1.2.0-alpha.1"), MOFeatureLockMigration)).To(BeTrue())
+	g.Expect(HasMOFeature(mustParse("v1.2.2-woraround-something-else"), MOFeatureLockMigration)).To(BeTrue())
 	featureVersions["dummy"] = []semver.Version{mustParse("1.2.3")}
 	g.Expect(HasMOFeature(mustParse("v1.2.3"), "dummy")).To(BeTrue())
 	g.Expect(HasMOFeature(mustParse("v1.3.0"), "dummy")).To(BeFalse())

--- a/pkg/controllers/common/podset.go
+++ b/pkg/controllers/common/podset.go
@@ -16,6 +16,8 @@ package common
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/blang/semver/v4"
 	"github.com/go-errors/errors"
 	recon "github.com/matrixorigin/controller-runtime/pkg/reconciler"
@@ -25,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strconv"
 )
 
 type SyncMOPodTask struct {
@@ -42,20 +43,19 @@ type SyncMOPodTask struct {
 
 // SyncPodMeta sync PodSet to pod object meta
 func SyncPodMeta(meta *metav1.ObjectMeta, p *v1alpha1.PodSet) {
-	v, ok := p.GetSemVer()
-	if !ok {
-		return
-	}
 	if meta.Annotations == nil {
 		meta.Annotations = make(map[string]string)
 	}
-	meta.Annotations[SemanticVersionAnno] = v.String()
 	if p.PromDiscoveredByPod() {
 		meta.Annotations[PrometheusScrapeAnno] = "true"
 		meta.Annotations[PrometheusPortAnno] = strconv.Itoa(MetricsPort)
 	} else {
 		delete(meta.Annotations, PrometheusScrapeAnno)
 		delete(meta.Annotations, PrometheusPortAnno)
+	}
+	v, ok := p.GetSemVer()
+	if ok {
+		meta.Annotations[SemanticVersionAnno] = v.String()
 	}
 }
 

--- a/pkg/controllers/common/podset_test.go
+++ b/pkg/controllers/common/podset_test.go
@@ -32,7 +32,7 @@ func Test_syncPodTemplate(t *testing.T) {
 		task: &SyncMOPodTask{
 			PodSet: &v1alpha1.PodSet{
 				MainContainer: v1alpha1.MainContainer{
-					Image: "test",
+					Image: "test:v1.2.3",
 				},
 				Overlay: &v1alpha1.Overlay{
 					SidecarContainers: []corev1.Container{{

--- a/pkg/webhook/cnset_webhook_test.go
+++ b/pkg/webhook/cnset_webhook_test.go
@@ -40,7 +40,7 @@ var _ = Describe("CNSet Webhook", func() {
 				PodSet: v1alpha1.PodSet{
 					Replicas: 2,
 					MainContainer: v1alpha1.MainContainer{
-						Image: "test",
+						Image: "test:v1.2.3",
 					},
 				},
 			},
@@ -68,7 +68,7 @@ var _ = Describe("CNSet Webhook", func() {
 				PodSet: v1alpha1.PodSet{
 					Replicas: 2,
 					MainContainer: v1alpha1.MainContainer{
-						Image: "test",
+						Image: "test:v1.2.3",
 					},
 				},
 				ConfigThatChangeCNSpec: v1alpha1.ConfigThatChangeCNSpec{
@@ -98,7 +98,7 @@ var _ = Describe("CNSet Webhook", func() {
 				PodSet: v1alpha1.PodSet{
 					Replicas: 2,
 					MainContainer: v1alpha1.MainContainer{
-						Image: "test",
+						Image: "test:v1.2.3",
 					},
 				},
 			},

--- a/pkg/webhook/common.go
+++ b/pkg/webhook/common.go
@@ -16,7 +16,7 @@ package webhook
 
 import (
 	"fmt"
-	"github.com/blang/semver/v4"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
@@ -96,11 +96,8 @@ func validatePodSet(podSet *v1alpha1.PodSet, path *field.Path) field.ErrorList {
 	if podSet.Overlay != nil {
 		errs = append(errs, validateOverlays(podSet.Overlay, path.Child("overlay"))...)
 	}
-	if podSet.SemanticVersion != nil {
-		_, err := semver.Parse(*podSet.SemanticVersion)
-		if err != nil {
-			errs = append(errs, field.Invalid(path.Child("semanticVersion"), *podSet.SemanticVersion, err.Error()))
-		}
+	if _, ok := podSet.GetSemVer(); !ok {
+		errs = append(errs, field.Invalid(path.Child("semanticVersion"), podSet.SemanticVersion, "a valid semanticVersion must be set or the image tag must be valid sematic version instead"))
 	}
 
 	if podSet.ExportToPrometheus != nil && *podSet.ExportToPrometheus {

--- a/pkg/webhook/dnset_webhook_test.go
+++ b/pkg/webhook/dnset_webhook_test.go
@@ -40,7 +40,7 @@ var _ = Describe("DNSet Webhook", func() {
 				PodSet: v1alpha1.PodSet{
 					Replicas: 2,
 					MainContainer: v1alpha1.MainContainer{
-						Image: "test",
+						Image: "test:v1.2.3",
 					},
 				},
 			},
@@ -68,7 +68,7 @@ var _ = Describe("DNSet Webhook", func() {
 				PodSet: v1alpha1.PodSet{
 					Replicas: 2,
 					MainContainer: v1alpha1.MainContainer{
-						Image: "test",
+						Image: "test:v1.2.3",
 					},
 				},
 				CacheVolume: &v1alpha1.Volume{
@@ -96,7 +96,7 @@ var _ = Describe("DNSet Webhook", func() {
 				PodSet: v1alpha1.PodSet{
 					Replicas: 2,
 					MainContainer: v1alpha1.MainContainer{
-						Image: "test",
+						Image: "test:v1.2.3",
 					},
 					Config: v1alpha1.NewTomlConfig(map[string]interface{}{
 						"tn": map[string]interface{}{

--- a/pkg/webhook/logset_webhook_test.go
+++ b/pkg/webhook/logset_webhook_test.go
@@ -40,7 +40,7 @@ var _ = Describe("LogSet Webhook", func() {
 				PodSet: v1alpha1.PodSet{
 					Replicas: 3,
 					MainContainer: v1alpha1.MainContainer{
-						Image: "test",
+						Image: "test:v1.2.3",
 					},
 				},
 				Volume: v1alpha1.Volume{
@@ -64,7 +64,7 @@ var _ = Describe("LogSet Webhook", func() {
 				PodSet: v1alpha1.PodSet{
 					Replicas: 3,
 					MainContainer: v1alpha1.MainContainer{
-						Image: "test",
+						Image: "test:v1.2.3",
 					},
 				},
 				Volume: v1alpha1.Volume{
@@ -91,7 +91,7 @@ var _ = Describe("LogSet Webhook", func() {
 				PodSet: v1alpha1.PodSet{
 					Replicas: 3,
 					MainContainer: v1alpha1.MainContainer{
-						Image: "test",
+						Image: "test:v1.2.3",
 					},
 				},
 				Volume: v1alpha1.Volume{

--- a/pkg/webhook/proxy_webhook_test.go
+++ b/pkg/webhook/proxy_webhook_test.go
@@ -36,7 +36,7 @@ var _ = Describe("ProxySet Webhook", func() {
 				PodSet: v1alpha1.PodSet{
 					Replicas: 2,
 					MainContainer: v1alpha1.MainContainer{
-						Image: "test",
+						Image: "test:v1.2.3",
 					},
 				},
 			},


### PR DESCRIPTION
### **User description**
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

https://github.com/matrixorigin/MO-Cloud/issues/4004

**What this PR does / why we need it:**

Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Improved the handling of semantic version annotations in the `SyncPodMeta` function to ensure robustness.
- Enhanced the `ValidateUpdate` function in the webhook to check for semantic version compatibility, ensuring that updates do not introduce incompatible versions.
- Updated multiple test files to use semantic versioned image tags, ensuring consistency and correctness in tests.
- Improved validation logic for `PodSet` semantic versions to ensure a valid semantic version is set or derived from the image tag.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>podset.go</strong><dd><code>Improve semantic version handling in pod metadata synchronization</code></dd></summary>
<hr>

pkg/controllers/common/podset.go

<li>Moved import of <code>strconv</code> to a more appropriate location.<br> <li> Adjusted the logic in <code>SyncPodMeta</code> to handle semantic version <br>annotations more robustly.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone-operator/pull/549/files#diff-7971be327363259582f2c5a9bcd29e12ba818a363363daa87968ebe05e59fcc5">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cnset_webhook.go</strong><dd><code>Validate semantic version compatibility during updates</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/webhook/cnset_webhook.go

<li>Enhanced <code>ValidateUpdate</code> to ensure semantic version compatibility.<br> <li> Added checks for semantic version presence in updates.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone-operator/pull/549/files#diff-75d58857b3768d5a68227b057d22ba4df277cd910c4a075926e566c36bbc5b83">+15/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>common.go</strong><dd><code>Enhance semantic version validation in PodSet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/webhook/common.go

- Improved validation logic for `PodSet` semantic version.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone-operator/pull/549/files#diff-3755ed4e77ba28d8271daaecb1e8f1c2340c0fe29d95bd641d915d8fc80d77cc">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>podset_test.go</strong><dd><code>Update test case with semantic versioned image tag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/controllers/common/podset_test.go

- Updated test case to use a semantic versioned image tag.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone-operator/pull/549/files#diff-3d559797af5a54022902c15a131ae2f0e10eecdc27eb9da7498994d4abdb48e2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cnset_webhook_test.go</strong><dd><code>Use semantic versioned image tags in CNSet webhook tests</code>&nbsp; </dd></summary>
<hr>

pkg/webhook/cnset_webhook_test.go

- Updated test cases to use semantic versioned image tags.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone-operator/pull/549/files#diff-a55d81960a489c68c68ac750389d57a3f052092cd507ba2319f9cd7ae2ee32bd">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dnset_webhook_test.go</strong><dd><code>Use semantic versioned image tags in DNSet webhook tests</code>&nbsp; </dd></summary>
<hr>

pkg/webhook/dnset_webhook_test.go

- Updated test cases to use semantic versioned image tags.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone-operator/pull/549/files#diff-688f227a7d765b12f8c14b35d1e7fdfaa280ad002977de6c4ee1260a147e10cc">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>logset_webhook_test.go</strong><dd><code>Use semantic versioned image tags in LogSet webhook tests</code></dd></summary>
<hr>

pkg/webhook/logset_webhook_test.go

- Updated test cases to use semantic versioned image tags.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone-operator/pull/549/files#diff-52290116e1e58fcadf98e8d3c5063915f5ae8b24f444da63de800e4b88dfb764">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>proxy_webhook_test.go</strong><dd><code>Use semantic versioned image tags in ProxySet webhook tests</code></dd></summary>
<hr>

pkg/webhook/proxy_webhook_test.go

- Updated test cases to use semantic versioned image tags.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone-operator/pull/549/files#diff-a153c0a3919781260f2dda886b505ac1b38dcc7df164ebf5bc52ec2821732373">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

