### PR TITLE
fix: preserve user-defined fileservice cache fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ charts/matrixone-operator/charts/
 *.tgz
 e2e*.xml
 e2e.test
+docs/troubleshooting/
+docs/draft

--- a/pkg/controllers/common/fileservice.go
+++ b/pkg/controllers/common/fileservice.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Matrix Origin
+// Copyright 2025-2026 Matrix Origin
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -179,7 +179,7 @@ func sharedFileServiceConfig(sp v1alpha1.SharedStorageProvider, cache *v1alpha1.
 		}
 		m["data-dir"] = fs.Path
 	}
-	cacheConfig := map[string]string{}
+	cacheConfig := map[string]interface{}{}
 	if cache != nil {
 		if cache.MemoryCacheSize != nil {
 			cacheConfig["memory-capacity"] = asSizeBytes(*cache.MemoryCacheSize)

--- a/pkg/controllers/common/fileservice_test.go
+++ b/pkg/controllers/common/fileservice_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Matrix Origin
+// Copyright 2025-2026 Matrix Origin
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ func TestFileServiceConfig(t *testing.T) {
 			}, {
 				"name":    "S3",
 				"backend": "S3",
-				"cache": map[string]string{
+				"cache": map[string]interface{}{
 					"memory-capacity": "1B",
 				},
 				"s3": map[string]interface{}{
@@ -68,7 +68,7 @@ func TestFileServiceConfig(t *testing.T) {
 			}, {
 				"name":    "ETL",
 				"backend": "S3",
-				"cache": map[string]string{
+				"cache": map[string]interface{}{
 					"memory-capacity": "1B",
 				},
 				"s3": map[string]interface{}{
@@ -109,7 +109,7 @@ func TestFileServiceConfig(t *testing.T) {
 					"key-prefix": "prefix/data",
 					"bucket":     "bucket",
 				},
-				"cache": map[string]string{
+				"cache": map[string]interface{}{
 					"memory-capacity": "1GiB",
 					"disk-path":       "/var/lib/matrixone/disk-cache",
 					"disk-capacity":   "1GiB",
@@ -122,7 +122,7 @@ func TestFileServiceConfig(t *testing.T) {
 					"key-prefix": "prefix/etl",
 					"bucket":     "bucket",
 				},
-				"cache": map[string]string{
+				"cache": map[string]interface{}{
 					"memory-capacity": "1B",
 				},
 			}},

--- a/pkg/controllers/dnset/resource_test.go
+++ b/pkg/controllers/dnset/resource_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Matrix Origin
+// Copyright 2025-2026 Matrix Origin
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/matrixorigin/matrixone-operator/api/core/v1alpha1"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -329,4 +330,60 @@ service-addresses = ["test-log-0.test-log-headless.test.svc:32001", "test-log-2.
 			g.Expect(cmp.Diff(tt.wantConfig, got.Data[configKey])).To(BeEmpty())
 		})
 	}
+}
+
+func TestBuildDNSetConfigMapPreservesUserFileServiceCache(t *testing.T) {
+	g := NewGomegaWithT(t)
+	userConfig := v1alpha1.NewTomlConfig(nil)
+	g.Expect(userConfig.UnmarshalTOML([]byte(`
+[[fileservice]]
+name = "S3"
+
+[fileservice.cache]
+custom-key = "keep-me"
+memory-capacity = "user-value"
+`))).To(Succeed())
+
+	memoryCacheSize := resource.MustParse("1Gi")
+	dn := &v1alpha1.DNSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "test",
+		},
+		Spec: v1alpha1.DNSetSpec{
+			PodSet: v1alpha1.PodSet{
+				Config: userConfig,
+			},
+			SharedStorageCache: v1alpha1.SharedStorageCache{
+				MemoryCacheSize: &memoryCacheSize,
+			},
+		},
+	}
+	ls := &v1alpha1.LogSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "test",
+		},
+		Spec: v1alpha1.LogSetSpec{
+			SharedStorage: v1alpha1.SharedStorageProvider{
+				S3: &v1alpha1.S3Provider{
+					Path: "bucket/prefix",
+				},
+			},
+		},
+		Status: v1alpha1.LogSetStatus{
+			Discovery: &v1alpha1.LogSetDiscovery{
+				Port:    6001,
+				Address: "test",
+			},
+		},
+	}
+
+	configMap, configSuffix, err := buildDNSetConfigMap(dn, ls, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(configSuffix).To(BeEmpty())
+	config := configMap.Data["config.toml"]
+	g.Expect(config).To(ContainSubstring(`custom-key = "keep-me"`))
+	g.Expect(config).To(ContainSubstring(`memory-capacity = "1GiB"`))
+	g.Expect(config).NotTo(ContainSubstring(`memory-capacity = "user-value"`))
 }


### PR DESCRIPTION
## Summary

- normalize operator-generated fileservice cache tables to `map[string]interface{}` at the source
- preserve non-conflicting user-defined cache fields while keeping operator values authoritative on conflicts
- add a DN ConfigMap regression test based on real TOML decoding
- update fileservice unit expectations for the normalized cache representation
- ignore local `docs/troubleshooting/` and `docs/draft` directories

## Testing

- `go test ./api/...`
- `KUBEBUILDER_ASSETS="/Users/lr90/Library/Application Support/io.kubebuilder.envtest/k8s/1.24.1-darwin-amd64" CGO_ENABLED=0 go test ./pkg/...`
- `CGO_ENABLED=0 go vet ./api/... ./pkg/...`
- `make check-license`
- `git diff --check`

Fixes #602