### PR TITLE
fix: generate cn monitor service like dn/log

### DIFF
--- a/pkg/controllers/cnset/controller.go
+++ b/pkg/controllers/cnset/controller.go
@@ -16,6 +16,7 @@ package cnset
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/matrixorigin/matrixone-operator/api/features"
@@ -91,6 +92,10 @@ func (c *Actor) Observe(ctx *recon.Context[*v1alpha1.CNSet]) (recon.Action[*v1al
 		return nil
 	}); err != nil {
 		return nil, errors.WrapPrefix(err, "sync service", 0)
+	}
+
+	if err := c.syncMetricService(ctx); err != nil {
+		return nil, errors.WrapPrefix(err, "sync metric service", 0)
 	}
 
 	// diff desired cloneset and determine whether should an update be invoked
@@ -184,6 +189,41 @@ func (c *Actor) Observe(ctx *recon.Context[*v1alpha1.CNSet]) (recon.Action[*v1al
 	return nil, recon.ErrReSync("cnset is not ready or synced", reSyncAfter)
 }
 
+// syncMetricService reconciles a dedicated ClusterIP Service exposing the CN metrics port,
+// so that Service-based Prometheus discovery (e.g. ServiceMonitor matching on port name
+// "metric") can find CN targets the same way it already does for DN/Log (issue #600).
+func (c *Actor) syncMetricService(ctx *recon.Context[*v1alpha1.CNSet]) error {
+	cn := ctx.Obj
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cn.Namespace,
+			Name:      metricSvcName(cn),
+			Labels:    common.SubResourceLabels(cn),
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: common.SubResourceLabels(cn),
+		},
+	}
+	return recon.CreateOwnedOrUpdate(ctx, svc, func() error {
+		svc.Spec.Type = corev1.ServiceTypeClusterIP
+		svc.Spec.Ports = []corev1.ServicePort{{
+			Name: "metric",
+			Port: int32(common.MetricsPort),
+		}}
+		if cn.Spec.PromDiscoveredByService() {
+			if svc.Annotations == nil {
+				svc.Annotations = map[string]string{}
+			}
+			svc.Annotations[common.PrometheusScrapeAnno] = "true"
+			svc.Annotations[common.PrometheusPortAnno] = strconv.Itoa(common.MetricsPort)
+		} else {
+			delete(svc.Annotations, common.PrometheusScrapeAnno)
+			delete(svc.Annotations, common.PrometheusPortAnno)
+		}
+		return nil
+	})
+}
+
 func (c *WithResources) Scale(ctx *recon.Context[*v1alpha1.CNSet]) error {
 	return ctx.Patch(c.cs, func() error {
 		scaleSet(ctx.Obj, c.cs)
@@ -208,6 +248,8 @@ func (c *Actor) Finalize(ctx *recon.Context[*v1alpha1.CNSet]) (bool, error) {
 		Name: setName(cn),
 	}}, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
 		Name: svcName(cn),
+	}}, &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: metricSvcName(cn),
 	}}}
 	for _, obj := range objs {
 		obj.SetNamespace(cn.Namespace)

--- a/pkg/controllers/cnset/controller_test.go
+++ b/pkg/controllers/cnset/controller_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Matrix Origin
+// Copyright 2025-2026 Matrix Origin
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 package cnset
 
 import (
+	"context"
+	"strconv"
 	"testing"
 
 	kruisev1alpha1 "github.com/openkruise/kruise-api/apps/v1alpha1"
@@ -36,6 +38,148 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func baseCNSetForMetricSvcTest() *v1alpha1.CNSet {
+	return &v1alpha1.CNSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test",
+			UID:       "test-uid",
+		},
+		Spec: v1alpha1.CNSetSpec{
+			PodSet: v1alpha1.PodSet{
+				MainContainer: v1alpha1.MainContainer{
+					Image: "test:latest",
+				},
+				Replicas: 1,
+			},
+		},
+	}
+}
+
+func enableCNPromServiceDiscovery(cn *v1alpha1.CNSet) {
+	cn.Spec.ExportToPrometheus = pointer.Bool(true)
+	scheme := v1alpha1.PromDiscoverySchemeService
+	cn.Spec.PromDiscoveryScheme = &scheme
+}
+
+// Test_syncMetricService is a regression test for issue #600: CNSet must reconcile a
+// dedicated metric Service so ServiceMonitor can match on port name "metric".
+func Test_syncMetricService(t *testing.T) {
+	s := newScheme()
+	labels := common.SubResourceLabels(baseCNSetForMetricSvcTest())
+
+	tests := []struct {
+		name   string
+		cnset  *v1alpha1.CNSet
+		client client.Client
+		setup  func(cn *v1alpha1.CNSet)
+		expect func(g *WithT, cn *v1alpha1.CNSet, cli client.Client, err error)
+	}{
+		{
+			name:  "creates metric service with prom annotations when export enabled",
+			cnset: baseCNSetForMetricSvcTest(),
+			client: &fake.Client{
+				Client: fake.KubeClientBuilder().WithScheme(s).Build(),
+			},
+			setup: enableCNPromServiceDiscovery,
+			expect: func(g *WithT, cn *v1alpha1.CNSet, cli client.Client, err error) {
+				g.Expect(err).To(BeNil())
+
+				svc := &corev1.Service{}
+				g.Expect(cli.Get(context.Background(), client.ObjectKey{
+					Namespace: cn.Namespace,
+					Name:      metricSvcName(cn),
+				}, svc)).To(Succeed())
+
+				g.Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+				g.Expect(svc.Spec.Ports).To(HaveLen(1))
+				g.Expect(svc.Spec.Ports[0].Name).To(Equal("metric"))
+				g.Expect(svc.Spec.Ports[0].Port).To(Equal(int32(common.MetricsPort)))
+				g.Expect(svc.Labels).To(Equal(labels))
+				g.Expect(svc.Spec.Selector).To(Equal(labels))
+				g.Expect(svc.Annotations[common.PrometheusScrapeAnno]).To(Equal("true"))
+				g.Expect(svc.Annotations[common.PrometheusPortAnno]).To(Equal(strconv.Itoa(common.MetricsPort)))
+			},
+		},
+		{
+			name:  "creates metric service without prom annotations when export disabled",
+			cnset: baseCNSetForMetricSvcTest(),
+			client: &fake.Client{
+				Client: fake.KubeClientBuilder().WithScheme(s).Build(),
+			},
+			expect: func(g *WithT, cn *v1alpha1.CNSet, cli client.Client, err error) {
+				g.Expect(err).To(BeNil())
+
+				svc := &corev1.Service{}
+				g.Expect(cli.Get(context.Background(), client.ObjectKey{
+					Namespace: cn.Namespace,
+					Name:      metricSvcName(cn),
+				}, svc)).To(Succeed())
+
+				g.Expect(svc.Spec.Ports).To(HaveLen(1))
+				g.Expect(svc.Spec.Ports[0].Name).To(Equal("metric"))
+				g.Expect(svc.Annotations).NotTo(HaveKey(common.PrometheusScrapeAnno))
+				g.Expect(svc.Annotations).NotTo(HaveKey(common.PrometheusPortAnno))
+			},
+		},
+		{
+			name:  "removes stale prom annotations when export disabled",
+			cnset: baseCNSetForMetricSvcTest(),
+			client: &fake.Client{
+				Client: fake.KubeClientBuilder().WithScheme(s).WithObjects(
+					&corev1.Service{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      metricSvcName(baseCNSetForMetricSvcTest()),
+							Labels:    labels,
+							Annotations: map[string]string{
+								common.PrometheusScrapeAnno: "true",
+								common.PrometheusPortAnno:   strconv.Itoa(common.MetricsPort),
+							},
+						},
+						Spec: corev1.ServiceSpec{
+							Type:     corev1.ServiceTypeClusterIP,
+							Selector: labels,
+							Ports: []corev1.ServicePort{{
+								Name: "metric",
+								Port: int32(common.MetricsPort),
+							}},
+						},
+					},
+				).Build(),
+			},
+			expect: func(g *WithT, cn *v1alpha1.CNSet, cli client.Client, err error) {
+				g.Expect(err).To(BeNil())
+
+				svc := &corev1.Service{}
+				g.Expect(cli.Get(context.Background(), client.ObjectKey{
+					Namespace: cn.Namespace,
+					Name:      metricSvcName(cn),
+				}, svc)).To(Succeed())
+				g.Expect(svc.Annotations).NotTo(HaveKey(common.PrometheusScrapeAnno))
+				g.Expect(svc.Annotations).NotTo(HaveKey(common.PrometheusPortAnno))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			cn := tt.cnset.DeepCopy()
+			if tt.setup != nil {
+				tt.setup(cn)
+			}
+
+			mockCtrl := gomock.NewController(t)
+			eventEmitter := fake.NewMockEventEmitter(mockCtrl)
+			ctx := fake.NewContext(cn, tt.client, eventEmitter)
+
+			err := (&Actor{}).syncMetricService(ctx)
+			tt.expect(g, cn, tt.client, err)
+		})
+	}
+}
 
 func TestCNSetActor_Observe(t *testing.T) {
 	s := newScheme()

--- a/pkg/controllers/cnset/resource.go
+++ b/pkg/controllers/cnset/resource.go
@@ -157,6 +157,7 @@ func syncService(cn *v1alpha1.CNSet, svc *corev1.Service) {
 		svc.Annotations[common.PrometheusPortAnno] = strconv.Itoa(common.MetricsPort)
 	} else {
 		delete(svc.Annotations, common.PrometheusScrapeAnno)
+		delete(svc.Annotations, common.PrometheusPortAnno)
 	}
 }
 

