### PR TITLE
ci: improve image tag to include branch name and short sha

### DIFF
--- a/.github/workflows/release_image.yml
+++ b/.github/workflows/release_image.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Short SHA
+        id: short_sha
+        run: echo "sha8=${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -27,7 +31,7 @@ jobs:
             registry.cn-hangzhou.aliyuncs.com/mocloud/matrixone-operator
             registry.cn-hangzhou.aliyuncs.com/moc-pub/matrixone-operator
           tags: |
-            type=ref,event=branch
+            type=raw,value=${{ github.ref_name }}-${{ steps.short_sha.outputs.sha8 }},enable=${{ github.ref_type == 'branch' }}
             type=sha
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
Replace branch ref tag with a more descriptive tag format: `{branch-name}-{sha8}`, which makes it easier to identify the exact commit of a built image.

- preview, https://github.com/matrixorigin/matrixone-operator/actions/runs/23332267328
<img width="1446" height="435" alt="image" src="https://github.com/user-attachments/assets/3a738108-7359-4cb0-8d11-7f9552d6c9fb" />
