### PR TITLE
fix: fix CI checks — CRD regeneration, license config, and lint

### DIFF
--- a/.licenserc.yml
+++ b/.licenserc.yml
@@ -2,6 +2,9 @@ header:
   license:
     spdx-id: Apache-2.0
     copyright-owner: Matrix Origin
+    copyright-year: '2025'
+    pattern: |
+      Copyright 20[0-9][0-9](-20[0-9][0-9])? Matrix Origin
   paths-ignore:
     - 'docs/'
     - 'examples/'

--- a/api/core/v1alpha1/logset_types.go
+++ b/api/core/v1alpha1/logset_types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Matrix Origin
+// Copyright 2025-2026 Matrix Origin
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -105,25 +105,25 @@ type InitialConfig struct {
 	// LogShards is the initial number of log shards,
 	// cannot be tuned after cluster creation currently.
 	// default to 1
-	// +required
+	// +optional
 	LogShards *int `json:"logShards,omitempty"`
 
 	// DNShards is the initial number of DN shards,
 	// cannot be tuned after cluster creation currently.
 	// default to 1
-	// +required
+	// +optional
 	DNShards *int `json:"dnShards,omitempty"`
 
 	// HAKeeperReplicas is the initial number of HAKeeper replicas,
 	// cannot be tuned after cluster creation currently.
 	// default to 3 if LogSet replicas >= 3, to 1 otherwise
-	// +required
+	// +optional
 	// HAKeeperReplicas *int `json:"haKeeperReplicas,omitempty"`
 
 	// LogShardReplicas is the replica numbers of each log shard,
 	// cannot be tuned after cluster creation currently.
 	// default to 3 if LogSet replicas >= 3, to 1 otherwise
-	// +required
+	// +optional
 	LogShardReplicas *int `json:"logShardReplicas,omitempty"`
 
 	// RestoreFrom declares the HAKeeper data should be restored

--- a/api/core/v1alpha1/matrixonecluster_types.go
+++ b/api/core/v1alpha1/matrixonecluster_types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Matrix Origin
+// Copyright 2025-2026 Matrix Origin
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/api/core/v1alpha1/matrixonecluster_types.go
+++ b/api/core/v1alpha1/matrixonecluster_types.go
@@ -66,7 +66,7 @@ type MatrixOneClusterSpec struct {
 	// ImageRepository allows user to override the default image
 	// repository in order to use a docker registry proxy or private
 	// registry.
-	// +required
+	// +optional
 	ImageRepository string `json:"imageRepository,omitempty"`
 
 	// TopologyEvenSpread specifies default topology policy for all components,

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_backupjobs.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_backupjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: backupjobs.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -211,7 +211,6 @@ spec:
                             description: |-
                               Name of the referent.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -239,16 +238,8 @@ spec:
                 type: string
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -289,12 +280,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_backups.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_backups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: backups.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -126,7 +126,6 @@ spec:
                             description: |-
                               Name of the referent.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_bucketclaims.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_bucketclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: bucketclaims.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -106,7 +106,6 @@ spec:
                         description: |-
                           Name of the referent.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
@@ -120,6 +119,7 @@ spec:
                 type: object
             required:
             - logSetSpec
+            - s3
             type: object
           status:
             description: Status is the current state of BucketClaim
@@ -130,16 +130,8 @@ spec:
                 type: string
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -180,12 +172,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_cnclaims.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_cnclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: cnclaims.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_cnclaimsets.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_cnclaimsets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: cnclaimsets.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_cnpools.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_cnpools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: cnpools.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -53,11 +53,12 @@ spec:
                     description: |-
                       An external LogSet the CNSet should connected to,
                       mutual exclusive with LogSet
-                      TODO: rethink the schema of ExternalLogSet
                     properties:
                       haKeeperEndpoint:
                         description: HAKeeperEndpoint of the ExternalLogSet
                         type: string
+                    required:
+                    - haKeeperEndpoint
                     type: object
                   logSet:
                     description: The LogSet it depends on, mutual exclusive with ExternalLogSet
@@ -121,6 +122,8 @@ spec:
                           StorageClassName reference to the storageclass of the desired volume,
                           the default storageclass of the cluster would be used if no specified.
                         type: string
+                    required:
+                    - size
                     type: object
                   clusterDomain:
                     description: |-
@@ -228,10 +231,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -289,10 +290,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_cnsets.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_cnsets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: cnsets.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -47,11 +47,12 @@ spec:
                 description: |-
                   An external LogSet the CNSet should connected to,
                   mutual exclusive with LogSet
-                  TODO: rethink the schema of ExternalLogSet
                 properties:
                   haKeeperEndpoint:
                     description: HAKeeperEndpoint of the ExternalLogSet
                     type: string
+                required:
+                - haKeeperEndpoint
                 type: object
               logSet:
                 description: The LogSet it depends on, mutual exclusive with ExternalLogSet
@@ -95,6 +96,8 @@ spec:
                       StorageClassName reference to the storageclass of the desired volume,
                       the default storageclass of the cluster would be used if no specified.
                     type: string
+                required:
+                - size
                 type: object
               clusterDomain:
                 description: |-
@@ -202,10 +205,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -262,10 +263,8 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-
                       This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
-
 
                       This field is immutable. It can only be set for containers.
                     items:
@@ -429,16 +428,8 @@ spec:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -479,12 +470,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_dnsets.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_dnsets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: dnsets.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -43,11 +43,12 @@ spec:
                 description: |-
                   An external LogSet the CNSet should connected to,
                   mutual exclusive with LogSet
-                  TODO: rethink the schema of ExternalLogSet
                 properties:
                   haKeeperEndpoint:
                     description: HAKeeperEndpoint of the ExternalLogSet
                     type: string
+                required:
+                - haKeeperEndpoint
                 type: object
               logSet:
                 description: The LogSet it depends on, mutual exclusive with ExternalLogSet
@@ -91,6 +92,8 @@ spec:
                       StorageClassName reference to the storageclass of the desired volume,
                       the default storageclass of the cluster would be used if no specified.
                     type: string
+                required:
+                - size
                 type: object
               clusterDomain:
                 description: |-
@@ -156,10 +159,8 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-
                       This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
-
 
                       This field is immutable. It can only be set for containers.
                     items:
@@ -273,16 +274,8 @@ spec:
                 type: array
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -323,12 +316,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_logsets.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_logsets.yaml
@@ -102,10 +102,6 @@ spec:
                       RestoreFrom declares the HAKeeper data should be restored
                       from the given path when hakeeper is bootstrapped
                     type: string
-                required:
-                - dnShards
-                - logShardReplicas
-                - logShards
                 type: object
               memoryFsSize:
                 anyOf:

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_logsets.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_logsets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: logsets.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -102,6 +102,10 @@ spec:
                       RestoreFrom declares the HAKeeper data should be restored
                       from the given path when hakeeper is bootstrapped
                     type: string
+                required:
+                - dnShards
+                - logShardReplicas
+                - logShards
                 type: object
               memoryFsSize:
                 anyOf:
@@ -156,10 +160,8 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-
                       This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
-
 
                       This field is immutable. It can only be set for containers.
                     items:
@@ -286,7 +288,6 @@ spec:
                             description: |-
                               Name of the referent.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -334,6 +335,8 @@ spec:
                       StorageClassName reference to the storageclass of the desired volume,
                       the default storageclass of the cluster would be used if no specified.
                     type: string
+                required:
+                - size
                 type: object
             required:
             - replicas
@@ -341,7 +344,6 @@ spec:
             - volume
             type: object
           status:
-            description: 'TODO: figure out what status should be exposed'
             properties:
               availableStores:
                 items:
@@ -357,16 +359,8 @@ spec:
                 type: array
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -407,12 +401,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_matrixoneclusters.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_matrixoneclusters.yaml
@@ -1054,10 +1054,6 @@ spec:
                           RestoreFrom declares the HAKeeper data should be restored
                           from the given path when hakeeper is bootstrapped
                         type: string
-                    required:
-                    - dnShards
-                    - logShardReplicas
-                    - logShards
                     type: object
                   memoryFsSize:
                     anyOf:

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_matrixoneclusters.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_matrixoneclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: matrixoneclusters.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -87,6 +87,8 @@ spec:
                           StorageClassName reference to the storageclass of the desired volume,
                           the default storageclass of the cluster would be used if no specified.
                         type: string
+                    required:
+                    - size
                     type: object
                   clusterDomain:
                     description: |-
@@ -194,10 +196,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -255,10 +255,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -450,6 +448,8 @@ spec:
                             StorageClassName reference to the storageclass of the desired volume,
                             the default storageclass of the cluster would be used if no specified.
                           type: string
+                      required:
+                      - size
                       type: object
                     clusterDomain:
                       description: |-
@@ -562,10 +562,8 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-
                                 This is an alpha field and requires enabling the
                                 DynamicResourceAllocation feature gate.
-
 
                                 This field is immutable. It can only be set for containers.
                               items:
@@ -625,10 +623,8 @@ spec:
                             Claims lists the names of resources, defined in spec.resourceClaims,
                             that are used by this container.
 
-
                             This is an alpha field and requires enabling the
                             DynamicResourceAllocation feature gate.
-
 
                             This field is immutable. It can only be set for containers.
                           items:
@@ -825,6 +821,8 @@ spec:
                           StorageClassName reference to the storageclass of the desired volume,
                           the default storageclass of the cluster would be used if no specified.
                         type: string
+                    required:
+                    - size
                     type: object
                   clusterDomain:
                     description: |-
@@ -891,10 +889,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -1058,6 +1054,10 @@ spec:
                           RestoreFrom declares the HAKeeper data should be restored
                           from the given path when hakeeper is bootstrapped
                         type: string
+                    required:
+                    - dnShards
+                    - logShardReplicas
+                    - logShards
                     type: object
                   memoryFsSize:
                     anyOf:
@@ -1113,10 +1113,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -1243,7 +1241,6 @@ spec:
                                 description: |-
                                   Name of the referent.
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -1291,6 +1288,8 @@ spec:
                           StorageClassName reference to the storageclass of the desired volume,
                           the default storageclass of the cluster would be used if no specified.
                         type: string
+                    required:
+                    - size
                     type: object
                 required:
                 - replicas
@@ -1394,10 +1393,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -1522,6 +1519,8 @@ spec:
                           StorageClassName reference to the storageclass of the desired volume,
                           the default storageclass of the cluster would be used if no specified.
                         type: string
+                    required:
+                    - size
                     type: object
                   clusterDomain:
                     description: |-
@@ -1588,10 +1587,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -1725,6 +1722,8 @@ spec:
                           StorageClassName reference to the storageclass of the desired volume,
                           the default storageclass of the cluster would be used if no specified.
                         type: string
+                    required:
+                    - size
                     type: object
                   clusterDomain:
                     description: |-
@@ -1832,10 +1831,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -1893,10 +1890,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -2137,10 +2132,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -2259,7 +2252,6 @@ spec:
                         description: |-
                           Name of the referent.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
@@ -2288,16 +2280,8 @@ spec:
                 type: object
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -2338,12 +2322,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -2364,7 +2343,6 @@ spec:
                     description: |-
                       Name of the referent.
                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
@@ -2385,17 +2363,8 @@ spec:
                     type: array
                   conditions:
                     items:
-                      description: "Condition contains details for one aspect of the
-                        current state of this API Resource.\n---\nThis struct is intended
-                        for direct use as an array at the field path .status.conditions.
-                        \ For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents
-                        the observations of a foo's current state.\n\t    // Known
-                        .status.conditions.type are: \"Available\", \"Progressing\",
-                        and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t
-                        \   // +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                        []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                        patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                        \   // other fields\n\t}"
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
                       properties:
                         lastTransitionTime:
                           description: |-
@@ -2437,12 +2406,7 @@ spec:
                           - Unknown
                           type: string
                         type:
-                          description: |-
-                            type of condition in CamelCase or in foo.example.com/CamelCase.
-                            ---
-                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                            useful (see .node.status.conditions), the ability to deconflict is important.
-                            The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
                           maxLength: 316
                           pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                           type: string
@@ -2486,17 +2450,8 @@ spec:
                     type: array
                   conditions:
                     items:
-                      description: "Condition contains details for one aspect of the
-                        current state of this API Resource.\n---\nThis struct is intended
-                        for direct use as an array at the field path .status.conditions.
-                        \ For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents
-                        the observations of a foo's current state.\n\t    // Known
-                        .status.conditions.type are: \"Available\", \"Progressing\",
-                        and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t
-                        \   // +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                        []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                        patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                        \   // other fields\n\t}"
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
                       properties:
                         lastTransitionTime:
                           description: |-
@@ -2538,12 +2493,7 @@ spec:
                           - Unknown
                           type: string
                         type:
-                          description: |-
-                            type of condition in CamelCase or in foo.example.com/CamelCase.
-                            ---
-                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                            useful (see .node.status.conditions), the ability to deconflict is important.
-                            The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
                           maxLength: 316
                           pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                           type: string
@@ -2588,17 +2538,8 @@ spec:
                 properties:
                   conditions:
                     items:
-                      description: "Condition contains details for one aspect of the
-                        current state of this API Resource.\n---\nThis struct is intended
-                        for direct use as an array at the field path .status.conditions.
-                        \ For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents
-                        the observations of a foo's current state.\n\t    // Known
-                        .status.conditions.type are: \"Available\", \"Progressing\",
-                        and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t
-                        \   // +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                        []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                        patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                        \   // other fields\n\t}"
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
                       properties:
                         lastTransitionTime:
                           description: |-
@@ -2640,12 +2581,7 @@ spec:
                           - Unknown
                           type: string
                         type:
-                          description: |-
-                            type of condition in CamelCase or in foo.example.com/CamelCase.
-                            ---
-                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                            useful (see .node.status.conditions), the ability to deconflict is important.
-                            The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
                           maxLength: 316
                           pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                           type: string
@@ -2689,17 +2625,8 @@ spec:
                     type: array
                   conditions:
                     items:
-                      description: "Condition contains details for one aspect of the
-                        current state of this API Resource.\n---\nThis struct is intended
-                        for direct use as an array at the field path .status.conditions.
-                        \ For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents
-                        the observations of a foo's current state.\n\t    // Known
-                        .status.conditions.type are: \"Available\", \"Progressing\",
-                        and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t
-                        \   // +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                        []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                        patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                        \   // other fields\n\t}"
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
                       properties:
                         lastTransitionTime:
                           description: |-
@@ -2741,12 +2668,7 @@ spec:
                           - Unknown
                           type: string
                         type:
-                          description: |-
-                            type of condition in CamelCase or in foo.example.com/CamelCase.
-                            ---
-                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                            useful (see .node.status.conditions), the ability to deconflict is important.
-                            The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
                           maxLength: 316
                           pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                           type: string

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_proxysets.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_proxysets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: proxysets.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -44,11 +44,12 @@ spec:
                 description: |-
                   An external LogSet the CNSet should connected to,
                   mutual exclusive with LogSet
-                  TODO: rethink the schema of ExternalLogSet
                 properties:
                   haKeeperEndpoint:
                     description: HAKeeperEndpoint of the ExternalLogSet
                     type: string
+                required:
+                - haKeeperEndpoint
                 type: object
               logSet:
                 description: The LogSet it depends on, mutual exclusive with ExternalLogSet
@@ -141,10 +142,8 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-
                       This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
-
 
                       This field is immutable. It can only be set for containers.
                     items:
@@ -235,16 +234,8 @@ spec:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -285,12 +276,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_restorejobs.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_restorejobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: restorejobs.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -198,7 +198,6 @@ spec:
                             description: |-
                               Name of the referent.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -278,7 +277,6 @@ spec:
                             description: |-
                               Name of the referent.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -303,16 +301,8 @@ spec:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -353,12 +343,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/charts/matrixone-operator/templates/crds/core.matrixorigin.io_webuis.yaml
+++ b/charts/matrixone-operator/templates/crds/core.matrixorigin.io_webuis.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: webuis.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -125,10 +125,8 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-
                       This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
-
 
                       This field is immutable. It can only be set for containers.
                     items:
@@ -242,16 +240,8 @@ spec:
                 type: array
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -292,12 +282,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/deploy/crds/core.matrixorigin.io_backupjobs.yaml
+++ b/deploy/crds/core.matrixorigin.io_backupjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: backupjobs.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -211,7 +211,6 @@ spec:
                             description: |-
                               Name of the referent.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -239,16 +238,8 @@ spec:
                 type: string
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -289,12 +280,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/deploy/crds/core.matrixorigin.io_backups.yaml
+++ b/deploy/crds/core.matrixorigin.io_backups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: backups.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -126,7 +126,6 @@ spec:
                             description: |-
                               Name of the referent.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic

--- a/deploy/crds/core.matrixorigin.io_bucketclaims.yaml
+++ b/deploy/crds/core.matrixorigin.io_bucketclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: bucketclaims.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -106,7 +106,6 @@ spec:
                         description: |-
                           Name of the referent.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
@@ -120,6 +119,7 @@ spec:
                 type: object
             required:
             - logSetSpec
+            - s3
             type: object
           status:
             description: Status is the current state of BucketClaim
@@ -130,16 +130,8 @@ spec:
                 type: string
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -180,12 +172,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/deploy/crds/core.matrixorigin.io_cnclaims.yaml
+++ b/deploy/crds/core.matrixorigin.io_cnclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: cnclaims.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io

--- a/deploy/crds/core.matrixorigin.io_cnclaimsets.yaml
+++ b/deploy/crds/core.matrixorigin.io_cnclaimsets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: cnclaimsets.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io

--- a/deploy/crds/core.matrixorigin.io_cnpools.yaml
+++ b/deploy/crds/core.matrixorigin.io_cnpools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: cnpools.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -53,11 +53,12 @@ spec:
                     description: |-
                       An external LogSet the CNSet should connected to,
                       mutual exclusive with LogSet
-                      TODO: rethink the schema of ExternalLogSet
                     properties:
                       haKeeperEndpoint:
                         description: HAKeeperEndpoint of the ExternalLogSet
                         type: string
+                    required:
+                    - haKeeperEndpoint
                     type: object
                   logSet:
                     description: The LogSet it depends on, mutual exclusive with ExternalLogSet
@@ -121,6 +122,8 @@ spec:
                           StorageClassName reference to the storageclass of the desired volume,
                           the default storageclass of the cluster would be used if no specified.
                         type: string
+                    required:
+                    - size
                     type: object
                   clusterDomain:
                     description: |-
@@ -228,10 +231,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -289,10 +290,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:

--- a/deploy/crds/core.matrixorigin.io_cnsets.yaml
+++ b/deploy/crds/core.matrixorigin.io_cnsets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: cnsets.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -47,11 +47,12 @@ spec:
                 description: |-
                   An external LogSet the CNSet should connected to,
                   mutual exclusive with LogSet
-                  TODO: rethink the schema of ExternalLogSet
                 properties:
                   haKeeperEndpoint:
                     description: HAKeeperEndpoint of the ExternalLogSet
                     type: string
+                required:
+                - haKeeperEndpoint
                 type: object
               logSet:
                 description: The LogSet it depends on, mutual exclusive with ExternalLogSet
@@ -95,6 +96,8 @@ spec:
                       StorageClassName reference to the storageclass of the desired volume,
                       the default storageclass of the cluster would be used if no specified.
                     type: string
+                required:
+                - size
                 type: object
               clusterDomain:
                 description: |-
@@ -202,10 +205,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -262,10 +263,8 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-
                       This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
-
 
                       This field is immutable. It can only be set for containers.
                     items:
@@ -429,16 +428,8 @@ spec:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -479,12 +470,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/deploy/crds/core.matrixorigin.io_dnsets.yaml
+++ b/deploy/crds/core.matrixorigin.io_dnsets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: dnsets.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -43,11 +43,12 @@ spec:
                 description: |-
                   An external LogSet the CNSet should connected to,
                   mutual exclusive with LogSet
-                  TODO: rethink the schema of ExternalLogSet
                 properties:
                   haKeeperEndpoint:
                     description: HAKeeperEndpoint of the ExternalLogSet
                     type: string
+                required:
+                - haKeeperEndpoint
                 type: object
               logSet:
                 description: The LogSet it depends on, mutual exclusive with ExternalLogSet
@@ -91,6 +92,8 @@ spec:
                       StorageClassName reference to the storageclass of the desired volume,
                       the default storageclass of the cluster would be used if no specified.
                     type: string
+                required:
+                - size
                 type: object
               clusterDomain:
                 description: |-
@@ -156,10 +159,8 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-
                       This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
-
 
                       This field is immutable. It can only be set for containers.
                     items:
@@ -273,16 +274,8 @@ spec:
                 type: array
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -323,12 +316,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/deploy/crds/core.matrixorigin.io_logsets.yaml
+++ b/deploy/crds/core.matrixorigin.io_logsets.yaml
@@ -102,10 +102,6 @@ spec:
                       RestoreFrom declares the HAKeeper data should be restored
                       from the given path when hakeeper is bootstrapped
                     type: string
-                required:
-                - dnShards
-                - logShardReplicas
-                - logShards
                 type: object
               memoryFsSize:
                 anyOf:

--- a/deploy/crds/core.matrixorigin.io_logsets.yaml
+++ b/deploy/crds/core.matrixorigin.io_logsets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: logsets.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -102,6 +102,10 @@ spec:
                       RestoreFrom declares the HAKeeper data should be restored
                       from the given path when hakeeper is bootstrapped
                     type: string
+                required:
+                - dnShards
+                - logShardReplicas
+                - logShards
                 type: object
               memoryFsSize:
                 anyOf:
@@ -156,10 +160,8 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-
                       This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
-
 
                       This field is immutable. It can only be set for containers.
                     items:
@@ -286,7 +288,6 @@ spec:
                             description: |-
                               Name of the referent.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -334,6 +335,8 @@ spec:
                       StorageClassName reference to the storageclass of the desired volume,
                       the default storageclass of the cluster would be used if no specified.
                     type: string
+                required:
+                - size
                 type: object
             required:
             - replicas
@@ -341,7 +344,6 @@ spec:
             - volume
             type: object
           status:
-            description: 'TODO: figure out what status should be exposed'
             properties:
               availableStores:
                 items:
@@ -357,16 +359,8 @@ spec:
                 type: array
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -407,12 +401,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/deploy/crds/core.matrixorigin.io_matrixoneclusters.yaml
+++ b/deploy/crds/core.matrixorigin.io_matrixoneclusters.yaml
@@ -1054,10 +1054,6 @@ spec:
                           RestoreFrom declares the HAKeeper data should be restored
                           from the given path when hakeeper is bootstrapped
                         type: string
-                    required:
-                    - dnShards
-                    - logShardReplicas
-                    - logShards
                     type: object
                   memoryFsSize:
                     anyOf:

--- a/deploy/crds/core.matrixorigin.io_matrixoneclusters.yaml
+++ b/deploy/crds/core.matrixorigin.io_matrixoneclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: matrixoneclusters.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -87,6 +87,8 @@ spec:
                           StorageClassName reference to the storageclass of the desired volume,
                           the default storageclass of the cluster would be used if no specified.
                         type: string
+                    required:
+                    - size
                     type: object
                   clusterDomain:
                     description: |-
@@ -194,10 +196,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -255,10 +255,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -450,6 +448,8 @@ spec:
                             StorageClassName reference to the storageclass of the desired volume,
                             the default storageclass of the cluster would be used if no specified.
                           type: string
+                      required:
+                      - size
                       type: object
                     clusterDomain:
                       description: |-
@@ -562,10 +562,8 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-
                                 This is an alpha field and requires enabling the
                                 DynamicResourceAllocation feature gate.
-
 
                                 This field is immutable. It can only be set for containers.
                               items:
@@ -625,10 +623,8 @@ spec:
                             Claims lists the names of resources, defined in spec.resourceClaims,
                             that are used by this container.
 
-
                             This is an alpha field and requires enabling the
                             DynamicResourceAllocation feature gate.
-
 
                             This field is immutable. It can only be set for containers.
                           items:
@@ -825,6 +821,8 @@ spec:
                           StorageClassName reference to the storageclass of the desired volume,
                           the default storageclass of the cluster would be used if no specified.
                         type: string
+                    required:
+                    - size
                     type: object
                   clusterDomain:
                     description: |-
@@ -891,10 +889,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -1058,6 +1054,10 @@ spec:
                           RestoreFrom declares the HAKeeper data should be restored
                           from the given path when hakeeper is bootstrapped
                         type: string
+                    required:
+                    - dnShards
+                    - logShardReplicas
+                    - logShards
                     type: object
                   memoryFsSize:
                     anyOf:
@@ -1113,10 +1113,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -1243,7 +1241,6 @@ spec:
                                 description: |-
                                   Name of the referent.
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -1291,6 +1288,8 @@ spec:
                           StorageClassName reference to the storageclass of the desired volume,
                           the default storageclass of the cluster would be used if no specified.
                         type: string
+                    required:
+                    - size
                     type: object
                 required:
                 - replicas
@@ -1394,10 +1393,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -1522,6 +1519,8 @@ spec:
                           StorageClassName reference to the storageclass of the desired volume,
                           the default storageclass of the cluster would be used if no specified.
                         type: string
+                    required:
+                    - size
                     type: object
                   clusterDomain:
                     description: |-
@@ -1588,10 +1587,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -1725,6 +1722,8 @@ spec:
                           StorageClassName reference to the storageclass of the desired volume,
                           the default storageclass of the cluster would be used if no specified.
                         type: string
+                    required:
+                    - size
                     type: object
                   clusterDomain:
                     description: |-
@@ -1832,10 +1831,8 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-
                               This is an alpha field and requires enabling the
                               DynamicResourceAllocation feature gate.
-
 
                               This field is immutable. It can only be set for containers.
                             items:
@@ -1893,10 +1890,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -2137,10 +2132,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -2259,7 +2252,6 @@ spec:
                         description: |-
                           Name of the referent.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
@@ -2288,16 +2280,8 @@ spec:
                 type: object
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -2338,12 +2322,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -2364,7 +2343,6 @@ spec:
                     description: |-
                       Name of the referent.
                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
@@ -2385,17 +2363,8 @@ spec:
                     type: array
                   conditions:
                     items:
-                      description: "Condition contains details for one aspect of the
-                        current state of this API Resource.\n---\nThis struct is intended
-                        for direct use as an array at the field path .status.conditions.
-                        \ For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents
-                        the observations of a foo's current state.\n\t    // Known
-                        .status.conditions.type are: \"Available\", \"Progressing\",
-                        and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t
-                        \   // +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                        []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                        patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                        \   // other fields\n\t}"
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
                       properties:
                         lastTransitionTime:
                           description: |-
@@ -2437,12 +2406,7 @@ spec:
                           - Unknown
                           type: string
                         type:
-                          description: |-
-                            type of condition in CamelCase or in foo.example.com/CamelCase.
-                            ---
-                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                            useful (see .node.status.conditions), the ability to deconflict is important.
-                            The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
                           maxLength: 316
                           pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                           type: string
@@ -2486,17 +2450,8 @@ spec:
                     type: array
                   conditions:
                     items:
-                      description: "Condition contains details for one aspect of the
-                        current state of this API Resource.\n---\nThis struct is intended
-                        for direct use as an array at the field path .status.conditions.
-                        \ For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents
-                        the observations of a foo's current state.\n\t    // Known
-                        .status.conditions.type are: \"Available\", \"Progressing\",
-                        and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t
-                        \   // +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                        []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                        patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                        \   // other fields\n\t}"
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
                       properties:
                         lastTransitionTime:
                           description: |-
@@ -2538,12 +2493,7 @@ spec:
                           - Unknown
                           type: string
                         type:
-                          description: |-
-                            type of condition in CamelCase or in foo.example.com/CamelCase.
-                            ---
-                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                            useful (see .node.status.conditions), the ability to deconflict is important.
-                            The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
                           maxLength: 316
                           pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                           type: string
@@ -2588,17 +2538,8 @@ spec:
                 properties:
                   conditions:
                     items:
-                      description: "Condition contains details for one aspect of the
-                        current state of this API Resource.\n---\nThis struct is intended
-                        for direct use as an array at the field path .status.conditions.
-                        \ For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents
-                        the observations of a foo's current state.\n\t    // Known
-                        .status.conditions.type are: \"Available\", \"Progressing\",
-                        and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t
-                        \   // +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                        []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                        patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                        \   // other fields\n\t}"
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
                       properties:
                         lastTransitionTime:
                           description: |-
@@ -2640,12 +2581,7 @@ spec:
                           - Unknown
                           type: string
                         type:
-                          description: |-
-                            type of condition in CamelCase or in foo.example.com/CamelCase.
-                            ---
-                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                            useful (see .node.status.conditions), the ability to deconflict is important.
-                            The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
                           maxLength: 316
                           pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                           type: string
@@ -2689,17 +2625,8 @@ spec:
                     type: array
                   conditions:
                     items:
-                      description: "Condition contains details for one aspect of the
-                        current state of this API Resource.\n---\nThis struct is intended
-                        for direct use as an array at the field path .status.conditions.
-                        \ For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents
-                        the observations of a foo's current state.\n\t    // Known
-                        .status.conditions.type are: \"Available\", \"Progressing\",
-                        and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t
-                        \   // +listType=map\n\t    // +listMapKey=type\n\t    Conditions
-                        []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
-                        patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                        \   // other fields\n\t}"
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
                       properties:
                         lastTransitionTime:
                           description: |-
@@ -2741,12 +2668,7 @@ spec:
                           - Unknown
                           type: string
                         type:
-                          description: |-
-                            type of condition in CamelCase or in foo.example.com/CamelCase.
-                            ---
-                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                            useful (see .node.status.conditions), the ability to deconflict is important.
-                            The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
                           maxLength: 316
                           pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                           type: string

--- a/deploy/crds/core.matrixorigin.io_proxysets.yaml
+++ b/deploy/crds/core.matrixorigin.io_proxysets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: proxysets.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -44,11 +44,12 @@ spec:
                 description: |-
                   An external LogSet the CNSet should connected to,
                   mutual exclusive with LogSet
-                  TODO: rethink the schema of ExternalLogSet
                 properties:
                   haKeeperEndpoint:
                     description: HAKeeperEndpoint of the ExternalLogSet
                     type: string
+                required:
+                - haKeeperEndpoint
                 type: object
               logSet:
                 description: The LogSet it depends on, mutual exclusive with ExternalLogSet
@@ -141,10 +142,8 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-
                       This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
-
 
                       This field is immutable. It can only be set for containers.
                     items:
@@ -235,16 +234,8 @@ spec:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -285,12 +276,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/deploy/crds/core.matrixorigin.io_restorejobs.yaml
+++ b/deploy/crds/core.matrixorigin.io_restorejobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: restorejobs.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -198,7 +198,6 @@ spec:
                             description: |-
                               Name of the referent.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -278,7 +277,6 @@ spec:
                             description: |-
                               Name of the referent.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -303,16 +301,8 @@ spec:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -353,12 +343,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/deploy/crds/core.matrixorigin.io_webuis.yaml
+++ b/deploy/crds/core.matrixorigin.io_webuis.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.0
   name: webuis.core.matrixorigin.io
 spec:
   group: core.matrixorigin.io
@@ -125,10 +125,8 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-
                       This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
-
 
                       This field is immutable. It can only be set for containers.
                     items:
@@ -242,16 +240,8 @@ spec:
                 type: array
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -292,12 +282,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/pkg/controllers/cnclaim/controller_test.go
+++ b/pkg/controllers/cnclaim/controller_test.go
@@ -63,7 +63,7 @@ func (f *fakeKubeClient) Delete(obj client.Object, opts ...client.DeleteOption) 
 func (f *fakeKubeClient) List(objList client.ObjectList, opts ...client.ListOption) error {
 	return f.Client.List(context.TODO(), objList, opts...)
 }
-func (f *fakeKubeClient) Patch(obj client.Object, mutateFn func() error, opts ...client.PatchOption) error {
+func (f *fakeKubeClient) Patch(_ client.Object, mutateFn func() error, _ ...client.PatchOption) error {
 	return mutateFn()
 }
 func (f *fakeKubeClient) Exist(objKey client.ObjectKey, kind client.Object) (bool, error) {

--- a/pkg/webhook/cnset_webhook_test.go
+++ b/pkg/webhook/cnset_webhook_test.go
@@ -79,7 +79,7 @@ var _ = Describe("CNSet Webhook", func() {
 			},
 			Deps: v1alpha1.CNSetDeps{
 				LogSetRef: v1alpha1.LogSetRef{
-					ExternalLogSet: &v1alpha1.ExternalLogSet{},
+					ExternalLogSet: &v1alpha1.ExternalLogSet{HAKeeperEndpoint: "test"},
 				},
 			},
 		}
@@ -104,7 +104,7 @@ var _ = Describe("CNSet Webhook", func() {
 			},
 			Deps: v1alpha1.CNSetDeps{
 				LogSetRef: v1alpha1.LogSetRef{
-					ExternalLogSet: &v1alpha1.ExternalLogSet{},
+					ExternalLogSet: &v1alpha1.ExternalLogSet{HAKeeperEndpoint: "test"},
 				},
 			},
 		}

--- a/pkg/webhook/cnset_webhook_test.go
+++ b/pkg/webhook/cnset_webhook_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Matrix Origin
+// Copyright 2025-2026 Matrix Origin
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/webhook/dnset_webhook_test.go
+++ b/pkg/webhook/dnset_webhook_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Matrix Origin
+// Copyright 2025-2026 Matrix Origin
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/webhook/dnset_webhook_test.go
+++ b/pkg/webhook/dnset_webhook_test.go
@@ -77,7 +77,7 @@ var _ = Describe("DNSet Webhook", func() {
 			},
 			Deps: v1alpha1.DNSetDeps{
 				LogSetRef: v1alpha1.LogSetRef{
-					ExternalLogSet: &v1alpha1.ExternalLogSet{},
+					ExternalLogSet: &v1alpha1.ExternalLogSet{HAKeeperEndpoint: "test"},
 				},
 			},
 		}
@@ -110,7 +110,7 @@ var _ = Describe("DNSet Webhook", func() {
 			},
 			Deps: v1alpha1.DNSetDeps{
 				LogSetRef: v1alpha1.LogSetRef{
-					ExternalLogSet: &v1alpha1.ExternalLogSet{},
+					ExternalLogSet: &v1alpha1.ExternalLogSet{HAKeeperEndpoint: "test"},
 				},
 			},
 		}

--- a/pkg/webhook/proxy_webhook_test.go
+++ b/pkg/webhook/proxy_webhook_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Matrix Origin
+// Copyright 2025-2026 Matrix Origin
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/webhook/proxy_webhook_test.go
+++ b/pkg/webhook/proxy_webhook_test.go
@@ -42,7 +42,7 @@ var _ = Describe("ProxySet Webhook", func() {
 			},
 			Deps: v1alpha1.ProxySetDeps{
 				LogSetRef: v1alpha1.LogSetRef{
-					ExternalLogSet: &v1alpha1.ExternalLogSet{},
+					ExternalLogSet: &v1alpha1.ExternalLogSet{HAKeeperEndpoint: "test"},
 				},
 			},
 		}


### PR DESCRIPTION
## Summary

This PR fixes the `test_workflows / checks` CI failure on `main` caused by stale CRDs, license header validation, and a lint warning.

### Changes

1. **Fix `+required` / `+optional` markers** — align kubebuilder markers with actual field semantics:
   - `MatrixOneClusterSpec.ImageRepository`: `+required` → `+optional` — optional override for the default image repository
   - `InitialConfig.LogShards`: `+required` → `+optional` — webhook defaults to 1
   - `InitialConfig.DNShards`: `+required` → `+optional` — webhook defaults to 1
   - `InitialConfig.LogShardReplicas`: `+required` → `+optional` — webhook defaults to 3 (or 1)

2. **Fix webhook tests** (`cnset_webhook_test.go`, `dnset_webhook_test.go`, `proxy_webhook_test.go`): Provide `HAKeeperEndpoint: "test"` when creating `ExternalLogSet` objects

3. **Regenerate CRDs**: All CRD manifests regenerated with controller-gen v0.16.0

4. **Fix license check** (`.licenserc.yml`): Add `copyright-year` and `pattern` to accept year-range headers (`Copyright 2025-2026`)

5. **Fix lint warning** (`pkg/controllers/cnclaim/controller_test.go`): Rename unused params to `_`

### Fields that remain `+required` and why

| Field | Reason |
|-------|--------|
| `ExternalLogSet.HAKeeperEndpoint` | An ExternalLogSet without an endpoint is meaningless — it's the only field in the struct |
| `Volume.Size` | A volume must have a size; there is no sensible default |
| `S3Provider.Path` | S3 storage path is required to locate data |
| `NFSProvider.Path` | NFS mount path is required |
| `CertificateRef.Name` | Certificate secret reference must have a name |
| `CertificateRef.Files` | Certificate must specify which files to use |
| `LogSetSpec.Volume` | LogSet requires persistent storage |
| `LogSetSpec.SharedStorage` | LogSet requires shared storage configuration |
| `BucketClaimSpec.S3` | BucketClaim must specify a storage provider |
| `MatrixOneClusterSpec.Version` | Cluster must have a version to select container images |
| `CNGroup.Name` | CN groups must be named for identification |

### Root Cause

controller-gen v0.16.0 properly enforces `+required` markers in CRD OpenAPI schemas. The committed CRDs were generated with an older version that silently ignored the mismatch between `+required` and `omitempty`. Several fields were incorrectly marked `+required` when they are actually optional with webhook defaults.

## Test plan
- [x] CI `checks` job passes
- [x] CI `e2e` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)