--- a/pkg/controllers/cnset/utils.go
+++ b/pkg/controllers/cnset/utils.go
@@ -42,6 +42,10 @@ func svcName(cn *v1alpha1.CNSet) string {
 	return resourceName(cn)
 }
 
+func metricSvcName(cn *v1alpha1.CNSet) string {
+	return resourceName(cn) + "-metric"
+}
+
 func setName(cn *v1alpha1.CNSet) string {
 	return resourceName(cn)
 }


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #600

**What this PR does / why we need it:**


  CNSet 开启 `exportToPrometheus: true` + `promDiscoveryScheme: Service` 时，Prometheus（通过 ServiceMonitor / VMServiceScrape）无法发现 CN
  的 metrics target，而 DN/Log 可以正常被发现。

  根因：CNSet 的 `syncService`（`pkg/controllers/cnset/resource.go`）只在已有的 SQL Service 上打了
  `prometheus.io/scrape`/`prometheus.io/port` annotation，但从未给任何 Service 加上 `metric` 端口。基于 Service 的 Prometheus 发现机制（如
  ServiceMonitor）根本不读 `prometheus.io/*` annotation——它是按 label selector 匹配 Service，再按端口名（`metric`）在 `spec.ports`
  里查找。由于没有任何 Service 暴露 `metric` 端口，CN 从未被发现，尽管 CN 进程本身已经在 `:7001` 正确暴露了 metrics。

  DNSet 和 LogSet 没有这个问题——它们已经会创建独立的 `*-dn-metric` / `*-log-metric` ClusterIP Service，带 `metric:7001` 端口。

  本 PR 让 CNSet 对齐 DNSet/LogSet 的实现：

  - 在 CNSet controller（`pkg/controllers/cnset/controller.go`）新增 `syncMetricService`，创建/reconcile 一个独立的 `<cn>-cn-metric`
  ClusterIP Service，带 `metric:7001` 端口（照抄 `dnset/controller.go` 的 `syncMetricService` 实现）
  - 该 Service 由 CNSet 拥有（owner reference），并在 `Finalize` 中一并清理
  - 仍然在 `PromDiscoveredByService()` 为真时给这个 Service 打 `prometheus.io/scrape`/`port` annotation，跟 DN/Log
  行为保持一致，也兼容仍在用 annotation-based scrape 的环境——但这两条 annotation 对 ServiceMonitor 发现机制不是必需的
  - 顺手修复了一个既有小问题：`exportToPrometheus` 关闭时，主 SQL Service 的 annotation 清理此前只删了 `prometheus.io/scrape`，遗漏了
  `prometheus.io/port`；现在两者都会被删除

**Special notes for your reviewer:**


  - 新的 metric Service 是无条件创建的（不管 `exportToPrometheus`/`promDiscoveryScheme` 取值），跟现有 DNSet/LogSet 行为一致——只有
  annotation 是有条件的。如果 reviewer 认为 CN 应该在没开 metrics 时完全不创建这个 Service，可以在这里讨论是否要让 CN 的行为跟 DN/Log
  出现分歧
  - operator 全仓库范围内都不会创建 `ServiceMonitor`/`VMServiceScrape` 这类
  CRD（已做过全仓库搜索确认），本次修复不涉及；用户需要自行确保现有 ServiceMonitor 的 selector 能覆盖 CNSet 的 `matrixorigin.io/*`
  标签，并且 endpoint 用 `metric` 这个端口名
  - `ProxySet` 存在同样的问题（在已有 Service 上打 annotation，没有创建独立 metric Service），本 PR 未处理，如有需要可以后续单独提 PR
  - 完整背景和根因分析见 `docs/dev/issue-600-cn-metrics-service.md`

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
