### PR TITLE
fix: make fileservice config deepcopy

### DIFF
--- a/.github/actions/checks/action.yml
+++ b/.github/actions/checks/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: ./.github/actions/dev_env
 
     - name: check_license_header
-      uses: apache/skywalking-eyes/header@main
+      uses: apache/skywalking-eyes/header@v0.6.0
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       with:

--- a/.github/env
+++ b/.github/env
@@ -1,4 +1,4 @@
-golang-version=1.21
+golang-version=1.22
 kind-version=v0.11.1
 kind-image=kindest/node:v1.23.0
 helm-version=v3.8.1

--- a/api/Makefile
+++ b/api/Makefile
@@ -37,7 +37,7 @@ core/v1alpha1/zz_generated.deepcopy.go: core/v1alpha1/*_types.go
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.0)
 
 CRD_REF_DOCS = $(shell pwd)/bin/crd-ref-docs
 crd-ref-docs:

--- a/api/core/v1alpha1/toml_config.go
+++ b/api/core/v1alpha1/toml_config.go
@@ -82,6 +82,102 @@ func (c *TomlConfig) Merge(mp map[string]interface{}) {
 	}
 }
 
+// MergeDeep merges the given map into the current config with deep merge semantics.
+// For map values present in both configs, it recursively merges rather than replacing.
+// For slices of maps that contain a "name" field, it matches entries by name and
+// deep-merges them, preserving user-specified fields that are not in the override.
+// In all cases, values in mp take precedence over existing values for conflicting keys.
+func (c *TomlConfig) MergeDeep(mp map[string]interface{}) {
+	if c.MP == nil {
+		c.MP = map[string]interface{}{}
+	}
+	c.MP = deepMergeMap(c.MP, mp)
+}
+
+func deepMergeMap(base, override map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{}, len(base)+len(override))
+	for k, v := range base {
+		result[k] = v
+	}
+	for k, v := range override {
+		baseVal, exists := result[k]
+		if !exists {
+			result[k] = v
+			continue
+		}
+		baseMap, baseOk := baseVal.(map[string]interface{})
+		overrideMap, overrideOk := v.(map[string]interface{})
+		if baseOk && overrideOk {
+			result[k] = deepMergeMap(baseMap, overrideMap)
+			continue
+		}
+		baseSlice := toNamedMapSlice(baseVal)
+		overrideSlice := toNamedMapSlice(v)
+		if baseSlice != nil && overrideSlice != nil {
+			result[k] = mergeNamedMapSlice(baseSlice, overrideSlice)
+			continue
+		}
+		result[k] = v
+	}
+	return result
+}
+
+// toNamedMapSlice converts a value to []map[string]interface{} if the value is
+// a slice of maps where the first element has a "name" key. Returns nil otherwise.
+func toNamedMapSlice(v interface{}) []map[string]interface{} {
+	var result []map[string]interface{}
+	switch s := v.(type) {
+	case []map[string]interface{}:
+		result = s
+	case []interface{}:
+		result = make([]map[string]interface{}, 0, len(s))
+		for _, item := range s {
+			m, ok := item.(map[string]interface{})
+			if !ok {
+				return nil
+			}
+			result = append(result, m)
+		}
+	default:
+		return nil
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	if _, ok := result[0]["name"]; !ok {
+		return nil
+	}
+	return result
+}
+
+func mergeNamedMapSlice(base, override []map[string]interface{}) []map[string]interface{} {
+	baseByName := make(map[string]int, len(base))
+	for i, entry := range base {
+		if name, ok := entry["name"].(string); ok {
+			baseByName[name] = i
+		}
+	}
+	matched := make(map[int]bool)
+	result := make([]map[string]interface{}, 0, len(override)+len(base))
+	for _, oe := range override {
+		name, _ := oe["name"].(string)
+		if name != "" {
+			if idx, ok := baseByName[name]; ok {
+				result = append(result, deepMergeMap(base[idx], oe))
+				matched[idx] = true
+				continue
+			}
+		}
+		result = append(result, oe)
+	}
+	for i, entry := range base {
+		if !matched[i] {
+			result = append(result, entry)
+		}
+	}
+	return result
+}
+
 // Set a key by path, override existing.
 // the keyPath has at least depth 1
 func (c *TomlConfig) Set(path []string, value interface{}) {

--- a/api/core/v1alpha1/toml_config_test.go
+++ b/api/core/v1alpha1/toml_config_test.go
@@ -17,6 +17,7 @@ package v1alpha1
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/util/json"
 )
@@ -109,6 +110,223 @@ func TestMarshal(t *testing.T) {
 	err = json.Unmarshal(data, sback)
 	g.Expect(err).Should(BeNil())
 	g.Expect(sback).Should(Equal(s))
+}
+
+func TestMergeDeep(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     map[string]interface{}
+		override map[string]interface{}
+		want     map[string]interface{}
+	}{
+		{
+			name: "fileservice merge by name preserves user fields",
+			base: map[string]interface{}{
+				"fileservice": []map[string]interface{}{
+					{
+						"name":    "S3",
+						"backend": "S3",
+						"s3": map[string]interface{}{
+							"parallel-mode": "1",
+						},
+					},
+				},
+			},
+			override: map[string]interface{}{
+				"data-dir": "/data/dir",
+				"fileservice": []map[string]interface{}{
+					{"name": "LOCAL", "backend": "DISK", "data-dir": "/data/dir"},
+					{
+						"name":    "S3",
+						"backend": "S3",
+						"s3": map[string]interface{}{
+							"endpoint":   "s3.us-west-2.amazonaws.com",
+							"bucket":     "my-bucket",
+							"key-prefix": "prefix/data",
+						},
+						"cache": map[string]string{"memory-capacity": "1B"},
+					},
+					{
+						"name":    "ETL",
+						"backend": "S3",
+						"s3": map[string]interface{}{
+							"endpoint":   "s3.us-west-2.amazonaws.com",
+							"bucket":     "my-bucket",
+							"key-prefix": "prefix/etl",
+						},
+						"cache": map[string]string{"memory-capacity": "1B"},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"data-dir": "/data/dir",
+				"fileservice": []map[string]interface{}{
+					{"name": "LOCAL", "backend": "DISK", "data-dir": "/data/dir"},
+					{
+						"name":    "S3",
+						"backend": "S3",
+						"s3": map[string]interface{}{
+							"endpoint":      "s3.us-west-2.amazonaws.com",
+							"bucket":        "my-bucket",
+							"key-prefix":    "prefix/data",
+							"parallel-mode": "1",
+						},
+						"cache": map[string]string{"memory-capacity": "1B"},
+					},
+					{
+						"name":    "ETL",
+						"backend": "S3",
+						"s3": map[string]interface{}{
+							"endpoint":   "s3.us-west-2.amazonaws.com",
+							"bucket":     "my-bucket",
+							"key-prefix": "prefix/etl",
+						},
+						"cache": map[string]string{"memory-capacity": "1B"},
+					},
+				},
+			},
+		},
+		{
+			name: "no user fileservice config",
+			base: map[string]interface{}{
+				"service-type": "CN",
+			},
+			override: map[string]interface{}{
+				"data-dir": "/data/dir",
+				"fileservice": []map[string]interface{}{
+					{"name": "LOCAL", "backend": "DISK"},
+				},
+			},
+			want: map[string]interface{}{
+				"service-type": "CN",
+				"data-dir":     "/data/dir",
+				"fileservice": []map[string]interface{}{
+					{"name": "LOCAL", "backend": "DISK"},
+				},
+			},
+		},
+		{
+			name: "user adds extra fileservice entry",
+			base: map[string]interface{}{
+				"fileservice": []map[string]interface{}{
+					{"name": "CUSTOM", "backend": "DISK", "data-dir": "/custom"},
+				},
+			},
+			override: map[string]interface{}{
+				"fileservice": []map[string]interface{}{
+					{"name": "LOCAL", "backend": "DISK", "data-dir": "/data"},
+				},
+			},
+			want: map[string]interface{}{
+				"fileservice": []map[string]interface{}{
+					{"name": "LOCAL", "backend": "DISK", "data-dir": "/data"},
+					{"name": "CUSTOM", "backend": "DISK", "data-dir": "/custom"},
+				},
+			},
+		},
+		{
+			name: "deep merge nested maps",
+			base: map[string]interface{}{
+				"section": map[string]interface{}{
+					"user-key": "user-val",
+					"nested": map[string]interface{}{
+						"a": "1",
+					},
+				},
+			},
+			override: map[string]interface{}{
+				"section": map[string]interface{}{
+					"op-key": "op-val",
+					"nested": map[string]interface{}{
+						"b": "2",
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"section": map[string]interface{}{
+					"user-key": "user-val",
+					"op-key":   "op-val",
+					"nested": map[string]interface{}{
+						"a": "1",
+						"b": "2",
+					},
+				},
+			},
+		},
+		{
+			name: "override wins on conflict",
+			base: map[string]interface{}{
+				"key": "user-value",
+				"section": map[string]interface{}{
+					"endpoint": "user-endpoint",
+					"extra":    "kept",
+				},
+			},
+			override: map[string]interface{}{
+				"key": "operator-value",
+				"section": map[string]interface{}{
+					"endpoint": "operator-endpoint",
+				},
+			},
+			want: map[string]interface{}{
+				"key": "operator-value",
+				"section": map[string]interface{}{
+					"endpoint": "operator-endpoint",
+					"extra":    "kept",
+				},
+			},
+		},
+		{
+			name: "fileservice with []interface{} base from json unmarshal",
+			base: map[string]interface{}{
+				"fileservice": []interface{}{
+					map[string]interface{}{
+						"name":    "S3",
+						"backend": "S3",
+						"s3": map[string]interface{}{
+							"parallel-mode": "1",
+						},
+					},
+				},
+			},
+			override: map[string]interface{}{
+				"fileservice": []map[string]interface{}{
+					{
+						"name":    "S3",
+						"backend": "S3",
+						"s3":     map[string]interface{}{"endpoint": "s3.amazonaws.com"},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"fileservice": []map[string]interface{}{
+					{
+						"name":    "S3",
+						"backend": "S3",
+						"s3": map[string]interface{}{
+							"endpoint":      "s3.amazonaws.com",
+							"parallel-mode": "1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "nil base",
+			base:     nil,
+			override: map[string]interface{}{"key": "val"},
+			want:     map[string]interface{}{"key": "val"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewTomlConfig(tt.base)
+			c.MergeDeep(tt.override)
+			if diff := cmp.Diff(tt.want, c.MP); diff != "" {
+				t.Errorf("MergeDeep() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
 }
 
 func TestOmitEmpty(t *testing.T) {

--- a/pkg/controllers/cnset/resource.go
+++ b/pkg/controllers/cnset/resource.go
@@ -279,7 +279,7 @@ func buildCNSetConfigMap(cn *v1alpha1.CNSet, ls *v1alpha1.LogSet) (*corev1.Confi
 	if cfg == nil {
 		cfg = v1alpha1.NewTomlConfig(map[string]interface{}{})
 	}
-	cfg.Merge(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, &cn.Spec.SharedStorageCache))
+	cfg.MergeDeep(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, &cn.Spec.SharedStorageCache))
 	cfg.Set([]string{"service-type"}, "CN")
 	if sv, ok := cn.Spec.GetSemVer(); ok && v1alpha1.HasMOFeature(*sv, v1alpha1.MOFeatureDiscoveryFixed) {
 		// issue: https://github.com/matrixorigin/MO-Cloud/issues/4158

--- a/pkg/controllers/dnset/resource.go
+++ b/pkg/controllers/dnset/resource.go
@@ -219,7 +219,7 @@ func buildDNSetConfigMap(dn *v1alpha1.DNSet, ls *v1alpha1.LogSet) (*corev1.Confi
 	} else {
 		conf.Set([]string{"hakeeper-client", "service-addresses"}, logset.HaKeeperAdds(ls))
 	}
-	conf.Merge(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, &dn.Spec.SharedStorageCache))
+	conf.MergeDeep(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, &dn.Spec.SharedStorageCache))
 	conf.Set([]string{"service-type"}, serviceType)
 	conf.Set([]string{configAlias, "listen-address"}, getListenAddress())
 	conf.Set([]string{configAlias, "lockservice", "listen-address"}, fmt.Sprintf("0.0.0.0:%d", common.LockServicePort))

--- a/pkg/controllers/logset/configmap.go
+++ b/pkg/controllers/logset/configmap.go
@@ -224,10 +224,10 @@ func buildConfigMap(ls *v1alpha1.LogSet) (*corev1.ConfigMap, string, error) {
 	}
 	// 1. build base config file
 	if ls.Spec.InitialConfig.RestoreFrom != nil {
-		conf.Merge(common.LogServiceFSConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage))
+		conf.MergeDeep(common.LogServiceFSConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage))
 	} else {
 		// TODO(aylei): for 0.8 compatibility, remove this compatibility code after we drop 0.8 support in operator
-		conf.Merge(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, nil))
+		conf.MergeDeep(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, nil))
 	}
 	conf.Set([]string{"service-type"}, serviceTypeLog)
 	conf.Set([]string{"logservice", "deployment-id"}, deploymentID(ls))

--- a/pkg/controllers/proxyset/resource.go
+++ b/pkg/controllers/proxyset/resource.go
@@ -173,7 +173,7 @@ func buildProxyConfigMap(proxy *v1alpha1.ProxySet, ls *v1alpha1.LogSet) (*corev1
 		conf = v1alpha1.NewTomlConfig(map[string]interface{}{})
 	}
 	conf.Set([]string{"hakeeper-client", "discovery-address"}, ls.Status.Discovery.String())
-	conf.Merge(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, nil))
+	conf.MergeDeep(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, nil))
 	conf.Set([]string{"service-type"}, "PROXY")
 	conf.Set([]string{"proxy", "listen-address"}, fmt.Sprintf("0.0.0.0:%d", port))
 	if proxy.Spec.GetExportToPrometheus() {

--- a/test/e2e/logset_test.go
+++ b/test/e2e/logset_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package e2e
 
 import (


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes # https://github.com/matrixorigin/matrixflow/issues/8659

**What this PR does / why we need it:**

### 概览

### 🔴 `Merge` 是浅层覆盖，用户的 `fileservice` 子配置会被完全丢弃

**位置**：`api/core/v1alpha1/toml_config.go:79-83` + `pkg/controllers/cnset/resource.go:282`

**问题**：

`Merge` 方法的实现如下：

```79:83:api/core/v1alpha1/toml_config.go
func (c *TomlConfig) Merge(mp map[string]interface{}) {
	for k, v := range mp {
		c.Set([]string{k}, v)
	}
}
```

它对传入 map 的**顶层 key** 逐个调用 `Set`，而 `Set` 在 path 长度为 1 时直接做 `m[path[0]] = value`（覆盖写）。

在 `resource.go:282`：

```282:282:pkg/controllers/cnset/resource.go
	cfg.Merge(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, &cn.Spec.SharedStorageCache))
```

`cfg` 是用户在 CR `.spec.config` 中提供的配置（已解析为 `TomlConfig`），`FileServiceConfig` 返回的 map 包含顶层 key `"fileservice"`：

```115:123:pkg/controllers/common/fileservice.go
	return map[string]interface{}{
		// some data are not accessed by fileservice and will be read/written at `data-dir` directly
		"data-dir": localPath,
		"fileservice": []map[string]interface{}{
			localFS,
			s3FS,
			etlFS,
		},
	}
```

执行 `Merge` 后，**用户在 CR 中配置的 `fileservice` 整体（包括 `parallel-mode` 等所有子项）会被 operator 生成的 `fileservice` 数组完全覆盖**。

具体流程：
1. 用户 CR 中配置了 `[[fileservice]]` + `[[fileservice.s3]]` + `parallel-mode = "1"`，解析后 `cfg.MP["fileservice"]` 是一个包含用户设置的数组。
2. `Merge` 调用 `cfg.Set([]string{"fileservice"}, [LOCAL, S3, ETL])` → 直接把用户的 `fileservice` 替换为 operator 生成的三个 fileservice 实例。
3. 用户配置的 `parallel-mode` 丢失。

**风险**：用户通过 CR 配置的 `fileservice` 级别的任何自定义参数（如 `parallel-mode`、`s3` 下的其他调优参数等）都无法生效，属于功能性缺陷。

**根因**：`Merge` 注释已明确说明是 "shallow override"，但对 `fileservice` 这种结构化的数组类型配置，浅层覆盖会导致用户配置完全丢失。这是 **merge 实现的设计缺陷**，不是用户配置的问题。

**建议**：需要对 `fileservice` 这类数组类型的配置实现**按 `name` 字段匹配的深度合并**。即 operator 生成的 fileservice 配置项应当和用户配置的同名 fileservice 进行合并，而不是整体替换。大致思路：

```go
func (c *TomlConfig) MergeFileService(operatorFS []map[string]interface{}) {
    userFS, _ := c.MP["fileservice"]
    // 将 operator 生成的 fs 与用户的 fs 按 name 字段合并
    // 用户的子配置优先（或 operator 的基础配置 + 用户的覆盖）
    merged := mergeByName(operatorFS, userFS)
    c.MP["fileservice"] = merged
}
```

或者，**反转 merge 方向**：先用 operator 的配置作为 base，再让用户的配置覆盖上去。这样用户配置的优先级最高。


### 总结

**核心问题是 `Merge` 的实现**：它是浅层覆盖，会将 operator 生成的 `fileservice` 整体替换用户配置中的 `fileservice`，导致用户的 `parallel-mode` 等自定义设置丢失。即使用户的 TOML 拼写正确，这个问题依然存在。需要在 merge 逻辑中对 `fileservice` 数组进行按 name 匹配的深度合并，或者调整 merge 的方向和策略。

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
