### PR TITLE
fix: use deep merge for fileservice config to preserve user custom fields

### DIFF
--- a/.github/actions/checks/action.yml
+++ b/.github/actions/checks/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: ./.github/actions/dev_env
 
     - name: check_license_header
-      uses: apache/skywalking-eyes/header@main
+      uses: apache/skywalking-eyes/header@v0.6.0
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       with:

--- a/.github/env
+++ b/.github/env
@@ -1,4 +1,4 @@
-golang-version=1.21
+golang-version=1.22
 kind-version=v0.11.1
 kind-image=kindest/node:v1.23.0
 helm-version=v3.8.1

--- a/api/Makefile
+++ b/api/Makefile
@@ -37,7 +37,7 @@ core/v1alpha1/zz_generated.deepcopy.go: core/v1alpha1/*_types.go
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.0)
 
 CRD_REF_DOCS = $(shell pwd)/bin/crd-ref-docs
 crd-ref-docs:

--- a/api/core/v1alpha1/toml_config.go
+++ b/api/core/v1alpha1/toml_config.go
@@ -82,6 +82,102 @@ func (c *TomlConfig) Merge(mp map[string]interface{}) {
 	}
 }
 
+// MergeDeep merges the given map into the current config with deep merge semantics.
+// For map values present in both configs, it recursively merges rather than replacing.
+// For slices of maps that contain a "name" field, it matches entries by name and
+// deep-merges them, preserving user-specified fields that are not in the override.
+// In all cases, values in mp take precedence over existing values for conflicting keys.
+func (c *TomlConfig) MergeDeep(mp map[string]interface{}) {
+	if c.MP == nil {
+		c.MP = map[string]interface{}{}
+	}
+	c.MP = deepMergeMap(c.MP, mp)
+}
+
+func deepMergeMap(base, override map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{}, len(base)+len(override))
+	for k, v := range base {
+		result[k] = v
+	}
+	for k, v := range override {
+		baseVal, exists := result[k]
+		if !exists {
+			result[k] = v
+			continue
+		}
+		baseMap, baseOk := baseVal.(map[string]interface{})
+		overrideMap, overrideOk := v.(map[string]interface{})
+		if baseOk && overrideOk {
+			result[k] = deepMergeMap(baseMap, overrideMap)
+			continue
+		}
+		baseSlice := toNamedMapSlice(baseVal)
+		overrideSlice := toNamedMapSlice(v)
+		if baseSlice != nil && overrideSlice != nil {
+			result[k] = mergeNamedMapSlice(baseSlice, overrideSlice)
+			continue
+		}
+		result[k] = v
+	}
+	return result
+}
+
+// toNamedMapSlice converts a value to []map[string]interface{} if the value is
+// a slice of maps where the first element has a "name" key. Returns nil otherwise.
+func toNamedMapSlice(v interface{}) []map[string]interface{} {
+	var result []map[string]interface{}
+	switch s := v.(type) {
+	case []map[string]interface{}:
+		result = s
+	case []interface{}:
+		result = make([]map[string]interface{}, 0, len(s))
+		for _, item := range s {
+			m, ok := item.(map[string]interface{})
+			if !ok {
+				return nil
+			}
+			result = append(result, m)
+		}
+	default:
+		return nil
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	if _, ok := result[0]["name"]; !ok {
+		return nil
+	}
+	return result
+}
+
+func mergeNamedMapSlice(base, override []map[string]interface{}) []map[string]interface{} {
+	baseByName := make(map[string]int, len(base))
+	for i, entry := range base {
+		if name, ok := entry["name"].(string); ok {
+			baseByName[name] = i
+		}
+	}
+	matched := make(map[int]bool)
+	result := make([]map[string]interface{}, 0, len(override)+len(base))
+	for _, oe := range override {
+		name, _ := oe["name"].(string)
+		if name != "" {
+			if idx, ok := baseByName[name]; ok {
+				result = append(result, deepMergeMap(base[idx], oe))
+				matched[idx] = true
+				continue
+			}
+		}
+		result = append(result, oe)
+	}
+	for i, entry := range base {
+		if !matched[i] {
+			result = append(result, entry)
+		}
+	}
+	return result
+}
+
 // Set a key by path, override existing.
 // the keyPath has at least depth 1
 func (c *TomlConfig) Set(path []string, value interface{}) {

--- a/api/core/v1alpha1/toml_config_test.go
+++ b/api/core/v1alpha1/toml_config_test.go
@@ -17,6 +17,7 @@ package v1alpha1
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/util/json"
 )
@@ -109,6 +110,223 @@ func TestMarshal(t *testing.T) {
 	err = json.Unmarshal(data, sback)
 	g.Expect(err).Should(BeNil())
 	g.Expect(sback).Should(Equal(s))
+}
+
+func TestMergeDeep(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     map[string]interface{}
+		override map[string]interface{}
+		want     map[string]interface{}
+	}{
+		{
+			name: "fileservice merge by name preserves user fields",
+			base: map[string]interface{}{
+				"fileservice": []map[string]interface{}{
+					{
+						"name":    "S3",
+						"backend": "S3",
+						"s3": map[string]interface{}{
+							"parallel-mode": "1",
+						},
+					},
+				},
+			},
+			override: map[string]interface{}{
+				"data-dir": "/data/dir",
+				"fileservice": []map[string]interface{}{
+					{"name": "LOCAL", "backend": "DISK", "data-dir": "/data/dir"},
+					{
+						"name":    "S3",
+						"backend": "S3",
+						"s3": map[string]interface{}{
+							"endpoint":   "s3.us-west-2.amazonaws.com",
+							"bucket":     "my-bucket",
+							"key-prefix": "prefix/data",
+						},
+						"cache": map[string]string{"memory-capacity": "1B"},
+					},
+					{
+						"name":    "ETL",
+						"backend": "S3",
+						"s3": map[string]interface{}{
+							"endpoint":   "s3.us-west-2.amazonaws.com",
+							"bucket":     "my-bucket",
+							"key-prefix": "prefix/etl",
+						},
+						"cache": map[string]string{"memory-capacity": "1B"},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"data-dir": "/data/dir",
+				"fileservice": []map[string]interface{}{
+					{"name": "LOCAL", "backend": "DISK", "data-dir": "/data/dir"},
+					{
+						"name":    "S3",
+						"backend": "S3",
+						"s3": map[string]interface{}{
+							"endpoint":      "s3.us-west-2.amazonaws.com",
+							"bucket":        "my-bucket",
+							"key-prefix":    "prefix/data",
+							"parallel-mode": "1",
+						},
+						"cache": map[string]string{"memory-capacity": "1B"},
+					},
+					{
+						"name":    "ETL",
+						"backend": "S3",
+						"s3": map[string]interface{}{
+							"endpoint":   "s3.us-west-2.amazonaws.com",
+							"bucket":     "my-bucket",
+							"key-prefix": "prefix/etl",
+						},
+						"cache": map[string]string{"memory-capacity": "1B"},
+					},
+				},
+			},
+		},
+		{
+			name: "no user fileservice config",
+			base: map[string]interface{}{
+				"service-type": "CN",
+			},
+			override: map[string]interface{}{
+				"data-dir": "/data/dir",
+				"fileservice": []map[string]interface{}{
+					{"name": "LOCAL", "backend": "DISK"},
+				},
+			},
+			want: map[string]interface{}{
+				"service-type": "CN",
+				"data-dir":     "/data/dir",
+				"fileservice": []map[string]interface{}{
+					{"name": "LOCAL", "backend": "DISK"},
+				},
+			},
+		},
+		{
+			name: "user adds extra fileservice entry",
+			base: map[string]interface{}{
+				"fileservice": []map[string]interface{}{
+					{"name": "CUSTOM", "backend": "DISK", "data-dir": "/custom"},
+				},
+			},
+			override: map[string]interface{}{
+				"fileservice": []map[string]interface{}{
+					{"name": "LOCAL", "backend": "DISK", "data-dir": "/data"},
+				},
+			},
+			want: map[string]interface{}{
+				"fileservice": []map[string]interface{}{
+					{"name": "LOCAL", "backend": "DISK", "data-dir": "/data"},
+					{"name": "CUSTOM", "backend": "DISK", "data-dir": "/custom"},
+				},
+			},
+		},
+		{
+			name: "deep merge nested maps",
+			base: map[string]interface{}{
+				"section": map[string]interface{}{
+					"user-key": "user-val",
+					"nested": map[string]interface{}{
+						"a": "1",
+					},
+				},
+			},
+			override: map[string]interface{}{
+				"section": map[string]interface{}{
+					"op-key": "op-val",
+					"nested": map[string]interface{}{
+						"b": "2",
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"section": map[string]interface{}{
+					"user-key": "user-val",
+					"op-key":   "op-val",
+					"nested": map[string]interface{}{
+						"a": "1",
+						"b": "2",
+					},
+				},
+			},
+		},
+		{
+			name: "override wins on conflict",
+			base: map[string]interface{}{
+				"key": "user-value",
+				"section": map[string]interface{}{
+					"endpoint": "user-endpoint",
+					"extra":    "kept",
+				},
+			},
+			override: map[string]interface{}{
+				"key": "operator-value",
+				"section": map[string]interface{}{
+					"endpoint": "operator-endpoint",
+				},
+			},
+			want: map[string]interface{}{
+				"key": "operator-value",
+				"section": map[string]interface{}{
+					"endpoint": "operator-endpoint",
+					"extra":    "kept",
+				},
+			},
+		},
+		{
+			name: "fileservice with []interface{} base from json unmarshal",
+			base: map[string]interface{}{
+				"fileservice": []interface{}{
+					map[string]interface{}{
+						"name":    "S3",
+						"backend": "S3",
+						"s3": map[string]interface{}{
+							"parallel-mode": "1",
+						},
+					},
+				},
+			},
+			override: map[string]interface{}{
+				"fileservice": []map[string]interface{}{
+					{
+						"name":    "S3",
+						"backend": "S3",
+						"s3":     map[string]interface{}{"endpoint": "s3.amazonaws.com"},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"fileservice": []map[string]interface{}{
+					{
+						"name":    "S3",
+						"backend": "S3",
+						"s3": map[string]interface{}{
+							"endpoint":      "s3.amazonaws.com",
+							"parallel-mode": "1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "nil base",
+			base:     nil,
+			override: map[string]interface{}{"key": "val"},
+			want:     map[string]interface{}{"key": "val"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewTomlConfig(tt.base)
+			c.MergeDeep(tt.override)
+			if diff := cmp.Diff(tt.want, c.MP); diff != "" {
+				t.Errorf("MergeDeep() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
 }
 
 func TestOmitEmpty(t *testing.T) {

--- a/pkg/controllers/cnset/resource.go
+++ b/pkg/controllers/cnset/resource.go
@@ -257,7 +257,7 @@ func buildCNSetConfigMap(cn *v1alpha1.CNSet, ls *v1alpha1.LogSet) (*corev1.Confi
 	if cfg == nil {
 		cfg = v1alpha1.NewTomlConfig(map[string]interface{}{})
 	}
-	cfg.Merge(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, &cn.Spec.SharedStorageCache))
+	cfg.MergeDeep(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, &cn.Spec.SharedStorageCache))
 	cfg.Set([]string{"service-type"}, "CN")
 	cfg.Set([]string{"hakeeper-client", "service-addresses"}, logset.HaKeeperAdds(ls))
 	// cfg.Set([]string{"hakeeper-client", "discovery-address"}, ls.Status.Discovery.String())

--- a/pkg/controllers/dnset/resource.go
+++ b/pkg/controllers/dnset/resource.go
@@ -191,8 +191,7 @@ func buildDNSetConfigMap(dn *v1alpha1.DNSet, ls *v1alpha1.LogSet) (*corev1.Confi
 		configAlias = aliasTN
 	}
 	conf.Set([]string{"hakeeper-client", "service-addresses"}, logset.HaKeeperAdds(ls))
-	// conf.Set([]string{"hakeeper-client", "discovery-address"}, ls.Status.Discovery.String())
-	conf.Merge(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, &dn.Spec.SharedStorageCache))
+	conf.MergeDeep(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, &dn.Spec.SharedStorageCache))
 	conf.Set([]string{"service-type"}, serviceType)
 	conf.Set([]string{configAlias, "listen-address"}, getListenAddress())
 	conf.Set([]string{configAlias, "lockservice", "listen-address"}, fmt.Sprintf("0.0.0.0:%d", common.LockServicePort))

--- a/pkg/controllers/dnset/resource_test.go
+++ b/pkg/controllers/dnset/resource_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/matrixorigin/matrixone-operator/api/core/v1alpha1"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 )
@@ -166,6 +167,94 @@ name = "ETL"
 
 [fileservice.cache]
 memory-capacity = "1B"
+
+[hakeeper-client]
+service-addresses = []
+`,
+		},
+		{
+			name: "user fileservice config preserved after merge",
+			args: args{
+				dn: &v1alpha1.DNSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test",
+					},
+					Spec: v1alpha1.DNSetSpec{PodSet: v1alpha1.PodSet{
+						Config: v1alpha1.NewTomlConfig(map[string]interface{}{
+							"fileservice": []map[string]interface{}{
+								{
+									"name":    "S3",
+									"backend": "S3",
+									"s3": map[string]interface{}{
+										"parallel-mode": "1",
+									},
+								},
+							},
+						}),
+					}},
+				},
+				ls: &v1alpha1.LogSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test",
+					},
+					Spec: v1alpha1.LogSetSpec{SharedStorage: v1alpha1.SharedStorageProvider{
+						S3: &v1alpha1.S3Provider{
+							Path:     "bucket-name/mo",
+							Endpoint: "http://obs.cn-szinternal.com",
+							SecretRef: &corev1.LocalObjectReference{
+								Name: "s3key",
+							},
+						},
+					}},
+					Status: v1alpha1.LogSetStatus{
+						Discovery: &v1alpha1.LogSetDiscovery{
+							Port:    6001,
+							Address: "test",
+						},
+					},
+				},
+			},
+			wantConfig: `data-dir = "/var/lib/matrixone/data"
+service-type = "DN"
+
+[dn]
+listen-address = "0.0.0.0:41010"
+port-base = 41010
+
+[dn.LogtailServer]
+listen-address = "0.0.0.0:32003"
+
+[dn.lockservice]
+listen-address = "0.0.0.0:6003"
+
+[[fileservice]]
+backend = "DISK"
+data-dir = "/var/lib/matrixone/data"
+name = "LOCAL"
+
+[[fileservice]]
+backend = "S3"
+name = "S3"
+
+[fileservice.s3]
+bucket = "bucket-name"
+endpoint = "http://obs.cn-szinternal.com"
+key-prefix = "mo/data"
+parallel-mode = "1"
+
+[[fileservice]]
+backend = "S3"
+name = "ETL"
+
+[fileservice.cache]
+memory-capacity = "1B"
+
+[fileservice.s3]
+bucket = "bucket-name"
+endpoint = "http://obs.cn-szinternal.com"
+key-prefix = "mo/etl"
 
 [hakeeper-client]
 service-addresses = []

--- a/pkg/controllers/logset/configmap.go
+++ b/pkg/controllers/logset/configmap.go
@@ -135,10 +135,10 @@ func buildConfigMap(ls *v1alpha1.LogSet) (*corev1.ConfigMap, error) {
 	}
 	// 1. build base config file
 	if ls.Spec.InitialConfig.RestoreFrom != nil {
-		conf.Merge(common.LogServiceFSConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage))
+		conf.MergeDeep(common.LogServiceFSConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage))
 	} else {
 		// TODO(aylei): for 0.8 compatibility, remove this compatibility code after we drop 0.8 support in operator
-		conf.Merge(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, nil))
+		conf.MergeDeep(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, nil))
 	}
 	conf.Set([]string{"service-type"}, serviceTypeLog)
 	conf.Set([]string{"logservice", "deployment-id"}, deploymentID(ls))

--- a/pkg/controllers/proxyset/resource.go
+++ b/pkg/controllers/proxyset/resource.go
@@ -154,7 +154,7 @@ func buildProxyConfigMap(proxy *v1alpha1.ProxySet, ls *v1alpha1.LogSet) (*corev1
 		conf = v1alpha1.NewTomlConfig(map[string]interface{}{})
 	}
 	conf.Set([]string{"hakeeper-client", "discovery-address"}, ls.Status.Discovery.String())
-	conf.Merge(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, nil))
+	conf.MergeDeep(common.FileServiceConfig(fmt.Sprintf("%s/%s", common.DataPath, common.DataDir), ls.Spec.SharedStorage, nil))
 	conf.Set([]string{"service-type"}, "PROXY")
 	conf.Set([]string{"proxy", "listen-address"}, fmt.Sprintf("0.0.0.0:%d", port))
 	if proxy.Spec.GetExportToPrometheus() {

--- a/test/e2e/logset_test.go
+++ b/test/e2e/logset_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package e2e
 
 import (


### PR DESCRIPTION
## 变更说明

修复 operator 在合并用户自定义 fileservice 配置时，使用浅合并（`Merge`）导致用户在 YAML 中指定的 `fileservice.s3` 子配置（如 `parallel-mode`）被 operator 生成的默认配置整体覆盖而丢失的问题。引入深度合并（`MergeDeep`）机制，按 `name` 字段匹配 fileservice 条目并递归合并嵌套 map，确保用户自定义字段被保留。

- 新增 `MergeDeep` 方法：对 `TomlConfig` 实现递归深度合并，map 类型递归合并，`fileservice` 等命名切片按 `name` 匹配后深度合并
- 所有组件（CN/DN/LogSet/Proxy）的 fileservice 配置合并从 `Merge` 切换为 `MergeDeep`
- CI 环境升级：Go 1.21 → 1.22，controller-gen v0.15.0 → v0.16.0，skywalking-eyes 固定到 v0.6.0

### 核心变更

**1. 深度合并引擎 (`api/core/v1alpha1/toml_config.go`)**
- 新增 `MergeDeep(mp)` 方法，替代原有的浅合并 `Merge`
- 新增 `deepMergeMap(base, override)` 递归合并两个 map，override 优先
- 新增 `toNamedMapSlice(v)` 将 `[]interface{}` 或 `[]map[string]interface{}` 统一转换为命名 map 切片（首元素需含 `name` 字段）
- 新增 `mergeNamedMapSlice(base, override)` 按 `name` 匹配条目后深度合并，未匹配的 base 条目追加到末尾

**2. 组件配置合并切换**
- `cnset/resource.go`：`cfg.Merge(...)` → `cfg.MergeDeep(...)`
- `dnset/resource.go`：`conf.Merge(...)` → `conf.MergeDeep(...)`
- `logset/configmap.go`：两处 `conf.Merge(...)` → `conf.MergeDeep(...)`
- `proxyset/resource.go`：`conf.Merge(...)` → `conf.MergeDeep(...)`

**3. CI/工具链升级**
- Go 版本 1.21 → 1.22
- controller-gen v0.15.0 → v0.16.0
- `apache/skywalking-eyes/header` 从 `@main` 固定到 `@v0.6.0`


### 新增单元测试概述

**`TestMergeDeep` (`api/core/v1alpha1/toml_config_test.go`)** — 7 个用例，覆盖 `MergeDeep` 核心逻辑：

| # | 用例名 | 验证点 |
|---|--------|--------|
| 1 | fileservice merge by name preserves user fields | 按 `name` 匹配 fileservice 条目，用户自定义的 `s3.parallel-mode` 在合并后保留 |
| 2 | no user fileservice config | base 无 fileservice 时，override 的 fileservice 正常写入 |
| 3 | user adds extra fileservice entry | base 中存在 override 没有的条目（CUSTOM），合并后追加到末尾 |
| 4 | deep merge nested maps | 嵌套 map 递归合并，双方字段均保留 |
| 5 | override wins on conflict | 同 key 冲突时 override 优先，base 独有字段保留 |
| 6 | fileservice with `[]interface{}` base from json unmarshal | base 为 JSON 反序列化产生的 `[]interface{}` 类型时，仍能正确按 name 匹配并深度合并 |
| 7 | nil base | base 为 nil 时不 panic，结果等于 override |

**DNSet 集成测试 (`pkg/controllers/dnset/resource_test.go`)** — 新增 1 个用例：

| 用例名 | 验证点 |
|--------|--------|
| user fileservice config preserved after merge | 模拟用户在 DNSet CR 中配置 `fileservice.s3.parallel-mode`，经 operator 生成默认配置并 `MergeDeep` 后，验证最终 TOML 输出中用户字段被完整保留 |

### 新增/修改文件
| 文件 | 说明 |
|------|------|
| `api/core/v1alpha1/toml_config.go` | 新增 `MergeDeep` 及深度合并辅助函数（+96） |
| `api/core/v1alpha1/toml_config_test.go` | 新增 `TestMergeDeep` 7 个用例覆盖各种合并场景（+218） |
| `pkg/controllers/dnset/resource_test.go` | 新增带 S3 SharedStorage 输入的 DNSet 配置合并测试（+89） |
| `pkg/controllers/cnset/resource.go` | `Merge` → `MergeDeep` |
| `pkg/controllers/dnset/resource.go` | `Merge` → `MergeDeep`，删除注释代码 |
| `pkg/controllers/logset/configmap.go` | 两处 `Merge` → `MergeDeep` |
| `pkg/controllers/proxyset/resource.go` | `Merge` → `MergeDeep` |
| `.github/env` | Go 1.21 → 1.22 |
| `.github/actions/checks/action.yml` | skywalking-eyes 固定到 v0.6.0 |
| `api/Makefile` | controller-gen v0.15.0 → v0.16.0 |

## 变更类型
- [ ] 新功能（向后兼容）
- [x] 缺陷修复（向后兼容）
- [ ] 破坏性变更（需要迁移指南）

## 影响范围
### 影响的团队
- [x] 平台组
- [ ] 应用后端组
- [ ] 应用前端组
- [x] 架构组

### 测试验证
- [x] 单元测试已添加/更新
- [ ] 集成测试已通过
- [ ] 手动测试已完成
- [ ] 性能测试已进行
- [x] **Issue修复必填**（moi内核团队）：已添加能够100%复现Issue的BVT测试或单元测试

### 文档更新
- [ ] API/SDK文档已更新
- [ ] 用户文档已更新
- [ ] README已更新
- [ ] CHANGELOG已更新

## 环境验证
| 环境 | 状态 | 备注 |
|------|------|------|
| 本地开发 | [x] | 单元测试全部通过 |
| 测试环境 | [ ] |  |
| 预发环境 | [ ] |  |

## 相关链接
- GitHub Issue: https://github.com/matrixorigin/matrixflow/issues/8659
- 上游修复: matrixorigin/matrixone-operator#578 (make fileservice config deepcopy)

## 检查清单
- [x] 代码已自测
- [x] 提交信息规范
- [x] 无调试代码
- [x] 遵循编码规范
- [ ] 已同步上游最新代码

