### PR TITLE
fix: prevent duplicate CNClaim binding to same CN Pod during migration

### DIFF
--- a/.licenserc.yml
+++ b/.licenserc.yml
@@ -2,6 +2,7 @@ header:
   license:
     spdx-id: Apache-2.0
     copyright-owner: Matrix Origin
+    copyright-year: '2025-2026'
   paths-ignore:
     - 'docs/'
     - 'examples/'

--- a/.licenserc.yml
+++ b/.licenserc.yml
@@ -2,7 +2,7 @@ header:
   license:
     spdx-id: Apache-2.0
     copyright-owner: Matrix Origin
-    copyright-year: '2025-2026'
+    copyright-year: '2025-2125'
   paths-ignore:
     - 'docs/'
     - 'examples/'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+## License Header 规范
+
+修改源代码文件时，必须同步更新文件头部的 copyright 年份标注。
+
+### 规则
+
+- 如果文件原始 copyright 年份为 `YYYY`，且当前修改年份不同，更新为 `YYYY-当前年份`
+- 如果已经是范围格式 `YYYY-ZZZZ`，将结束年份更新为当前年份
+- 仅修改本次 PR 实际变更的文件，不要批量更新未修改的文件
+
+### 示例
+
+```
+// 原始
+// Copyright 2025 Matrix Origin
+
+// 修改后（当前年份 2026）
+// Copyright 2025-2026 Matrix Origin
+```

--- a/pkg/controllers/cnclaim/controller.go
+++ b/pkg/controllers/cnclaim/controller.go
@@ -159,13 +159,16 @@ func (r *Actor) selectCN(ctx *recon.Context[*v1alpha1.CNClaim], orphans []corev1
 	}
 
 	sortCNByPriority(c, idleCNs)
+	// build index once: podName -> claimName for all other CNClaims
+	claimIndex, err := buildPodClaimIndex(ctx, c.Namespace, c.Name)
+	if err != nil {
+		return nil, errors.WrapPrefix(err, "error building pod claim index", 0)
+	}
 	for i := range idleCNs {
 		pod := &idleCNs[i]
 		// skip pod already referenced by another CNClaim's spec.podName
-		if claimed, err := podClaimedByOthers(ctx, c.Namespace, pod.Name, c.Name); err != nil {
-			return nil, errors.WrapPrefix(err, "error checking pod claims", 0)
-		} else if claimed {
-			ctx.Log.Info("skip pod claimed by other CNClaim", "podName", pod.Name)
+		if holder, ok := claimIndex[pod.Name]; ok {
+			ctx.Log.Info("skip pod claimed by other CNClaim", "podName", pod.Name, "holder", holder)
 			continue
 		}
 		if err := r.ensureOwnership(ctx, pod); err != nil {
@@ -347,13 +350,16 @@ func (r *Actor) Finalize(ctx *recon.Context[*v1alpha1.CNClaim]) (bool, error) {
 	if len(ownedCNs) == 0 {
 		return true, nil
 	}
+	// build index once: podName -> claimName for all other CNClaims
+	claimIndex, err := buildPodClaimIndex(ctx, c.Namespace, c.Name)
+	if err != nil {
+		return false, errors.WrapPrefix(err, "error building pod claim index", 0)
+	}
 	for i := range ownedCNs {
 		cn := ownedCNs[i]
 		// skip reclaim if another CNClaim still references this pod via spec.podName
-		if claimed, err := podClaimedByOthers(ctx, c.Namespace, cn.Name, c.Name); err != nil {
-			return false, errors.WrapPrefix(err, "error checking pod claims", 0)
-		} else if claimed {
-			ctx.Log.Info("skip reclaim, pod still claimed by other CNClaim", "pod", cn.Name)
+		if holder, ok := claimIndex[cn.Name]; ok {
+			ctx.Log.Info("skip reclaim, pod still claimed by other CNClaim", "pod", cn.Name, "holder", holder)
 			continue
 		}
 		ctx.Log.Info("finalize CNClaim, reclaim bound CN", "cn", cn.Name)
@@ -366,6 +372,7 @@ func (r *Actor) Finalize(ctx *recon.Context[*v1alpha1.CNClaim]) (bool, error) {
 
 // podClaimedByOthers checks if the given pod is referenced by any CNClaim's
 // spec.podName other than excludeClaim in the same namespace.
+// It skips CNClaims that are being deleted (DeletionTimestamp != nil).
 func podClaimedByOthers(cli recon.KubeClient, namespace, podName, excludeClaim string) (bool, error) {
 	claimList := &v1alpha1.CNClaimList{}
 	if err := cli.List(claimList, client.InNamespace(namespace)); err != nil {
@@ -373,7 +380,7 @@ func podClaimedByOthers(cli recon.KubeClient, namespace, podName, excludeClaim s
 	}
 	for i := range claimList.Items {
 		claim := &claimList.Items[i]
-		if claim.Name == excludeClaim {
+		if claim.Name == excludeClaim || claim.DeletionTimestamp != nil {
 			continue
 		}
 		if claim.Spec.PodName == podName {
@@ -381,6 +388,25 @@ func podClaimedByOthers(cli recon.KubeClient, namespace, podName, excludeClaim s
 		}
 	}
 	return false, nil
+}
+
+// buildPodClaimIndex lists all CNClaims in the namespace and returns a map
+// from podName to the claiming CNClaim name, excluding the given claim and
+// CNClaims that are being deleted.
+func buildPodClaimIndex(cli recon.KubeClient, namespace, excludeClaim string) (map[string]string, error) {
+	claimList := &v1alpha1.CNClaimList{}
+	if err := cli.List(claimList, client.InNamespace(namespace)); err != nil {
+		return nil, err
+	}
+	index := make(map[string]string, len(claimList.Items))
+	for i := range claimList.Items {
+		claim := &claimList.Items[i]
+		if claim.Name == excludeClaim || claim.DeletionTimestamp != nil || claim.Spec.PodName == "" {
+			continue
+		}
+		index[claim.Spec.PodName] = claim.Name
+	}
+	return index, nil
 }
 
 func (r *Actor) patchStore(ctx *recon.Context[*v1alpha1.CNClaim], pod *corev1.Pod, req logpb.CNStateLabel) (*metadata.CNService, error) {

--- a/pkg/controllers/cnclaim/controller.go
+++ b/pkg/controllers/cnclaim/controller.go
@@ -161,6 +161,13 @@ func (r *Actor) selectCN(ctx *recon.Context[*v1alpha1.CNClaim], orphans []corev1
 	sortCNByPriority(c, idleCNs)
 	for i := range idleCNs {
 		pod := &idleCNs[i]
+		// skip pod already referenced by another CNClaim's spec.podName
+		if claimed, err := podClaimedByOthers(ctx, c.Namespace, pod.Name, c.Name); err != nil {
+			return nil, errors.WrapPrefix(err, "error checking pod claims", 0)
+		} else if claimed {
+			ctx.Log.Info("skip pod claimed by other CNClaim", "podName", pod.Name)
+			continue
+		}
 		if err := r.ensureOwnership(ctx, pod); err != nil {
 			if apierrors.IsConflict(err) {
 				ctx.Log.Info("CN pod is not up to date, try next", "podName", pod.Name)
@@ -342,9 +349,35 @@ func (r *Actor) Finalize(ctx *recon.Context[*v1alpha1.CNClaim]) (bool, error) {
 	}
 	for i := range ownedCNs {
 		cn := ownedCNs[i]
+		// skip reclaim if another CNClaim still references this pod via spec.podName
+		if claimed, err := podClaimedByOthers(ctx, c.Namespace, cn.Name, c.Name); err != nil {
+			return false, errors.WrapPrefix(err, "error checking pod claims", 0)
+		} else if claimed {
+			ctx.Log.Info("skip reclaim, pod still claimed by other CNClaim", "pod", cn.Name)
+			continue
+		}
 		ctx.Log.Info("finalize CNClaim, reclaim bound CN", "cn", cn.Name)
 		if err := r.reclaimCN(ctx, &cn); err != nil {
 			return false, err
+		}
+	}
+	return false, nil
+}
+
+// podClaimedByOthers checks if the given pod is referenced by any CNClaim's
+// spec.podName other than excludeClaim in the same namespace.
+func podClaimedByOthers(cli recon.KubeClient, namespace, podName, excludeClaim string) (bool, error) {
+	claimList := &v1alpha1.CNClaimList{}
+	if err := cli.List(claimList, client.InNamespace(namespace)); err != nil {
+		return false, err
+	}
+	for i := range claimList.Items {
+		claim := &claimList.Items[i]
+		if claim.Name == excludeClaim {
+			continue
+		}
+		if claim.Spec.PodName == podName {
+			return true, nil
 		}
 	}
 	return false, nil

--- a/pkg/controllers/cnclaim/controller.go
+++ b/pkg/controllers/cnclaim/controller.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Matrix Origin
+// Copyright 2025-2026 Matrix Origin
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controllers/cnclaim/controller_test.go
+++ b/pkg/controllers/cnclaim/controller_test.go
@@ -141,6 +141,23 @@ func Test_podClaimedByOthers(t *testing.T) {
 			excludeClaim: "claim-a",
 			want:         false,
 		},
+		{
+			name: "deleting claim is ignored",
+			claims: []client.Object{
+				&v1alpha1.CNClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "claim-deleting",
+						Namespace:         "ns",
+						DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+						Finalizers:        []string{"test"},
+					},
+					Spec: v1alpha1.CNClaimSpec{ClaimPodRef: v1alpha1.ClaimPodRef{PodName: "pod-1"}},
+				},
+			},
+			podName:      "pod-1",
+			excludeClaim: "claim-a",
+			want:         false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -151,6 +168,34 @@ func Test_podClaimedByOthers(t *testing.T) {
 			g.Expect(got).To(Equal(tt.want))
 		})
 	}
+}
+
+func Test_buildPodClaimIndex(t *testing.T) {
+	g := NewGomegaWithT(t)
+	now := metav1.Now()
+	cli := newFakeClient(
+		&v1alpha1.CNClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "self", Namespace: "ns"},
+			Spec:       v1alpha1.CNClaimSpec{ClaimPodRef: v1alpha1.ClaimPodRef{PodName: "pod-1"}},
+		},
+		&v1alpha1.CNClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "ns"},
+			Spec:       v1alpha1.CNClaimSpec{ClaimPodRef: v1alpha1.ClaimPodRef{PodName: "pod-2"}},
+		},
+		&v1alpha1.CNClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "deleting", Namespace: "ns",
+				DeletionTimestamp: &now, Finalizers: []string{"test"}},
+			Spec: v1alpha1.CNClaimSpec{ClaimPodRef: v1alpha1.ClaimPodRef{PodName: "pod-3"}},
+		},
+		&v1alpha1.CNClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "pending", Namespace: "ns"},
+			Spec:       v1alpha1.CNClaimSpec{},
+		},
+	)
+	index, err := buildPodClaimIndex(&fakeKubeClient{cli}, "ns", "self")
+	g.Expect(err).NotTo(HaveOccurred())
+	// "self" excluded, "deleting" filtered, "pending" has no podName
+	g.Expect(index).To(Equal(map[string]string{"pod-2": "other"}))
 }
 
 func Test_sortCNByPriority(t *testing.T) {

--- a/pkg/controllers/cnclaim/controller_test.go
+++ b/pkg/controllers/cnclaim/controller_test.go
@@ -15,16 +15,143 @@
 package cnclaim
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 
 	"github.com/matrixorigin/matrixone-operator/api/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	. "github.com/onsi/gomega"
 )
+
+func newFakeClient(objs ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = v1alpha1.SchemeBuilder.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+// fakeKubeClient adapts client.Client to recon.KubeClient for testing.
+type fakeKubeClient struct {
+	client.Client
+}
+
+func (f *fakeKubeClient) Create(obj client.Object, opts ...client.CreateOption) error {
+	return f.Client.Create(context.TODO(), obj, opts...)
+}
+func (f *fakeKubeClient) CreateOwned(obj client.Object, opts ...client.CreateOption) error {
+	return f.Client.Create(context.TODO(), obj, opts...)
+}
+func (f *fakeKubeClient) Get(objKey client.ObjectKey, obj client.Object) error {
+	return f.Client.Get(context.TODO(), objKey, obj)
+}
+func (f *fakeKubeClient) Update(obj client.Object, opts ...client.UpdateOption) error {
+	return f.Client.Update(context.TODO(), obj, opts...)
+}
+func (f *fakeKubeClient) UpdateStatus(obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	return f.Client.Status().Update(context.TODO(), obj, opts...)
+}
+func (f *fakeKubeClient) Delete(obj client.Object, opts ...client.DeleteOption) error {
+	return f.Client.Delete(context.TODO(), obj, opts...)
+}
+func (f *fakeKubeClient) List(objList client.ObjectList, opts ...client.ListOption) error {
+	return f.Client.List(context.TODO(), objList, opts...)
+}
+func (f *fakeKubeClient) Patch(obj client.Object, mutateFn func() error, opts ...client.PatchOption) error {
+	return mutateFn()
+}
+func (f *fakeKubeClient) Exist(objKey client.ObjectKey, kind client.Object) (bool, error) {
+	err := f.Client.Get(context.TODO(), objKey, kind)
+	if err != nil {
+		return false, client.IgnoreNotFound(err)
+	}
+	return true, nil
+}
+
+func Test_podClaimedByOthers(t *testing.T) {
+	tests := []struct {
+		name         string
+		claims       []client.Object
+		podName      string
+		excludeClaim string
+		want         bool
+	}{
+		{
+			name:         "no claims exist",
+			claims:       nil,
+			podName:      "pod-1",
+			excludeClaim: "claim-a",
+			want:         false,
+		},
+		{
+			name: "pod only claimed by self",
+			claims: []client.Object{
+				&v1alpha1.CNClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "claim-a", Namespace: "ns"},
+					Spec:       v1alpha1.CNClaimSpec{ClaimPodRef: v1alpha1.ClaimPodRef{PodName: "pod-1"}},
+				},
+			},
+			podName:      "pod-1",
+			excludeClaim: "claim-a",
+			want:         false,
+		},
+		{
+			name: "pod claimed by another claim",
+			claims: []client.Object{
+				&v1alpha1.CNClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "claim-a", Namespace: "ns"},
+					Spec:       v1alpha1.CNClaimSpec{ClaimPodRef: v1alpha1.ClaimPodRef{PodName: "pod-1"}},
+				},
+				&v1alpha1.CNClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "claim-b", Namespace: "ns"},
+					Spec:       v1alpha1.CNClaimSpec{ClaimPodRef: v1alpha1.ClaimPodRef{PodName: "pod-1"}},
+				},
+			},
+			podName:      "pod-1",
+			excludeClaim: "claim-a",
+			want:         true,
+		},
+		{
+			name: "pod not claimed by anyone",
+			claims: []client.Object{
+				&v1alpha1.CNClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "claim-a", Namespace: "ns"},
+					Spec:       v1alpha1.CNClaimSpec{ClaimPodRef: v1alpha1.ClaimPodRef{PodName: "pod-2"}},
+				},
+			},
+			podName:      "pod-1",
+			excludeClaim: "claim-a",
+			want:         false,
+		},
+		{
+			name: "claim with empty podName is ignored",
+			claims: []client.Object{
+				&v1alpha1.CNClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "claim-pending", Namespace: "ns"},
+					Spec:       v1alpha1.CNClaimSpec{},
+				},
+			},
+			podName:      "pod-1",
+			excludeClaim: "claim-a",
+			want:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			cli := newFakeClient(tt.claims...)
+			got, err := podClaimedByOthers(&fakeKubeClient{cli}, "ns", tt.podName, tt.excludeClaim)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
 
 func Test_sortCNByPriority(t *testing.T) {
 	tests := []struct {

--- a/pkg/controllers/cnclaim/controller_test.go
+++ b/pkg/controllers/cnclaim/controller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Matrix Origin
+// Copyright 2025-2026 Matrix Origin
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## 变更说明

修复 CNClaim controller 在 CN Pod 迁移流程中的竞态条件：多个 CNClaim 可以同时绑定到同一个 CN Pod，删除其中一个 claim 后 Pod 被错误回收，破坏另一个 claim 的绑定关系。核心思路是以 `CNClaim.spec.podName` 为 Pod 归属的 source of truth，在 `selectCN()` 和 `Finalize()` 中增加 CNClaim 列表校验。

- 新增 `podClaimedByOthers()` helper：列出 namespace 下所有 CNClaim，检查是否有其他 claim 的 `spec.podName` 指向目标 Pod
- `selectCN()` 绑定前校验：在 `ensureOwnership()` 前调用 `podClaimedByOthers()` 跳过已被占用的 Pod
- `Finalize()` 回收前校验：回收 Pod 前检查是否有其他 CNClaim 仍引用该 Pod，有则跳过

### 核心变更

**1. CNClaim Controller (`pkg/controllers/cnclaim/controller.go`)**
- `selectCN()`: 在遍历 idle Pod 列表时，调用 `podClaimedByOthers()` 过滤已被其他 claim 绑定的 Pod
- `Finalize()`: 回收 Pod 前检查 `podClaimedByOthers()`，如果有其他 claim 引用则跳过回收
- 新增 `podClaimedByOthers()` 函数：列出 namespace 下所有 CNClaim，检查 `spec.podName` 是否匹配

### 调用链

```
selectCN()
  → sortCNByPriority(idleCNs)
  → for each idle pod:
      → podClaimedByOthers(pod.Name, claim.Name)  ← NEW: 跳过已被占用的 Pod
      → ensureOwnership(pod)                       ← 已有: optimistic lock

Finalize()
  → ListPods(Bound + ClaimedBy=self)
  → for each owned pod:
      → podClaimedByOthers(pod.Name, claim.Name)  ← NEW: 跳过被其他 claim 引用的 Pod
      → reclaimCN(pod)                             ← 已有: 设置 Draining
```

### 新增文件
| 文件 | 说明 |
|------|------|
| 无新增文件 | 所有变更在现有文件中 |

## 变更类型
- [ ] 新功能（向后兼容）
- [x] 缺陷修复（向后兼容）
- [ ] 破坏性变更（需要迁移指南）

## 影响范围
### 测试验证
- [x] 单元测试已添加/更新
- [ ] 集成测试已通过
- [ ] 手动测试已完成
- [ ] 性能测试已进行
- [x] **Issue修复必填**：已添加能够100%复现Issue的单元测试

#### UT 覆盖说明

**`podClaimedByOthers`** — 5 个 case（`controller_test.go`）

| 场景 | 输入 / mock 行为 | 期望结果 |
|------|------------------|----------|
| no claims exist | 空 CNClaim 列表 | 返回 false |
| pod only claimed by self | 仅自身 claim 引用该 Pod | 返回 false |
| pod claimed by another claim | 另一个 claim 的 spec.podName 指向同一 Pod | 返回 true |
| pod not claimed by anyone | 其他 claim 指向不同 Pod | 返回 false |
| claim with empty podName | pending claim 无 podName | 返回 false |

#### 回归验证（Bug Fix PR 专项）

`Test_podClaimedByOthers/pod_claimed_by_another_claim` 精确复现了 Issue #581 的竞态场景：两个 CNClaim 的 `spec.podName` 指向同一 Pod。修复前 `selectCN()` 不检查此条件会绑定成功；修复后返回 `true` 并跳过。

## 相关链接
- GitHub Issue: Fixes #581, Fixes #582, Fixes #585
- 设计文档: https://github.com/matrixorigin/matrixone-operator/issues/581#issuecomment-4318191622
