### PR TITLE
fix: upgrade bundled Kruise chart to v1.8.3

### DIFF
--- a/.github/workflows/release_chart.yml
+++ b/.github/workflows/release_chart.yml
@@ -30,6 +30,12 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Package local chart dependencies
+        run: |
+          mkdir -p charts/matrixone-operator/charts
+          helm package charts/kruise \
+            --destination charts/matrixone-operator/charts
+
       - name: Run Artifact Hub lint
         run: |
           curl -s https://api.github.com/repos/artifacthub/hub/releases/latest | grep -E 'browser_download_url' | grep linux_amd64.tar.gz\" | grep -Eo 'https://[^\"]*' | xargs wget -O - | tar -xz

--- a/charts/kruise/Chart.yaml
+++ b/charts/kruise/Chart.yaml
@@ -1,9 +1,9 @@
 annotations:
   artifacthub.io/changes: |
     - "[Changed]: https://github.com/openkruise/kruise/blob/master/CHANGELOG.md"
-    - "[Changed]: Support extra environment variables in the manager DaemonSet"
+    - "[Security]: Fix potential security issues of dependent packages"
 apiVersion: v1
-appVersion: 1.4.0
+appVersion: 1.8.3
 description: Helm chart for kruise components
 home: https://openkruise.io
 icon: https://openkruise.io/img/openkruise-logo-bg.jpg
@@ -17,8 +17,8 @@ keywords:
 - job
 - deployment
 - cloneset
-kubeVersion: '>= 1.16.0-0'
+kubeVersion: '>= 1.18.0-0'
 name: kruise
 sources:
 - https://github.com/openkruise/kruise
-version: 1.4.0
+version: 1.8.3

--- a/charts/kruise/README.md
+++ b/charts/kruise/README.md
@@ -1,74 +1,111 @@
-# Kruise v1.4.0
+# Kruise v1.8.0
 
 ## Configuration
 
 The following table lists the configurable parameters of the kruise chart and their default values.
 
-| Parameter                                 | Description                                                  | Default                       |
-| ----------------------------------------- | ------------------------------------------------------------ | ----------------------------- |
-| `featureGates`                            | Feature gates for Kruise, empty string means all enabled     | ` `                           |
-| `installation.namespace`                  | namespace for kruise installation                            | `kruise-system`               |
-| `installation.createNamespace`            | Whether to create the installation.namespace                 | `true`                        |
-| `manager.log.level`                       | Log level that kruise-manager printed                        | `4`                           |
-| `manager.replicas`                        | Replicas of kruise-controller-manager deployment             | `2`                           |
-| `manager.image.repository`                | Repository for kruise-manager image                          | `openkruise/kruise-manager`   |
-| `manager.image.tag`                       | Tag for kruise-manager image                                 | `v1.4.0`                      |
-| `manager.resources.limits.cpu`            | CPU resource limit of kruise-manager container               | `200m`                        |
-| `manager.resources.limits.memory`         | Memory resource limit of kruise-manager container            | `512Mi`                       |
-| `manager.resources.requests.cpu`          | CPU resource request of kruise-manager container             | `100m`                        |
-| `manager.resources.requests.memory`       | Memory resource request of kruise-manager container          | `256Mi`                       |
-| `manager.metrics.port`                    | Port of metrics served                                       | `8080`                        |
-| `manager.webhook.port`                    | Port of webhook served                                       | `9443`                        |
-| `manager.pprofAddr`                       | Address of pprof served                                      | `localhost:8090`              |
-| `manager.nodeAffinity`                    | Node affinity policy for kruise-manager pod                  | `{}`                          |
-| `manager.nodeSelector`                    | Node labels for kruise-manager pod                           | `{}`                          |
-| `manager.tolerations`                     | Tolerations for kruise-manager pod                           | `[]`                          |
-| `daemon.extraEnvs`                        | Extra environment variables that will be pass onto pods      | `[]`                          |
-| `daemon.log.level`                        | Log level that kruise-daemon printed                         | `4`                           |
-| `daemon.port`                             | Port of metrics and healthz that kruise-daemon served        | `10221`                       |
-| `daemon.pprofAddr`                        | Address of pprof served                                      | `localhost:10222`             |
-| `daemon.resources.limits.cpu`             | CPU resource limit of kruise-daemon container                | `50m`                         |
-| `daemon.resources.limits.memory`          | Memory resource limit of kruise-daemon container             | `128Mi`                       |
-| `daemon.resources.requests.cpu`           | CPU resource request of kruise-daemon container              | `0`                           |
-| `daemon.resources.requests.memory`        | Memory resource request of kruise-daemon container           | `0`                           |
-| `daemon.affinity`                         | Affinity policy for kruise-daemon pod                        | `{}`                          |
-| `daemon.socketLocation`                   | Location of the container manager control socket             | `/var/run`                    |
-| `daemon.socketFile`                       | Specify the socket file name in `socketLocation` (if you are not using containerd/docker/pouch/cri-o) | ` ` |
-| `webhookConfiguration.failurePolicy.pods` | The failurePolicy for pods in mutating webhook configuration | `Ignore`                      |
-| `webhookConfiguration.timeoutSeconds`     | The timeoutSeconds for all webhook configuration             | `30`                          |
-| `crds.managed`                            | Kruise will not install CRDs with chart if this is false     | `true`                        |
-| `manager.resyncPeriod`                    | Resync period of informer kruise-manager, defaults no resync | `0`                           |
-| `manager.hostNetwork`                     | Whether kruise-manager pod should run with hostnetwork       | `false`                       |
-| `imagePullSecrets`                        | The list of image pull secrets for kruise image              | `false`                       |
-| `enableKubeCacheMutationDetector`         | Whether to enable KUBE_CACHE_MUTATION_DETECTOR               | `false`                       |
+## setup parameters
+
+| Parameter                      | Description                                                     | Default         |
+|--------------------------------|-----------------------------------------------------------------|-----------------|
+| `featureGates`                 | Feature gates for Kruise, empty string means all enabled        | `""`            |
+| `installation.namespace`       | Namespace for kruise installation                               | `kruise-system` |
+| `installation.createNamespace` | Whether to create the installation.namespace                    | `true`          |
+| `installation.roleListGroups`  | ApiGroups which kruise is permit to list, default set to be all | `*`             |
+| `crds.managed`                 | Kruise will not install CRDs with chart if this is false        | `true`          |
+| `imagePullSecrets`             | The list of image pull secrets for kruise image                 | `[]`            |
+
+#### manager parameters
+
+| Parameter                           | Description                                                    | Default                     |
+|-------------------------------------|----------------------------------------------------------------|-----------------------------|
+| `manager.log.level`                 | Log level that kruise-manager printed                          | `4`                         |
+| `manager.replicas`                  | Replicas of kruise-controller-manager deployment               | `2`                         |
+| `manager.image.repository`          | Repository for kruise-manager image                            | `openkruise/kruise-manager` |
+| `manager.image.tag`                 | Tag for kruise-manager image                                   | `v1.8.0`                    |
+| `manager.resources.limits.cpu`      | CPU resource limit of kruise-manager container                 | `200m`                      |
+| `manager.resources.limits.memory`   | Memory resource limit of kruise-manager container              | `512Mi`                     |
+| `manager.resources.requests.cpu`    | CPU resource request of kruise-manager container               | `100m`                      |
+| `manager.resources.requests.memory` | Memory resource request of kruise-manager container            | `256Mi`                     |
+| `manager.metrics.port`              | Port of metrics served                                         | `8080`                      |
+| `manager.webhook.port`              | Port of webhook served                                         | `9443`                      |
+| `manager.pprofAddr`                 | Address of pprof served                                        | `localhost:8090`            |
+| `manager.nodeAffinity`              | Node affinity policy for kruise-manager pod                    | `{}`                        |
+| `manager.nodeSelector`              | Node labels for kruise-manager pod                             | `{}`                        |
+| `manager.tolerations`               | Tolerations for kruise-manager pod                             | `[]`                        |
+| `manager.resyncPeriod`              | Resync period of informer kruise-manager, defaults no resync   | `0`                         |
+| `manager.hostNetwork`               | Whether kruise-manager pod should run with hostnetwork         | `false`                     |
+| `manager.loggingFormat`             | Logging format, valid formats includes ` `(plain text), `json` | ` `                         |
+
+#### daemon parameters
+
+| Parameter                                     | Description                                                                                           | Default                      |
+|-----------------------------------------------|-------------------------------------------------------------------------------------------------------|------------------------------|
+| `daemon.extraEnvs`                            | Extra environment variables that will be pass onto pods                                               | `[]`                         |
+| `daemon.log.level`                            | Log level that kruise-daemon printed                                                                  | `4`                          |
+| `daemon.port`                                 | Port of metrics and healthz that kruise-daemon served                                                 | `10221`                      |
+| `daemon.pprofAddr`                            | Address of pprof served                                                                               | `localhost:10222`            |
+| `daemon.resources.limits.cpu`                 | CPU resource limit of kruise-daemon container                                                         | `50m`                        |
+| `daemon.resources.limits.memory`              | Memory resource limit of kruise-daemon container                                                      | `128Mi`                      |
+| `daemon.resources.requests.cpu`               | CPU resource request of kruise-daemon container                                                       | `0`                          |
+| `daemon.resources.requests.memory`            | Memory resource request of kruise-daemon container                                                    | `0`                          |
+| `daemon.affinity`                             | Affinity policy for kruise-daemon pod                                                                 | `{}`                         |
+| `daemon.socketLocation`                       | Location of the container manager control socket                                                      | `/var/run`                   |
+| `daemon.socketFile`                           | Specify the socket file name in `socketLocation` (if you are not using containerd/docker/pouch/cri-o) | ` `                          |
+| `daemon.credentialProvider.enable`            | Whether to enable credential provider for image pull job                                              | `false`                      |
+| `daemon.credentialProvider.hostPath`          | node dir of the credential provider plugin, kruise-daemon will mount the dir as a hostpath volume     | `credential-provider-plugin` |
+| `daemon.credentialProvider.configmap`         | configmap name of the credential provider in kruise-system ns                                         | `credential-provider-config` |
+| `daemon.credentialProvider.awsCredentialsDir` | aws credentials dir if using AWS, for example: `/root/.aws`                                           | ` `                          |
+
+### other parameters
+
+| Parameter                             | Description                                                                                                                                                                                  | Default |
+|---------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `enableKubeCacheMutationDetector`     | Whether to enable KUBE_CACHE_MUTATION_DETECTOR                                                                                                                                               | `false` |
+| `webhookConfiguration.timeoutSeconds` | The timeoutSeconds for all webhook configuration                                                                                                                                             | `30`    |
+| `serviceAccount.annotations`          | Annotations to patch for serviceAccounts                                                                                                                                                     | `{}`    |
+| `externalCerts.annotations`           | Annotations to patch for webhook configuration and crd when featuregate `EnableExternalCerts` is enabled. For example, `cert-manager.io/inject-ca-from: kruise-system/kruise-webhook-certs`. | `{}`    |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+`helm install kruise https://... --set featureGates="AllAlpha=true"`.
 
 ### Optional: feature-gate
 
 Feature-gate controls some influential features in Kruise:
 
-| Name                   | Description                                                  | Default | Effect (if closed)                   |
-| ---------------------- | ------------------------------------------------------------ | ------- | --------------------------------------
-| `PodWebhook`           | Whether to open a webhook for Pod **create**                 | `true`  | SidecarSet/KruisePodReadinessGate disabled    |
-| `KruiseDaemon`         | Whether to deploy `kruise-daemon` DaemonSet                  | `true`  | ImagePulling/ContainerRecreateRequest disabled |
-| `DaemonWatchingPod`    | Should each `kruise-daemon` watch pods on the same node      | `true`  | For in-place update with same imageID or env from labels/annotations |
-| `CloneSetShortHash`    | Enables CloneSet controller only set revision hash name to pod label | `false` | CloneSet name can not be longer than 54 characters |
-| `KruisePodReadinessGate` | Enables Kruise webhook to inject 'KruisePodReady' readiness-gate to all Pods during creation | `false` | The readiness-gate will only be injected to Pods created by Kruise workloads |
-| `PreDownloadImageForInPlaceUpdate` | Enables CloneSet controller to create ImagePullJobs to pre-download images for in-place update | `true` | No image pre-download for in-place update |
-| `CloneSetPartitionRollback` | Enables CloneSet controller to rollback Pods to currentRevision when number of updateRevision pods is bigger than (replicas - partition) | `false` | CloneSet will only update Pods to updateRevision |
-| `ResourcesDeletionProtection` | Enables protection for resources deletion              | `true` | No protection for resources deletion |
-| `TemplateNoDefaults` | Whether to disable defaults injection for pod/pvc template in workloads | `false` | Should not close this feature if it has open |
-| `PodUnavailableBudgetDeleteGate` | Enables PodUnavailableBudget for pod deletion, eviction           | `true` | No protection for pod deletion, eviction |
-| `PodUnavailableBudgetUpdateGate` | Enables PodUnavailableBudget for pod.Spec update                  | `false` | No protection for in-place update |
-| `WorkloadSpread`                 | Enables WorkloadSpread to manage multi-domain and elastic deploy  | `true` | WorkloadSpread disabled |
-| `InPlaceUpdateEnvFromMetadata`   | Enables Kruise to in-place update a container in Pod when its env from labels/annotations changed and pod is in-place updating | `true` | Only container image can be in-place update |
-| `StatefulSetAutoDeletePVC`       | Enables policies controlling deletion of PVCs created by a StatefulSet  | `true` | No deletion of PVCs by StatefulSet |
-| `PreDownloadImageForDaemonSetUpdate`       | Enables DaemonSet controller to create ImagePullJobs to pre-download images for in-place update  | `false` | No image pre-download for in-place update |
-| `PodProbeMarkerGate`   | Whether to turn on PodProbeMarker ability  | `true` | PodProbeMarker disabled |
-| `SidecarSetPatchPodMetadataDefaultsAllowed`   | Allow SidecarSet patch any annotations to Pod Object | `false` | Annotations are not allowed to patch randomly and need to be configured via SidecarSet_PatchPodMetadata_WhiteList |
-| `SidecarTerminator`   | SidecarTerminator enables SidecarTerminator to stop sidecar containers when all main containers exited | `false` | SidecarTerminator disabled |
-| `CloneSetEventHandlerOptimization`   | CloneSetEventHandlerOptimization enable optimization for cloneset-controller to reduce the queuing frequency cased by pod update | `false` | optimization for cloneset-controller to reduce the queuing frequency cased by pod update disabled |
+| Name                                        | Description                                                                                                                                                                | Default | Effect (if closed)                                                                                                      |
+|---------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|-------------------------------------------------------------------------------------------------------------------------|
+| `PodWebhook`                                | Whether to open a webhook for Pod **create**                                                                                                                               | `true`  | SidecarSet/KruisePodReadinessGate disabled                                                                              |
+| `KruiseDaemon`                              | Whether to deploy `kruise-daemon` DaemonSet                                                                                                                                | `true`  | ImagePulling/ContainerRecreateRequest disabled                                                                          |
+| `DaemonWatchingPod`                         | Should each `kruise-daemon` watch pods on the same node                                                                                                                    | `true`  | For in-place update with same imageID or env from labels/annotations                                                    |
+| `CloneSetShortHash`                         | Enables CloneSet controller only set revision hash name to pod label                                                                                                       | `false` | CloneSet name can not be longer than 54 characters                                                                      |
+| `KruisePodReadinessGate`                    | Enables Kruise webhook to inject 'KruisePodReady' readiness-gate to all Pods during creation                                                                               | `false` | The readiness-gate will only be injected to Pods created by Kruise workloads                                            |
+| `PreDownloadImageForInPlaceUpdate`          | Enables CloneSet controller to create ImagePullJobs to pre-download images for in-place update                                                                             | `true`  | No image pre-download for in-place update                                                                               |
+| `CloneSetPartitionRollback`                 | Enables CloneSet controller to rollback Pods to currentRevision when number of updateRevision pods is bigger than (replicas - partition)                                   | `false` | CloneSet will only update Pods to updateRevision                                                                        |
+| `ResourcesDeletionProtection`               | Enables protection for resources deletion                                                                                                                                  | `false` | No protection for resources deletion                                                                                    |
+| `TemplateNoDefaults`                        | Whether to disable defaults injection for pod/pvc template in workloads                                                                                                    | `false` | Should not close this feature if it has open                                                                            |
+| `PodUnavailableBudgetDeleteGate`            | Enables PodUnavailableBudget for pod deletion, eviction                                                                                                                    | `true`  | No protection for pod deletion, eviction                                                                                |
+| `PodUnavailableBudgetUpdateGate`            | Enables PodUnavailableBudget for pod.Spec update                                                                                                                           | `false` | No protection for in-place update                                                                                       |
+| `WorkloadSpread`                            | Enables WorkloadSpread to manage multi-domain and elastic deploy                                                                                                           | `true`  | WorkloadSpread disabled                                                                                                 |
+| `InPlaceUpdateEnvFromMetadata`              | Enables Kruise to in-place update a container in Pod when its env from labels/annotations changed and pod is in-place updating                                             | `true`  | Only container image can be in-place update                                                                             |
+| `StatefulSetAutoDeletePVC`                  | Enables policies controlling deletion of PVCs created by a StatefulSet                                                                                                     | `true`  | No deletion of PVCs by StatefulSet                                                                                      |
+| `PreDownloadImageForDaemonSetUpdate`        | Enables DaemonSet controller to create ImagePullJobs to pre-download images for in-place update                                                                            | `false` | No image pre-download for in-place update                                                                               |
+| `PodProbeMarkerGate`                        | Whether to turn on PodProbeMarker ability                                                                                                                                  | `true`  | PodProbeMarker disabled                                                                                                 |
+| `SidecarSetPatchPodMetadataDefaultsAllowed` | Allow SidecarSet patch any annotations to Pod Object                                                                                                                       | `false` | Annotations are not allowed to patch randomly and need to be configured via SidecarSet_PatchPodMetadata_WhiteList       |
+| `SidecarTerminator`                         | SidecarTerminator enables SidecarTerminator to stop sidecar containers when all main containers exited                                                                     | `false` | SidecarTerminator disabled                                                                                              |
+| `CloneSetEventHandlerOptimization`          | CloneSetEventHandlerOptimization enable optimization for cloneset-controller to reduce the queuing frequency cased by pod update                                           | `false` | optimization for cloneset-controller to reduce the queuing frequency cased by pod update disabled                       |
+| `PreparingUpdateAsUpdate`                   | PreparingUpdateAsUpdate enable CloneSet/Advanced StatefulSet controller to regard preparing-update Pod as updated when calculating update/current revision during scaling. | `false` | Pods at preparing update state will be regarded as current revision instead of update revision                          |
+| `ImagePullJobGate`                          | ImagePullJobGate enable imagepulljob-controller execute ImagePullJob                                                                                                       | `false` | ImagePullJob and PreDownloadImageForInPlaceUpdate are disabled                                                          |
+| `ResourceDistributionGate`                  | ResourceDistributionGate enable resourcedistribution-controller execute ResourceDistribution.                                                                              | `false` | ResourceDistribution disabled                                                                                           |
+| `DeletionProtectionForCRDCascadingGate`     | DeletionProtectionForCRDCascadingGate enable deletionProtection for crd Cascading                                                                                          | `false` | CustomResourceDefinition deletion protection disabled                                                                   |
+| `EnableExternalCerts`                       | Using certs generated externally, cert-manager e.g., for webhook server                                                                                                    | `false` | kruise-manager will generate self-signed certs for webhook server                                                       |
+| `RecreatePodWhenChangeVCTInCloneSetGate`    | Recreate the pod upon changing volume claim templates in a clone set to ensure PVC consistency                                                                             | `false` | kruise-manager will recreate the pod upon changing volume claim templates in a clone set to ensure PVC consistency      |
+| `StatefulSetStartOrdinal`                   | Enables a StatefulSet to start from an arbitrary non zero ordinal                                                                                                          | `false` | kruise-manager will enables a StatefulSet to start from an arbitrary non zero ordinal                                   |
+| `PodIndexLabel`                             | Set pod completion index as a pod label for Indexed Jobs.                                                                                                                  | `true`  | kruise-manager will set pod completion index as a pod label for Indexed Jobs.                                           |
+| `StatefulSetAutoResizePVCGate`              | Enables policies auto resizing PVCs created by a StatefulSet when user expands volumeClaimTemplates.                                                                       | `false` | kruise-manager will enable policies auto resizing PVCs created by a StatefulSet when user expands volumeClaimTemplates. |
+| `InPlaceWorkloadVerticalScaling`            | Enables CloneSet/Advanced StatefulSet controller to support vertical scaling of managed Pods.                                                                              | `false` | kruise-manager will enable CloneSet/Advanced StatefulSet controller to support vertical scaling of managed Pods.        |
+| `EnablePodProbeMarkerOnServerless`          | Enables PodProbeMarker on Serverless Pod.                                                                                                                                  | `false` | kruise-manager will enable PodProbeMarker on Serverless Pod.                                                            |
+| `ForceDeleteTimeoutExpectationFeatureGate`  | Enables delete timeout expectation, for example: cloneSet ScaleExpectation                                                                                                 | `false` | kruise-manager will enable delete timeout expectation, for example: cloneSet ScaleExpectation                           |
 
 If you want to configure the feature-gate, just set the parameter when install or upgrade. Such as:
 
@@ -81,9 +118,57 @@ If you want to enable all feature-gates, set the parameter as `featureGates=AllA
 
 ### Optional: the local image for China
 
-If you are in China and have problem to pull image from official DockerHub, you can use the registry hosted on Alibaba Cloud:
+If you are in China and have problem to pull image from official DockerHub, you can use the registry hosted on Alibaba
+Cloud:
 
 ```bash
 $ helm install kruise https://... --set  manager.image.repository=openkruise-registry.cn-hangzhou.cr.aliyuncs.com/openkruise/kruise-manager
 ...
 ```
+
+### Optional: Support webhook CA injection using external certification management tool
+
+Kruise needs certificates to enable mutating, validating and conversion webhooks. By default, kruise will generate
+self-signed certificates for webhook server.
+If you want to use external certification management tool, e.g. cert-manager, you can follow these steps when install or
+upgrade:
+
+1. Install external certification management tool, e.g. [cert-manager](https://cert-manager.io/docs/installation/helm/).
+2. Create issuer and certificate resources if you have not done this before.
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kruise-webhook-certs
+  # consistent with installation.namespace
+  namespace: kruise-system
+spec:
+  # where to store the certificates
+  # cert-manager would generate a secret kruise-system/kruise-webhook-certs with the certificates
+  # DO NOT CHANGE THE SECRET NAME SINCE KRUISE READ CERTS FROM THIS SECRET
+  secretName: kruise-webhook-certs
+  dnsNames:
+    - kruise-webhook-service.kruise-system.svc
+    - localhost
+  issuerRef:
+    name: selfsigned-kruise
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-kruise
+  namespace: kruise-system
+spec:
+  selfSigned: { }
+```
+
+3. During installation and upgrade, enable external certs support by setting featureGates=EnableExternalCerts=true and
+   specify extra annotations that should be added to webhookconfiguration and CRD.
+
+```
+helm install kruise https://... --set featureGates="EnableExternalCerts=true" --set-json externalCerts.annotations='{"cert-manager.io/inject-ca-from":"kruise-system/kruise-webhook-certs"}'
+```
+
+Visit [CA Injector - cert manager](https://cert-manager.io/docs/concepts/ca-injector/) for more details.

--- a/charts/kruise/ci/default-values.yaml
+++ b/charts/kruise/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# Test with default values

--- a/charts/kruise/templates/apps.kruise.io_advancedcronjobs.yaml
+++ b/charts/kruise/templates/apps.kruise.io_advancedcronjobs.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.crds.managed }}
-
+ 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: advancedcronjobs.apps.kruise.io
 spec:
   group: apps.kruise.io
@@ -45,14 +44,19 @@ spec:
         description: AdvancedCronJob is the Schema for the advancedcronjobs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -60,19 +64,21 @@ spec:
             description: AdvancedCronJobSpec defines the desired state of AdvancedCronJob
             properties:
               concurrencyPolicy:
-                description: 'Specifies how to treat concurrent executions of a Job.
-                  Valid values are: - "Allow" (default): allows CronJobs to run concurrently;
-                  - "Forbid": forbids concurrent runs, skipping next run if previous
-                  run hasn''t finished yet; - "Replace": cancels currently running
-                  job and replaces it with a new one'
+                description: |-
+                  Specifies how to treat concurrent executions of a Job.
+                  Valid values are:
+                  - "Allow" (default): allows CronJobs to run concurrently;
+                  - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet;
+                  - "Replace": cancels currently running job and replaces it with a new one
                 enum:
                 - Allow
                 - Forbid
                 - Replace
                 type: string
               failedJobsHistoryLimit:
-                description: The number of failed finished jobs to retain. This is
-                  a pointer to distinguish between explicit zero and not specified.
+                description: |-
+                  The number of failed finished jobs to retain.
+                  This is a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer
               paused:
@@ -83,14 +89,15 @@ spec:
                 minLength: 0
                 type: string
               startingDeadlineSeconds:
-                description: Optional deadline in seconds for starting the job if
-                  it misses scheduled time for any reason.  Missed jobs executions
-                  will be counted as failed ones.
+                description: |-
+                  Optional deadline in seconds for starting the job if it misses scheduled
+                  time for any reason.  Missed jobs executions will be counted as failed ones.
                 format: int64
                 type: integer
               successfulJobsHistoryLimit:
-                description: The number of successful finished jobs to retain. This
-                  is a pointer to distinguish between explicit zero and not specified.
+                description: |-
+                  The number of successful finished jobs to retain.
+                  This is a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer
               template:
@@ -110,34 +117,34 @@ spec:
                           broadcastjob.
                         properties:
                           completionPolicy:
-                            description: CompletionPolicy indicates the completion
-                              policy of the job. Default is Always CompletionPolicyType.
+                            description: |-
+                              CompletionPolicy indicates the completion policy of the job.
+                              Default is Always CompletionPolicyType.
                             properties:
                               activeDeadlineSeconds:
-                                description: ActiveDeadlineSeconds specifies the duration
-                                  in seconds relative to the startTime that the job
-                                  may be active before the system tries to terminate
-                                  it; value must be positive integer. Only works for
-                                  Always type.
+                                description: |-
+                                  ActiveDeadlineSeconds specifies the duration in seconds relative to the startTime that the job may be active
+                                  before the system tries to terminate it; value must be positive integer.
+                                  Only works for Always type.
                                 format: int64
                                 type: integer
                               ttlSecondsAfterFinished:
-                                description: ttlSecondsAfterFinished limits the lifetime
-                                  of a Job that has finished execution (either Complete
-                                  or Failed). If this field is set, ttlSecondsAfterFinished
-                                  after the Job finishes, it is eligible to be automatically
-                                  deleted. When the Job is being deleted, its lifecycle
-                                  guarantees (e.g. finalizers) will be honored. If
-                                  this field is unset, the Job won't be automatically
-                                  deleted. If this field is set to zero, the Job becomes
-                                  eligible to be deleted immediately after it finishes.
-                                  This field is alpha-level and is only honored by
-                                  servers that enable the TTLAfterFinished feature.
+                                description: |-
+                                  ttlSecondsAfterFinished limits the lifetime of a Job that has finished
+                                  execution (either Complete or Failed). If this field is set,
+                                  ttlSecondsAfterFinished after the Job finishes, it is eligible to be
+                                  automatically deleted. When the Job is being deleted, its lifecycle
+                                  guarantees (e.g. finalizers) will be honored. If this field is unset,
+                                  the Job won't be automatically deleted. If this field is set to zero,
+                                  the Job becomes eligible to be deleted immediately after it finishes.
+                                  This field is alpha-level and is only honored by servers that enable the
+                                  TTLAfterFinished feature.
                                   Only works for Always type
                                 format: int32
                                 type: integer
                               type:
-                                description: Type indicates the type of the CompletionPolicy.
+                                description: |-
+                                  Type indicates the type of the CompletionPolicy.
                                   Default is Always.
                                 type: string
                             type: object
@@ -151,7 +158,8 @@ spec:
                                 format: int32
                                 type: integer
                               type:
-                                description: Type indicates the type of FailurePolicyType.
+                                description: |-
+                                  Type indicates the type of FailurePolicyType.
                                   Default is FailurePolicyTypeFailFast.
                                 type: string
                             type: object
@@ -159,12 +167,11 @@ spec:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: Parallelism specifies the maximum desired
-                              number of pods the job should run at any given time.
-                              The actual number of pods running in steady state will
-                              be less than this number when the work left to do is
-                              less than max parallelism. Not setting this value means
-                              no limit.
+                            description: |-
+                              Parallelism specifies the maximum desired number of pods the job should
+                              run at any given time. The actual number of pods running in steady state will
+                              be less than this number when the work left to do is less than max parallelism.
+                              Not setting this value means no limit.
                             x-kubernetes-int-or-string: true
                           paused:
                             description: Paused will pause the job.
@@ -183,9 +190,9 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
               timeZone:
-                description: The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
-                  If not specified, this will default to the time zone of the kruise-controller-manager
-                  process.
+                description: |-
+                  The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
+                  If not specified, this will default to the time zone of the kruise-controller-manager process.
                 type: string
             required:
             - schedule
@@ -197,65 +204,66 @@ spec:
               active:
                 description: A list of pointers to currently running jobs.
                 items:
-                  description: 'ObjectReference contains enough information to let
-                    you inspect or modify the referred object. --- New uses of this
-                    type are discouraged because of difficulty describing its usage
-                    when embedded in APIs.  1. Ignored fields.  It includes many fields
-                    which are not generally honored.  For instance, ResourceVersion
-                    and FieldPath are both very rarely valid in actual usage.  2.
-                    Invalid usage help.  It is impossible to add specific help for
-                    individual usage.  In most embedded usages, there are particular     restrictions
-                    like, "must refer only to types A and B" or "UID not honored"
-                    or "name must be restricted".     Those cannot be well described
-                    when embedded.  3. Inconsistent validation.  Because the usages
-                    are different, the validation rules are different by usage, which
-                    makes it hard for users to predict what will happen.  4. The fields
-                    are both imprecise and overly precise.  Kind is not a precise
-                    mapping to a URL. This can produce ambiguity     during interpretation
-                    and require a REST mapping.  In most cases, the dependency is
-                    on the group,resource tuple     and the version of the actual
-                    struct is irrelevant.  5. We cannot easily change it.  Because
-                    this type is embedded in many locations, updates to this type     will
-                    affect numerous schemas.  Don''t make new APIs embed an underspecified
-                    API type they do not control. Instead of using this type, create
-                    a locally provided and used type that is well-focused on your
-                    reference. For example, ServiceReferences for admission registration:
-                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                    .'
+                  description: |-
+                    ObjectReference contains enough information to let you inspect or modify the referred object.
+                    ---
+                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                        Those cannot be well described when embedded.
+                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                        and the version of the actual struct is irrelevant.
+                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
                   properties:
                     apiVersion:
                       description: API version of the referent.
                       type: string
                     fieldPath:
-                      description: 'If referring to a piece of an object instead of
-                        an entire object, this string should contain a valid JSON/Go
-                        field access statement, such as desiredState.manifest.containers[2].
-                        For example, if the object reference is to a container within
-                        a pod, this would take on a value like: "spec.containers{name}"
-                        (where "name" refers to the name of the container that triggered
-                        the event) or if no container name is specified "spec.containers[2]"
-                        (container with index 2 in this pod). This syntax is chosen
-                        only to have some well-defined way of referencing a part of
-                        an object. TODO: this design is not final and this field is
-                        subject to change in the future.'
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
                       type: string
                     kind:
-                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                       type: string
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
-                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                       type: string
                     resourceVersion:
-                      description: 'Specific resourceVersion to which this reference
-                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                       type: string
                     uid:
-                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                       type: string
                   type: object
+                  x-kubernetes-map-type: atomic
                 type: array
               lastScheduleTime:
                 description: Information when was the last time the job was successfully
@@ -270,10 +278,4 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}

--- a/charts/kruise/templates/apps.kruise.io_broadcastjobs.yaml
+++ b/charts/kruise/templates/apps.kruise.io_broadcastjobs.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.crds.managed }}
-
+ 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: broadcastjobs.apps.kruise.io
 spec:
   group: apps.kruise.io
@@ -50,14 +49,19 @@ spec:
         description: BroadcastJob is the Schema for the broadcastjobs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -65,31 +69,34 @@ spec:
             description: BroadcastJobSpec defines the desired state of BroadcastJob
             properties:
               completionPolicy:
-                description: CompletionPolicy indicates the completion policy of the
-                  job. Default is Always CompletionPolicyType.
+                description: |-
+                  CompletionPolicy indicates the completion policy of the job.
+                  Default is Always CompletionPolicyType.
                 properties:
                   activeDeadlineSeconds:
-                    description: ActiveDeadlineSeconds specifies the duration in seconds
-                      relative to the startTime that the job may be active before
-                      the system tries to terminate it; value must be positive integer.
+                    description: |-
+                      ActiveDeadlineSeconds specifies the duration in seconds relative to the startTime that the job may be active
+                      before the system tries to terminate it; value must be positive integer.
                       Only works for Always type.
                     format: int64
                     type: integer
                   ttlSecondsAfterFinished:
-                    description: ttlSecondsAfterFinished limits the lifetime of a
-                      Job that has finished execution (either Complete or Failed).
-                      If this field is set, ttlSecondsAfterFinished after the Job
-                      finishes, it is eligible to be automatically deleted. When the
-                      Job is being deleted, its lifecycle guarantees (e.g. finalizers)
-                      will be honored. If this field is unset, the Job won't be automatically
-                      deleted. If this field is set to zero, the Job becomes eligible
-                      to be deleted immediately after it finishes. This field is alpha-level
-                      and is only honored by servers that enable the TTLAfterFinished
-                      feature. Only works for Always type
+                    description: |-
+                      ttlSecondsAfterFinished limits the lifetime of a Job that has finished
+                      execution (either Complete or Failed). If this field is set,
+                      ttlSecondsAfterFinished after the Job finishes, it is eligible to be
+                      automatically deleted. When the Job is being deleted, its lifecycle
+                      guarantees (e.g. finalizers) will be honored. If this field is unset,
+                      the Job won't be automatically deleted. If this field is set to zero,
+                      the Job becomes eligible to be deleted immediately after it finishes.
+                      This field is alpha-level and is only honored by servers that enable the
+                      TTLAfterFinished feature.
+                      Only works for Always type
                     format: int32
                     type: integer
                   type:
-                    description: Type indicates the type of the CompletionPolicy.
+                    description: |-
+                      Type indicates the type of the CompletionPolicy.
                       Default is Always.
                     type: string
                 type: object
@@ -103,19 +110,20 @@ spec:
                     format: int32
                     type: integer
                   type:
-                    description: Type indicates the type of FailurePolicyType. Default
-                      is FailurePolicyTypeFailFast.
+                    description: |-
+                      Type indicates the type of FailurePolicyType.
+                      Default is FailurePolicyTypeFailFast.
                     type: string
                 type: object
               parallelism:
                 anyOf:
                 - type: integer
                 - type: string
-                description: Parallelism specifies the maximum desired number of pods
-                  the job should run at any given time. The actual number of pods
-                  running in steady state will be less than this number when the work
-                  left to do is less than max parallelism. Not setting this value
-                  means no limit.
+                description: |-
+                  Parallelism specifies the maximum desired number of pods the job should
+                  run at any given time. The actual number of pods running in steady state will
+                  be less than this number when the work left to do is less than max parallelism.
+                  Not setting this value means no limit.
                 x-kubernetes-int-or-string: true
               paused:
                 description: Paused will pause the job.
@@ -135,8 +143,9 @@ spec:
                 format: int32
                 type: integer
               completionTime:
-                description: Represents time when the job was completed. It is not
-                  guaranteed to be set in happens-before order across separate operations.
+                description: |-
+                  Represents time when the job was completed. It is not guaranteed to
+                  be set in happens-before order across separate operations.
                   It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
@@ -186,10 +195,10 @@ spec:
                 description: The phase of the job.
                 type: string
               startTime:
-                description: Represents time when the job was acknowledged by the
-                  job controller. It is not guaranteed to be set in happens-before
-                  order across separate operations. It is represented in RFC3339 form
-                  and is in UTC.
+                description: |-
+                  Represents time when the job was acknowledged by the job controller.
+                  It is not guaranteed to be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               succeeded:
@@ -202,10 +211,4 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}

--- a/charts/kruise/templates/apps.kruise.io_clonesets.yaml
+++ b/charts/kruise/templates/apps.kruise.io_clonesets.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.crds.managed }}
-
+ 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: clonesets.apps.kruise.io
 spec:
   group: apps.kruise.io
@@ -31,6 +30,10 @@ spec:
     - description: The number of pods updated and ready.
       jsonPath: .status.updatedReadyReplicas
       name: UPDATED_READY
+      type: integer
+    - description: The number of pods updated and available.
+      jsonPath: .status.updatedAvailableReplicas
+      name: UPDATED_AVAILABLE
       type: integer
     - description: The number of pods ready.
       jsonPath: .status.readyReplicas
@@ -68,14 +71,19 @@ spec:
         description: CloneSet is the Schema for the clonesets API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -99,12 +107,12 @@ spec:
                           type: string
                         type: object
                       markPodNotReady:
-                        description: 'MarkPodNotReady = true means: - Pod will be
-                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
-                          - Pod will be restored to ''Ready'' at Updated state if
-                          it was set to ''NotReady'' at preparingUpdate state. Currently,
-                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
-                          hook. Default to false.'
+                        description: |-
+                          MarkPodNotReady = true means:
+                          - Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.
+                          Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook.
+                          Default to false.
                         type: boolean
                     type: object
                   preDelete:
@@ -119,12 +127,12 @@ spec:
                           type: string
                         type: object
                       markPodNotReady:
-                        description: 'MarkPodNotReady = true means: - Pod will be
-                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
-                          - Pod will be restored to ''Ready'' at Updated state if
-                          it was set to ''NotReady'' at preparingUpdate state. Currently,
-                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
-                          hook. Default to false.'
+                        description: |-
+                          MarkPodNotReady = true means:
+                          - Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.
+                          Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook.
+                          Default to false.
                         type: boolean
                     type: object
                   preNormal:
@@ -140,88 +148,94 @@ spec:
                           type: string
                         type: object
                       markPodNotReady:
-                        description: 'MarkPodNotReady = true means: - Pod will be
-                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
-                          - Pod will be restored to ''Ready'' at Updated state if
-                          it was set to ''NotReady'' at preparingUpdate state. Currently,
-                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
-                          hook. Default to false.'
+                        description: |-
+                          MarkPodNotReady = true means:
+                          - Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.
+                          Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook.
+                          Default to false.
                         type: boolean
                     type: object
                 type: object
               minReadySeconds:
-                description: Minimum number of seconds for which a newly created pod
-                  should be ready without any of its container crashing, for it to
-                  be considered available. Defaults to 0 (pod will be considered available
-                  as soon as it is ready)
+                description: |-
+                  Minimum number of seconds for which a newly created pod should be ready
+                  without any of its container crashing, for it to be considered available.
+                  Defaults to 0 (pod will be considered available as soon as it is ready)
                 format: int32
                 type: integer
               replicas:
-                description: Replicas is the desired number of replicas of the given
-                  Template. These are replicas in the sense that they are instantiations
-                  of the same Template. If unspecified, defaults to 1.
+                description: |-
+                  Replicas is the desired number of replicas of the given Template.
+                  These are replicas in the sense that they are instantiations of the
+                  same Template.
+                  If unspecified, defaults to 1.
                 format: int32
                 type: integer
               revisionHistoryLimit:
-                description: RevisionHistoryLimit is the maximum number of revisions
-                  that will be maintained in the CloneSet's revision history. The
-                  revision history consists of all revisions not represented by a
-                  currently applied CloneSetSpec version. The default value is 10.
+                description: |-
+                  RevisionHistoryLimit is the maximum number of revisions that will
+                  be maintained in the CloneSet's revision history. The revision history
+                  consists of all revisions not represented by a currently applied
+                  CloneSetSpec version. The default value is 10.
                 format: int32
                 type: integer
               scaleStrategy:
-                description: ScaleStrategy indicates the ScaleStrategy that will be
-                  employed to create and delete Pods in the CloneSet.
+                description: |-
+                  ScaleStrategy indicates the ScaleStrategy that will be employed to
+                  create and delete Pods in the CloneSet.
                 properties:
                   disablePVCReuse:
-                    description: Indicate if cloneSet will reuse already existed pvc
-                      to rebuild a new pod
+                    description: |-
+                      Indicate if cloneSet will reuse already existed pvc to
+                      rebuild a new pod
                     type: boolean
                   maxUnavailable:
                     anyOf:
                     - type: integer
                     - type: string
-                    description: The maximum number of pods that can be unavailable
-                      for scaled pods. This field can control the changes rate of
-                      replicas for CloneSet so as to minimize the impact for users'
-                      service. The scale will fail if the number of unavailable pods
-                      were greater than this MaxUnavailable at scaling up. MaxUnavailable
-                      works only when scaling up.
+                    description: |-
+                      The maximum number of pods that can be unavailable for scaled pods.
+                      This field can control the changes rate of replicas for CloneSet so as to minimize the impact for users' service.
+                      The scale will fail if the number of unavailable pods were greater than this MaxUnavailable at scaling up.
+                      MaxUnavailable works only when scaling up.
                     x-kubernetes-int-or-string: true
                   podsToDelete:
-                    description: PodsToDelete is the names of Pod should be deleted.
+                    description: |-
+                      PodsToDelete is the names of Pod should be deleted.
                       Note that this list will be truncated for non-existing pod names.
                     items:
                       type: string
                     type: array
                 type: object
               selector:
-                description: 'Selector is a label query over pods that should match
-                  the replica count. It must match the pod template''s labels. More
-                  info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                description: |-
+                  Selector is a label query over pods that should match the replica count.
+                  It must match the pod template's labels.
+                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
@@ -234,29 +248,29 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               template:
                 description: Template describes the pods that will be created.
                 x-kubernetes-preserve-unknown-fields: true
               updateStrategy:
-                description: UpdateStrategy indicates the UpdateStrategy that will
-                  be employed to update Pods in the CloneSet when a revision is made
-                  to Template.
+                description: |-
+                  UpdateStrategy indicates the UpdateStrategy that will be employed to
+                  update Pods in the CloneSet when a revision is made to Template.
                 properties:
                   inPlaceUpdateStrategy:
                     description: InPlaceUpdateStrategy contains strategies for in-place
                       update.
                     properties:
                       gracePeriodSeconds:
-                        description: GracePeriodSeconds is the timespan between set
-                          Pod status to not-ready and update images in Pod spec when
-                          in-place update a Pod.
+                        description: |-
+                          GracePeriodSeconds is the timespan between set Pod status to not-ready and update images in Pod spec
+                          when in-place update a Pod.
                         format: int32
                         type: integer
                     type: object
@@ -264,59 +278,64 @@ spec:
                     anyOf:
                     - type: integer
                     - type: string
-                    description: 'The maximum number of pods that can be scheduled
-                      above the desired replicas during update or specified delete.
-                      Value can be an absolute number (ex: 5) or a percentage of desired
-                      pods (ex: 10%). Absolute number is calculated from percentage
-                      by rounding up. Defaults to 0.'
+                    description: |-
+                      The maximum number of pods that can be scheduled above the desired replicas during update or specified delete.
+                      Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                      Absolute number is calculated from percentage by rounding up.
+                      Defaults to 0.
                     x-kubernetes-int-or-string: true
                   maxUnavailable:
                     anyOf:
                     - type: integer
                     - type: string
-                    description: 'The maximum number of pods that can be unavailable
-                      during update or scale. Value can be an absolute number (ex:
-                      5) or a percentage of desired pods (ex: 10%). Absolute number
-                      is calculated from percentage by rounding up by default. When
-                      maxSurge > 0, absolute number is calculated from percentage
-                      by rounding down. Defaults to 20%.'
+                    description: |-
+                      The maximum number of pods that can be unavailable during update or scale.
+                      Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                      Absolute number is calculated from percentage by rounding up by default.
+                      When maxSurge > 0, absolute number is calculated from percentage by rounding down.
+                      Defaults to 20%.
                     x-kubernetes-int-or-string: true
                   partition:
                     anyOf:
                     - type: integer
                     - type: string
-                    description: 'Partition is the desired number of pods in old revisions.
-                      Value can be an absolute number (ex: 5) or a percentage of desired
-                      pods (ex: 10%). Absolute number is calculated from percentage
-                      by rounding up by default. It means when partition is set during
-                      pods updating, (replicas - partition value) number of pods will
-                      be updated. Default value is 0.'
+                    description: |-
+                      Partition is the desired number of pods in old revisions.
+                      Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                      Absolute number is calculated from percentage by rounding up by default.
+                      It means when partition is set during pods updating, (replicas - partition value) number of pods will be updated.
+                      Default value is 0.
                     x-kubernetes-int-or-string: true
                   paused:
-                    description: Paused indicates that the CloneSet is paused. Default
-                      value is false
+                    description: |-
+                      Paused indicates that the CloneSet is paused.
+                      Default value is false
                     type: boolean
                   priorityStrategy:
-                    description: Priorities are the rules for calculating the priority
-                      of updating pods. Each pod to be updated, will pass through
-                      these terms and get a sum of weights.
+                    description: |-
+                      Priorities are the rules for calculating the priority of updating pods.
+                      Each pod to be updated, will pass through these terms and get a sum of weights.
                     properties:
                       orderPriority:
-                        description: 'Order priority terms, pods will be sorted by
-                          the value of orderedKey. For example: ``` orderPriority:
-                          - orderedKey: key1 - orderedKey: key2 ``` First, all pods
-                          which have key1 in labels will be sorted by the value of
-                          key1. Then, the left pods which have no key1 but have key2
-                          in labels will be sorted by the value of key2 and put behind
-                          those pods have key1.'
+                        description: |-
+                          Order priority terms, pods will be sorted by the value of orderedKey.
+                          For example:
+                          ```
+                          orderPriority:
+                          - orderedKey: key1
+                          - orderedKey: key2
+                          ```
+                          First, all pods which have key1 in labels will be sorted by the value of key1.
+                          Then, the left pods which have no key1 but have key2 in labels will be sorted by
+                          the value of key2 and put behind those pods have key1.
                         items:
                           description: UpdatePriorityOrderTerm defines order priority.
                           properties:
                             orderedKey:
-                              description: Calculate priority by value of this key.
-                                Values of this key, will be sorted by GetInt(val).
-                                GetInt method will find the last int in value, such
-                                as getting 5 in value '5', getting 10 in value 'sts-10'.
+                              description: |-
+                                Calculate priority by value of this key.
+                                Values of this key, will be sorted by GetInt(val). GetInt method will find the last int in value,
+                                such as getting 5 in value '5', getting 10 in value 'sts-10'.
                               type: string
                           required:
                           - orderedKey
@@ -336,26 +355,25 @@ spec:
                                   description: matchExpressions is a list of label
                                     selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
                                         description: key is the label key that the
                                           selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -367,14 +385,13 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             weight:
                               description: Weight associated with matching the corresponding
                                 matchExpressions, in the range 1-100.
@@ -387,14 +404,11 @@ spec:
                         type: array
                     type: object
                   scatterStrategy:
-                    description: ScatterStrategy defines the scatter rules to make
-                      pods been scattered when update. This will avoid pods with the
-                      same key-value to be updated in one batch. - Note that pods
-                      will be scattered after priority sort. So, although priority
-                      strategy and scatter strategy can be applied together, we suggest
-                      to use either one of them. - If scatterStrategy is used, we
-                      suggest to just use one term. Otherwise, the update order can
-                      be hard to understand.
+                    description: |-
+                      ScatterStrategy defines the scatter rules to make pods been scattered when update.
+                      This will avoid pods with the same key-value to be updated in one batch.
+                      - Note that pods will be scattered after priority sort. So, although priority strategy and scatter strategy can be applied together, we suggest to use either one of them.
+                      - If scatterStrategy is used, we suggest to just use one term. Otherwise, the update order can be hard to understand.
                     items:
                       properties:
                         key:
@@ -407,14 +421,15 @@ spec:
                       type: object
                     type: array
                   type:
-                    description: Type indicates the type of the CloneSetUpdateStrategy.
+                    description: |-
+                      Type indicates the type of the CloneSetUpdateStrategy.
                       Default is ReCreate.
                     type: string
                 type: object
               volumeClaimTemplates:
-                description: VolumeClaimTemplates is a list of claims that pods are
-                  allowed to reference. Note that PVC will be deleted when its pod
-                  has been deleted.
+                description: |-
+                  VolumeClaimTemplates is a list of claims that pods are allowed to reference.
+                  Note that PVC will be deleted when its pod has been deleted.
                 x-kubernetes-preserve-unknown-fields: true
             required:
             - selector
@@ -429,10 +444,10 @@ spec:
                 format: int32
                 type: integer
               collisionCount:
-                description: CollisionCount is the count of hash collisions for the
-                  CloneSet. The CloneSet controller uses this field as a collision
-                  avoidance mechanism when it needs to create the name for the newest
-                  ControllerRevision.
+                description: |-
+                  CollisionCount is the count of hash collisions for the CloneSet. The CloneSet controller
+                  uses this field as a collision avoidance mechanism when it needs to create the name for the
+                  newest ControllerRevision.
                 format: int32
                 type: integer
               conditions:
@@ -470,9 +485,9 @@ spec:
                   revision version of the CloneSet.
                 type: string
               expectedUpdatedReplicas:
-                description: ExpectedUpdatedReplicas is the number of Pods that should
-                  be updated by CloneSet controller. This field is calculated via
-                  Replicas - Partition.
+                description: |-
+                  ExpectedUpdatedReplicas is the number of Pods that should be updated by CloneSet controller.
+                  This field is calculated via Replicas - Partition.
                 format: int32
                 type: integer
               labelSelector:
@@ -480,9 +495,9 @@ spec:
                   that should match the replica count used by HPA.
                 type: string
               observedGeneration:
-                description: ObservedGeneration is the most recent generation observed
-                  for this CloneSet. It corresponds to the CloneSet's generation,
-                  which is updated on mutation by the API Server.
+                description: |-
+                  ObservedGeneration is the most recent generation observed for this CloneSet. It corresponds to the
+                  CloneSet's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
               readyReplicas:
@@ -499,15 +514,24 @@ spec:
                 description: UpdateRevision, if not empty, indicates the latest revision
                   of the CloneSet.
                 type: string
+              updatedAvailableReplicas:
+                description: |-
+                  UpdatedAvailableReplicas is the number of Pods created by the CloneSet controller from the CloneSet version
+                  indicated by updateRevision and have a Ready Condition for at least minReadySeconds.
+                  Notice: when enable InPlaceWorkloadVerticalScaling, pod during resource resizing will also be unavailable.
+                  This means these pod will be counted in maxUnavailable.
+                format: int32
+                type: integer
               updatedReadyReplicas:
-                description: UpdatedReadyReplicas is the number of Pods created by
-                  the CloneSet controller from the CloneSet version indicated by updateRevision
-                  and have a Ready Condition.
+                description: |-
+                  UpdatedReadyReplicas is the number of Pods created by the CloneSet controller from the CloneSet version
+                  indicated by updateRevision and have a Ready Condition.
                 format: int32
                 type: integer
               updatedReplicas:
-                description: UpdatedReplicas is the number of Pods created by the
-                  CloneSet controller from the CloneSet version indicated by updateRevision.
+                description: |-
+                  UpdatedReplicas is the number of Pods created by the CloneSet controller from the CloneSet version
+                  indicated by updateRevision.
                 format: int32
                 type: integer
             required:
@@ -526,10 +550,4 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}

--- a/charts/kruise/templates/apps.kruise.io_containerrecreaterequests.yaml
+++ b/charts/kruise/templates/apps.kruise.io_containerrecreaterequests.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.crds.managed }}
-
+ 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: containerrecreaterequests.apps.kruise.io
 spec:
   group: apps.kruise.io
@@ -46,14 +45,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -74,41 +78,46 @@ spec:
                     that need to recreate.
                   properties:
                     name:
-                      description: Name of the container that need to recreate. It
-                        must be existing in the real pod.Spec.Containers.
+                      description: |-
+                        Name of the container that need to recreate.
+                        It must be existing in the real pod.Spec.Containers.
                       type: string
                     ports:
-                      description: Ports is synced from the real container in Pod
-                        spec during this ContainerRecreateRequest creating. Populated
-                        by the system. Read-only.
+                      description: |-
+                        Ports is synced from the real container in Pod spec during this ContainerRecreateRequest creating.
+                        Populated by the system.
+                        Read-only.
                       items:
                         description: ContainerPort represents a network port in a
                           single container.
                         properties:
                           containerPort:
-                            description: Number of port to expose on the pod's IP
-                              address. This must be a valid port number, 0 < x < 65536.
+                            description: |-
+                              Number of port to expose on the pod's IP address.
+                              This must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           hostIP:
                             description: What host IP to bind the external port to.
                             type: string
                           hostPort:
-                            description: Number of port to expose on the host. If
-                              specified, this must be a valid port number, 0 < x <
-                              65536. If HostNetwork is specified, this must match
-                              ContainerPort. Most containers do not need this.
+                            description: |-
+                              Number of port to expose on the host.
+                              If specified, this must be a valid port number, 0 < x < 65536.
+                              If HostNetwork is specified, this must match ContainerPort.
+                              Most containers do not need this.
                             format: int32
                             type: integer
                           name:
-                            description: If specified, this must be an IANA_SVC_NAME
-                              and unique within the pod. Each named port in a pod
-                              must have a unique name. Name for the port that can
-                              be referred to by services.
+                            description: |-
+                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                              named port in a pod must have a unique name. Name for the port that can be
+                              referred to by services.
                             type: string
                           protocol:
                             default: TCP
-                            description: Protocol for port. Must be UDP, TCP, or SCTP.
+                            description: |-
+                              Protocol for port. Must be UDP, TCP, or SCTP.
                               Defaults to "TCP".
                             type: string
                         required:
@@ -116,23 +125,23 @@ spec:
                         type: object
                       type: array
                     preStop:
-                      description: PreStop is synced from the real container in Pod
-                        spec during this ContainerRecreateRequest creating. Populated
-                        by the system. Read-only.
+                      description: |-
+                        PreStop is synced from the real container in Pod spec during this ContainerRecreateRequest creating.
+                        Populated by the system.
+                        Read-only.
                       properties:
                         exec:
-                          description: One and only one of the following should be
-                            specified. Exec specifies the action to take.
+                          description: |-
+                            One and only one of the following should be specified.
+                            Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute
-                                inside the container, the working directory for the
-                                command  is root ('/') in the container's filesystem.
-                                The command is simply exec'd, it is not run inside
-                                a shell, so traditional shell instructions ('|', etc)
-                                won't work. To use a shell, you need to explicitly
-                                call out to that shell. Exit status of 0 is treated
-                                as live/healthy and non-zero is unhealthy.
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                a shell, you need to explicitly call out to that shell.
+                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
@@ -141,9 +150,9 @@ spec:
                           description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
                               description: Custom headers to set in the request. HTTP
@@ -153,7 +162,9 @@ spec:
                                   to be used in HTTP probes
                                 properties:
                                   name:
-                                    description: The header field name
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
                                     description: The header field value
@@ -170,21 +181,24 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on
-                                the container. Number must be in the range 1 to 65535.
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
                                 Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host.
+                              description: |-
+                                Scheme to use for connecting to the host.
                                 Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         tcpSocket:
-                          description: 'TCPSocket specifies an action involving a
-                            TCP port. TCP hooks not yet supported TODO: implement
-                            a realistic TCP lifecycle hook'
+                          description: |-
+                            TCPSocket specifies an action involving a TCP port.
+                            TCP hooks not yet supported
+                            TODO: implement a realistic TCP lifecycle hook
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults
@@ -194,8 +208,9 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on
-                                the container. Number must be in the range 1 to 65535.
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
                                 Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
@@ -203,20 +218,20 @@ spec:
                           type: object
                       type: object
                     statusContext:
-                      description: StatusContext is synced from the real Pod status
-                        during this ContainerRecreateRequest creating. Populated by
-                        the system. Read-only.
+                      description: |-
+                        StatusContext is synced from the real Pod status during this ContainerRecreateRequest creating.
+                        Populated by the system.
+                        Read-only.
                       properties:
                         containerID:
                           description: Container's ID in the format 'docker://<container_id>'.
                           type: string
                         restartCount:
-                          description: The number of times the container has been
-                            restarted, currently based on the number of dead containers
-                            that have not yet been removed. Note that this is calculated
-                            from dead containers. But those containers are subject
-                            to garbage collection. This value will get capped at 5
-                            by GC.
+                          description: |-
+                            The number of times the container has been restarted, currently based on
+                            the number of dead containers that have not yet been removed.
+                            Note that this is calculated from dead containers. But those containers are subject to
+                            garbage collection. This value will get capped at 5 by GC.
                           format: int32
                           type: integer
                       required:
@@ -242,10 +257,10 @@ spec:
                       container even if the previous container is starting.
                     type: boolean
                   minStartedSeconds:
-                    description: Minimum number of seconds for which a newly created
-                      container should be started and ready without any of its container
-                      crashing, for it to be considered Succeeded. Defaults to 0 (container
-                      will be considered Succeeded as soon as it is started and ready)
+                    description: |-
+                      Minimum number of seconds for which a newly created container should be started and ready
+                      without any of its container crashing, for it to be considered Succeeded.
+                      Defaults to 0 (container will be considered Succeeded as soon as it is started and ready)
                     format: int32
                     type: integer
                   orderedRecreate:
@@ -253,16 +268,15 @@ spec:
                       next container only if the previous one has recreated completely.
                     type: boolean
                   terminationGracePeriodSeconds:
-                    description: TerminationGracePeriodSeconds is the optional duration
-                      in seconds to wait the container terminating gracefully. Value
-                      must be non-negative integer. The value zero indicates delete
-                      immediately. If this value is nil, we will use pod.Spec.TerminationGracePeriodSeconds
-                      as default value.
+                    description: |-
+                      TerminationGracePeriodSeconds is the optional duration in seconds to wait the container terminating gracefully.
+                      Value must be non-negative integer. The value zero indicates delete immediately.
+                      If this value is nil, we will use pod.Spec.TerminationGracePeriodSeconds as default value.
                     format: int64
                     type: integer
                   unreadyGracePeriodSeconds:
-                    description: UnreadyGracePeriodSeconds is the optional duration
-                      in seconds to mark Pod as not ready over this duration before
+                    description: |-
+                      UnreadyGracePeriodSeconds is the optional duration in seconds to mark Pod as not ready over this duration before
                       executing preStop hook and stopping the container.
                     format: int64
                     type: integer
@@ -281,10 +295,10 @@ spec:
               of ContainerRecreateRequest
             properties:
               completionTime:
-                description: Represents time when the ContainerRecreateRequest was
-                  completed. It is not guaranteed to be set in happens-before order
-                  across separate operations. It is represented in RFC3339 form and
-                  is in UTC.
+                description: |-
+                  Represents time when the ContainerRecreateRequest was completed. It is not guaranteed to
+                  be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               containerRecreateStates:
@@ -328,10 +342,4 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}

--- a/charts/kruise/templates/apps.kruise.io_daemonsets.yaml
+++ b/charts/kruise/templates/apps.kruise.io_daemonsets.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.crds.managed }}
-
+ 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: daemonsets.apps.kruise.io
 spec:
   group: apps.kruise.io
@@ -64,14 +63,19 @@ spec:
         description: DaemonSet is the Schema for the daemonsets API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -82,13 +86,14 @@ spec:
                 anyOf:
                 - type: integer
                 - type: string
-                description: BurstReplicas is a rate limiter for booting pods on a
-                  lot of pods. The default value is 250
+                description: |-
+                  BurstReplicas is a rate limiter for booting pods on a lot of pods.
+                  The default value is 250
                 x-kubernetes-int-or-string: true
               lifecycle:
-                description: Lifecycle defines the lifecycle hooks for Pods pre-delete,
-                  in-place update. Currently, we only support pre-delete hook for
-                  Advanced DaemonSet.
+                description: |-
+                  Lifecycle defines the lifecycle hooks for Pods pre-delete, in-place update.
+                  Currently, we only support pre-delete hook for Advanced DaemonSet.
                 properties:
                   inPlaceUpdate:
                     description: InPlaceUpdate is the hook before Pod to update and
@@ -103,12 +108,12 @@ spec:
                           type: string
                         type: object
                       markPodNotReady:
-                        description: 'MarkPodNotReady = true means: - Pod will be
-                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
-                          - Pod will be restored to ''Ready'' at Updated state if
-                          it was set to ''NotReady'' at preparingUpdate state. Currently,
-                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
-                          hook. Default to false.'
+                        description: |-
+                          MarkPodNotReady = true means:
+                          - Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.
+                          Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook.
+                          Default to false.
                         type: boolean
                     type: object
                   preDelete:
@@ -123,12 +128,12 @@ spec:
                           type: string
                         type: object
                       markPodNotReady:
-                        description: 'MarkPodNotReady = true means: - Pod will be
-                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
-                          - Pod will be restored to ''Ready'' at Updated state if
-                          it was set to ''NotReady'' at preparingUpdate state. Currently,
-                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
-                          hook. Default to false.'
+                        description: |-
+                          MarkPodNotReady = true means:
+                          - Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.
+                          Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook.
+                          Default to false.
                         type: boolean
                     type: object
                   preNormal:
@@ -144,55 +149,59 @@ spec:
                           type: string
                         type: object
                       markPodNotReady:
-                        description: 'MarkPodNotReady = true means: - Pod will be
-                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
-                          - Pod will be restored to ''Ready'' at Updated state if
-                          it was set to ''NotReady'' at preparingUpdate state. Currently,
-                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
-                          hook. Default to false.'
+                        description: |-
+                          MarkPodNotReady = true means:
+                          - Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.
+                          Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook.
+                          Default to false.
                         type: boolean
                     type: object
                 type: object
               minReadySeconds:
-                description: The minimum number of seconds for which a newly created
-                  DaemonSet pod should be ready without any of its container crashing,
-                  for it to be considered available. Defaults to 0 (pod will be considered
-                  available as soon as it is ready).
+                description: |-
+                  The minimum number of seconds for which a newly created DaemonSet pod should
+                  be ready without any of its container crashing, for it to be considered
+                  available. Defaults to 0 (pod will be considered available as soon as it
+                  is ready).
                 format: int32
                 type: integer
               revisionHistoryLimit:
-                description: The number of old history to retain to allow rollback.
+                description: |-
+                  The number of old history to retain to allow rollback.
                   This is a pointer to distinguish between explicit zero and not specified.
                   Defaults to 10.
                 format: int32
                 type: integer
               selector:
-                description: 'A label query over pods that are managed by the daemon
-                  set. Must match in order to be controlled. It must match the pod
-                  template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                description: |-
+                  A label query over pods that are managed by the daemon set.
+                  Must match in order to be controlled.
+                  It must match the pod template's labels.
+                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
@@ -205,18 +214,20 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               template:
-                description: 'An object that describes the pod that will be created.
-                  The DaemonSet will create exactly one copy of this pod on every
-                  node that matches the template''s node selector (or on every node
-                  if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template'
+                description: |-
+                  An object that describes the pod that will be created.
+                  The DaemonSet will create exactly one copy of this pod on every node
+                  that matches the template's node selector (or on every node if no node
+                  selector is specified).
+                  More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
                 x-kubernetes-preserve-unknown-fields: true
               updateStrategy:
                 description: An update strategy to replace existing DaemonSet pods
@@ -230,74 +241,74 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'The maximum number of nodes with an existing
-                          available DaemonSet pod that can have an updated DaemonSet
-                          pod during during an update. Value can be an absolute number
-                          (ex: 5) or a percentage of desired pods (ex: 10%). This
-                          can not be 0 if MaxUnavailable is 0. Absolute number is
-                          calculated from percentage by rounding up to a minimum of
-                          1. Default value is 0. Example: when this is set to 30%,
-                          at most 30% of the total number of nodes that should be
-                          running the daemon pod (i.e. status.desiredNumberScheduled)
-                          can have their a new pod created before the old pod is marked
-                          as deleted. The update starts by launching new pods on 30%
-                          of nodes. Once an updated pod is available (Ready for at
-                          least minReadySeconds) the old DaemonSet pod on that node
-                          is marked deleted. If the old pod becomes unavailable for
-                          any reason (Ready transitions to false, is evicted, or is
-                          drained) an updated pod is immediatedly created on that
-                          node without considering surge limits. Allowing surge implies
-                          the possibility that the resources consumed by the daemonset
-                          on any given node can double if the readiness check fails,
-                          and so resource intensive daemonsets should take into account
-                          that they may cause evictions during disruption. This is
-                          beta field and enabled/disabled by DaemonSetUpdateSurge
-                          feature gate.'
+                        description: |-
+                          The maximum number of nodes with an existing available DaemonSet pod that
+                          can have an updated DaemonSet pod during during an update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0.
+                          Absolute number is calculated from percentage by rounding up to a minimum of 1.
+                          Default value is 0.
+                          Example: when this is set to 30%, at most 30% of the total number of nodes
+                          that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                          can have their a new pod created before the old pod is marked as deleted.
+                          The update starts by launching new pods on 30% of nodes. Once an updated
+                          pod is available (Ready for at least minReadySeconds) the old DaemonSet pod
+                          on that node is marked deleted. If the old pod becomes unavailable for any
+                          reason (Ready transitions to false, is evicted, or is drained) an updated
+                          pod is immediately created on that node without considering surge limits.
+                          Allowing surge implies the possibility that the resources consumed by the
+                          daemonset on any given node can double if the readiness check fails, and
+                          so resource intensive daemonsets should take into account that they may
+                          cause evictions during disruption.
+                          This is beta field and enabled/disabled by DaemonSetUpdateSurge feature gate.
                         x-kubernetes-int-or-string: true
                       maxUnavailable:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'The maximum number of DaemonSet pods that can
-                          be unavailable during the update. Value can be an absolute
-                          number (ex: 5) or a percentage of total number of DaemonSet
-                          pods at the start of the update (ex: 10%). Absolute number
-                          is calculated from percentage by rounding up. This cannot
-                          be 0 if MaxSurge is 0 Default value is 1. Example: when
-                          this is set to 30%, at most 30% of the total number of nodes
+                        description: |-
+                          The maximum number of DaemonSet pods that can be unavailable during the
+                          update. Value can be an absolute number (ex: 5) or a percentage of total
+                          number of DaemonSet pods at the start of the update (ex: 10%). Absolute
+                          number is calculated from percentage by rounding up.
+                          This cannot be 0 if MaxSurge is 0
+                          Default value is 1.
+                          Example: when this is set to 30%, at most 30% of the total number of nodes
                           that should be running the daemon pod (i.e. status.desiredNumberScheduled)
-                          can have their pods stopped for an update at any given time.
-                          The update starts by stopping at most 30% of those DaemonSet
-                          pods and then brings up new DaemonSet pods in their place.
-                          Once the new pods are available, it then proceeds onto other
-                          DaemonSet pods, thus ensuring that at least 70% of original
-                          number of DaemonSet pods are available at all times during
-                          the update.'
+                          can have their pods stopped for an update at any given time. The update
+                          starts by stopping at most 30% of those DaemonSet pods and then brings
+                          up new DaemonSet pods in their place. Once the new pods are available,
+                          it then proceeds onto other DaemonSet pods, thus ensuring that at least
+                          70% of original number of DaemonSet pods are available at all times during
+                          the update.
                         x-kubernetes-int-or-string: true
                       partition:
-                        description: The number of DaemonSet pods remained to be old
-                          version. Default value is 0. Maximum value is status.DesiredNumberScheduled,
-                          which means no pod will be updated.
+                        description: |-
+                          The number of DaemonSet pods remained to be old version.
+                          Default value is 0.
+                          Maximum value is status.DesiredNumberScheduled, which means no pod will be updated.
                         format: int32
                         type: integer
                       paused:
-                        description: Indicates that the daemon set is paused and will
-                          not be processed by the daemon set controller.
+                        description: |-
+                          Indicates that the daemon set is paused and will not be processed by the
+                          daemon set controller.
                         type: boolean
                       rollingUpdateType:
                         description: Type is to specify which kind of rollingUpdate.
                         type: string
                       selector:
-                        description: A label query over nodes that are managed by
-                          the daemon set RollingUpdate. Must match in order to be
-                          controlled. It must match the node's labels.
+                        description: |-
+                          A label query over nodes that are managed by the daemon set RollingUpdate.
+                          Must match in order to be controlled.
+                          It must match the node's labels.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
                               requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
                                 relates the key and values.
                               properties:
                                 key:
@@ -305,17 +316,16 @@ spec:
                                     applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -327,13 +337,13 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
+                        x-kubernetes-map-type: atomic
                     type: object
                   type:
                     description: Type of daemon set update. Can be "RollingUpdate"
@@ -348,9 +358,10 @@ spec:
             description: DaemonSetStatus defines the observed state of DaemonSet
             properties:
               collisionCount:
-                description: Count of hash collisions for the DaemonSet. The DaemonSet
-                  controller uses this field as a collision avoidance mechanism when
-                  it needs to create the name for the newest ControllerRevision.
+                description: |-
+                  Count of hash collisions for the DaemonSet. The DaemonSet controller
+                  uses this field as a collision avoidance mechanism when it needs to
+                  create the name for the newest ControllerRevision.
                 format: int32
                 type: integer
               conditions:
@@ -384,8 +395,10 @@ spec:
                   type: object
                 type: array
               currentNumberScheduled:
-                description: 'The number of nodes that are running at least 1 daemon
-                  pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                description: |-
+                  The number of nodes that are running at least 1
+                  daemon pod and are supposed to run the daemon pod.
+                  More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
                 format: int32
                 type: integer
               daemonSetHash:
@@ -393,31 +406,37 @@ spec:
                   represents the latest version of the DaemonSet.
                 type: string
               desiredNumberScheduled:
-                description: 'The total number of nodes that should be running the
-                  daemon pod (including nodes correctly running the daemon pod). More
-                  info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                description: |-
+                  The total number of nodes that should be running the daemon
+                  pod (including nodes correctly running the daemon pod).
+                  More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
                 format: int32
                 type: integer
               numberAvailable:
-                description: The number of nodes that should be running the daemon
-                  pod and have one or more of the daemon pod running and available
-                  (ready for at least spec.minReadySeconds)
+                description: |-
+                  The number of nodes that should be running the
+                  daemon pod and have one or more of the daemon pod running and
+                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               numberMisscheduled:
-                description: 'The number of nodes that are running the daemon pod,
-                  but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                description: |-
+                  The number of nodes that are running the daemon pod, but are
+                  not supposed to run the daemon pod.
+                  More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
                 format: int32
                 type: integer
               numberReady:
-                description: The number of nodes that should be running the daemon
-                  pod and have one or more of the daemon pod running and ready.
+                description: |-
+                  The number of nodes that should be running the daemon pod and have one
+                  or more of the daemon pod running and ready.
                 format: int32
                 type: integer
               numberUnavailable:
-                description: The number of nodes that should be running the daemon
-                  pod and have none of the daemon pod running and available (ready
-                  for at least spec.minReadySeconds)
+                description: |-
+                  The number of nodes that should be running the
+                  daemon pod and have none of the daemon pod running and available
+                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               observedGeneration:
@@ -443,10 +462,4 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}

--- a/charts/kruise/templates/apps.kruise.io_imagelistpulljobs.yaml
+++ b/charts/kruise/templates/apps.kruise.io_imagelistpulljobs.yaml
@@ -6,32 +6,28 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
-  name: imagepulljobs.apps.kruise.io
+  name: imagelistpulljobs.apps.kruise.io
 spec:
   group: apps.kruise.io
   names:
-    kind: ImagePullJob
-    listKind: ImagePullJobList
-    plural: imagepulljobs
-    singular: imagepulljob
+    kind: ImageListPullJob
+    listKind: ImageListPullJobList
+    plural: imagelistpulljobs
+    singular: imagelistpulljob
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Number of all nodes matched by this job
+    - description: Number of image pull job
       jsonPath: .status.desired
       name: TOTAL
       type: integer
-    - description: Number of image pull task active
-      jsonPath: .status.active
-      name: ACTIVE
-      type: integer
-    - description: Number of image pull task succeeded
+    - description: Number of image pull job succeeded
       jsonPath: .status.succeeded
-      name: SUCCEED
+      name: SUCCEEDED
       type: integer
-    - description: Number of image pull tasks failed
-      jsonPath: .status.failed
-      name: FAILED
+    - description: Number of ImagePullJobs which are finished
+      jsonPath: .status.completed
+      name: COMPLETED
       type: integer
     - description: CreationTimestamp is a timestamp representing the server time when
         this object was created. It is not guaranteed to be set in happens-before
@@ -40,14 +36,10 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
-    - description: Summary of status when job is failed
-      jsonPath: .status.message
-      name: MESSAGE
-      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ImagePullJob is the Schema for the imagepulljobs API
+        description: ImageListPullJob is the Schema for the imagelistpulljobs API
         properties:
           apiVersion:
             description: |-
@@ -67,7 +59,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: ImagePullJobSpec defines the desired state of ImagePullJob
+            description: ImageListPullJobSpec defines the desired state of ImageListPullJob
             properties:
               completionPolicy:
                 description: |-
@@ -101,14 +93,16 @@ spec:
                       Default is Always.
                     type: string
                 type: object
-              image:
-                description: Image is the image to be pulled by the job
-                type: string
               imagePullPolicy:
                 description: |-
                   Image pull policy.
                   One of Always, IfNotPresent. Defaults to IfNotPresent.
                 type: string
+              images:
+                description: Images is the image list to be pulled by the job
+                items:
+                  type: string
+                type: array
               parallelism:
                 anyOf:
                 - type: integer
@@ -255,39 +249,50 @@ spec:
                 x-kubernetes-map-type: atomic
             required:
             - completionPolicy
-            - image
+            - images
             type: object
           status:
-            description: ImagePullJobStatus defines the observed state of ImagePullJob
+            description: ImageListPullJobStatus defines the observed state of ImageListPullJob
             properties:
               active:
-                description: The number of actively running pulling tasks.
+                description: The number of running ImagePullJobs which are acknowledged
+                  by the imagepulljob controller.
+                format: int32
+                type: integer
+              completed:
+                description: The number of ImagePullJobs which are finished
                 format: int32
                 type: integer
               completionTime:
                 description: |-
-                  Represents time when the job was completed. It is not guaranteed to
+                  Represents time when the all the image pull job was completed. It is not guaranteed to
                   be set in happens-before order across separate operations.
                   It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               desired:
-                description: The desired number of pulling tasks, this is typically
-                  equal to the number of nodes satisfied.
+                description: The desired number of ImagePullJobs, this is typically
+                  equal to the number of len(spec.Images).
                 format: int32
                 type: integer
-              failed:
-                description: The number of pulling tasks  which reached phase Failed.
-                format: int32
-                type: integer
-              failedNodes:
-                description: The nodes that failed to pull the image.
+              failedImageStatuses:
+                description: The status of ImagePullJob which has the failed nodes(status.Failed>0)
+                  .
                 items:
-                  type: string
+                  description: FailedImageStatus the state of ImagePullJob which has
+                    the failed nodes(status.Failed>0)
+                  properties:
+                    imagePullJob:
+                      description: The name of ImagePullJob which has the failed nodes(status.Failed>0)
+                      type: string
+                    message:
+                      description: The text prompt for job running status.
+                      type: string
+                    name:
+                      description: Name of the image
+                      type: string
+                  type: object
                 type: array
-              message:
-                description: The text prompt for job running status.
-                type: string
               startTime:
                 description: |-
                   Represents time when the job was acknowledged by the job controller.
@@ -296,7 +301,7 @@ spec:
                 format: date-time
                 type: string
               succeeded:
-                description: The number of pulling tasks which reached phase Succeeded.
+                description: The number of image pull job which are finished and status.Succeeded==status.Desired.
                 format: int32
                 type: integer
             required:

--- a/charts/kruise/templates/apps.kruise.io_nodeimages.yaml
+++ b/charts/kruise/templates/apps.kruise.io_nodeimages.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.crds.managed }}
-
+ 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: nodeimages.apps.kruise.io
 spec:
   group: apps.kruise.io
@@ -47,14 +46,19 @@ spec:
         description: NodeImage is the Schema for the nodeimages API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -66,14 +70,14 @@ spec:
                   description: ImageSpec defines the pulling spec of an image
                   properties:
                     pullSecrets:
-                      description: PullSecrets is an optional list of references to
-                        secrets in the same namespace to use for pulling the image.
-                        If specified, these secrets will be passed to individual puller
-                        implementations for them to use.  For example, in the case
-                        of docker, only DockerConfig type secrets are honored.
+                      description: |-
+                        PullSecrets is an optional list of references to secrets in the same namespace to use for pulling the image.
+                        If specified, these secrets will be passed to individual puller implementations for them to use.  For example,
+                        in the case of docker, only DockerConfig type secrets are honored.
                       items:
-                        description: ReferenceObject comprises a resource name, with
-                          a mandatory namespace, rendered as "<namespace>/<name>".
+                        description: |-
+                          ReferenceObject comprises a resource name, with a mandatory namespace,
+                          rendered as "<namespace>/<name>".
                         properties:
                           name:
                             type: string
@@ -104,112 +108,107 @@ spec:
                             description: Specifies the create time of this tag
                             format: date-time
                             type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy.
+                              One of Always, IfNotPresent. Defaults to IfNotPresent.
+                            type: string
                           ownerReferences:
-                            description: List of objects depended by this object.
-                              If this image is managed by a controller, then an entry
-                              in this list will point to this controller.
+                            description: |-
+                              List of objects depended by this object. If this image is managed by a controller,
+                              then an entry in this list will point to this controller.
                             items:
-                              description: 'ObjectReference contains enough information
-                                to let you inspect or modify the referred object.
-                                --- New uses of this type are discouraged because
-                                of difficulty describing its usage when embedded in
-                                APIs.  1. Ignored fields.  It includes many fields
-                                which are not generally honored.  For instance, ResourceVersion
-                                and FieldPath are both very rarely valid in actual
-                                usage.  2. Invalid usage help.  It is impossible to
-                                add specific help for individual usage.  In most embedded
-                                usages, there are particular     restrictions like,
-                                "must refer only to types A and B" or "UID not honored"
-                                or "name must be restricted".     Those cannot be
-                                well described when embedded.  3. Inconsistent validation.  Because
-                                the usages are different, the validation rules are
-                                different by usage, which makes it hard for users
-                                to predict what will happen.  4. The fields are both
-                                imprecise and overly precise.  Kind is not a precise
-                                mapping to a URL. This can produce ambiguity     during
-                                interpretation and require a REST mapping.  In most
-                                cases, the dependency is on the group,resource tuple     and
-                                the version of the actual struct is irrelevant.  5.
-                                We cannot easily change it.  Because this type is
-                                embedded in many locations, updates to this type     will
-                                affect numerous schemas.  Don''t make new APIs embed
-                                an underspecified API type they do not control. Instead
-                                of using this type, create a locally provided and
-                                used type that is well-focused on your reference.
-                                For example, ServiceReferences for admission registration:
-                                https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                                .'
+                              description: |-
+                                ObjectReference contains enough information to let you inspect or modify the referred object.
+                                ---
+                                New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                                 1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                                 2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                                    restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                                    Those cannot be well described when embedded.
+                                 3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                                 4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                                    during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                                    and the version of the actual struct is irrelevant.
+                                 5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                                    will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                                Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                                For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
                               properties:
                                 apiVersion:
                                   description: API version of the referent.
                                   type: string
                                 fieldPath:
-                                  description: 'If referring to a piece of an object
-                                    instead of an entire object, this string should
-                                    contain a valid JSON/Go field access statement,
-                                    such as desiredState.manifest.containers[2]. For
-                                    example, if the object reference is to a container
-                                    within a pod, this would take on a value like:
-                                    "spec.containers{name}" (where "name" refers to
-                                    the name of the container that triggered the event)
-                                    or if no container name is specified "spec.containers[2]"
-                                    (container with index 2 in this pod). This syntax
-                                    is chosen only to have some well-defined way of
-                                    referencing a part of an object. TODO: this design
-                                    is not final and this field is subject to change
-                                    in the future.'
+                                  description: |-
+                                    If referring to a piece of an object instead of an entire object, this string
+                                    should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                    For example, if the object reference is to a container within a pod, this would take on a value like:
+                                    "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                    the event) or if no container name is specified "spec.containers[2]" (container with
+                                    index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                    referencing a part of an object.
+                                    TODO: this design is not final and this field is subject to change in the future.
                                   type: string
                                 kind:
-                                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                  description: |-
+                                    Kind of the referent.
+                                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 namespace:
-                                  description: 'Namespace of the referent. More info:
-                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                  description: |-
+                                    Namespace of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                                   type: string
                                 resourceVersion:
-                                  description: 'Specific resourceVersion to which
-                                    this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                  description: |-
+                                    Specific resourceVersion to which this reference is made, if any.
+                                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                                   type: string
                                 uid:
-                                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                  description: |-
+                                    UID of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                                   type: string
                               type: object
+                              x-kubernetes-map-type: atomic
                             type: array
                           pullPolicy:
-                            description: PullPolicy is an optional field to set parameters
-                              of the pulling task. If not specified, the system will
-                              use the default values.
+                            description: |-
+                              PullPolicy is an optional field to set parameters of the pulling task. If not specified,
+                              the system will use the default values.
                             properties:
                               activeDeadlineSeconds:
-                                description: ActiveDeadlineSeconds specifies the duration
-                                  in seconds relative to the startTime that the task
-                                  may be active before the system tries to terminate
-                                  it; value must be positive integer. if not specified,
-                                  the system will never terminate it.
+                                description: |-
+                                  ActiveDeadlineSeconds specifies the duration in seconds relative to the startTime that the task may be active
+                                  before the system tries to terminate it; value must be positive integer.
+                                  if not specified, the system will never terminate it.
                                 format: int64
                                 type: integer
                               backoffLimit:
-                                description: Specifies the number of retries before
-                                  marking the pulling task failed. Defaults to 3
+                                description: |-
+                                  Specifies the number of retries before marking the pulling task failed.
+                                  Defaults to 3
                                 format: int32
                                 type: integer
                               timeoutSeconds:
-                                description: Specifies the timeout of the pulling
-                                  task. Defaults to 600
+                                description: |-
+                                  Specifies the timeout of the pulling task.
+                                  Defaults to 600
                                 format: int32
                                 type: integer
                               ttlSecondsAfterFinished:
-                                description: TTLSecondsAfterFinished limits the lifetime
-                                  of a pulling task that has finished execution (either
-                                  Complete or Failed). If this field is set, ttlSecondsAfterFinished
-                                  after the task finishes, it is eligible to be automatically
-                                  deleted. If this field is unset, the task won't
-                                  be automatically deleted. If this field is set to
-                                  zero, the task becomes eligible to be deleted immediately
-                                  after it finishes.
+                                description: |-
+                                  TTLSecondsAfterFinished limits the lifetime of a pulling task that has finished execution (either Complete or Failed).
+                                  If this field is set, ttlSecondsAfterFinished after the task finishes, it is eligible to be automatically deleted.
+                                  If this field is unset, the task won't be automatically deleted.
+                                  If this field is set to zero, the task becomes eligible to be deleted immediately after it finishes.
                                 format: int32
                                 type: integer
                             type: object
@@ -217,14 +216,16 @@ spec:
                             description: Specifies the image tag
                             type: string
                           version:
-                            description: "An opaque value that represents the internal
-                              version of this tag that can be used by clients to determine
-                              when objects have changed. May be used for optimistic
-                              concurrency, change detection, and the watch operation
-                              on a resource or set of resources. Clients must treat
-                              these values as opaque and passed unmodified back to
-                              the server. \n Populated by the system. Read-only. Value
-                              must be treated as opaque by clients and ."
+                            description: |-
+                              An opaque value that represents the internal version of this tag that can
+                              be used by clients to determine when objects have changed. May be used for optimistic
+                              concurrency, change detection, and the watch operation on a resource or set of resources.
+                              Clients must treat these values as opaque and passed unmodified back to the server.
+
+
+                              Populated by the system.
+                              Read-only.
+                              Value must be treated as opaque by clients and .
                             format: int64
                             type: integer
                         required:
@@ -234,8 +235,9 @@ spec:
                   required:
                   - tags
                   type: object
-                description: Specifies images to be pulled on this node It can not
-                  be more than 256 for each NodeImage
+                description: |-
+                  Specifies images to be pulled on this node
+                  It can not be more than 256 for each NodeImage
                 type: object
             type: object
           status:
@@ -251,10 +253,9 @@ spec:
                 format: int32
                 type: integer
               firstSyncStatus:
-                description: The first of all job has finished on this node. When
-                  a node is added to the cluster, we want to know the time when the
-                  node's image pulling is completed, and use it to trigger the operation
-                  of the upper system.
+                description: |-
+                  The first of all job has finished on this node. When a node is added to the cluster, we want to know
+                  the time when the node's image pulling is completed, and use it to trigger the operation of the upper system.
                 properties:
                   message:
                     type: string
@@ -276,10 +277,10 @@ spec:
                           an image tag
                         properties:
                           completionTime:
-                            description: Represents time when the pulling task was
-                              completed. It is not guaranteed to be set in happens-before
-                              order across separate operations. It is represented
-                              in RFC3339 form and is in UTC.
+                            description: |-
+                              Represents time when the pulling task was completed. It is not guaranteed to
+                              be set in happens-before order across separate operations.
+                              It is represented in RFC3339 form and is in UTC.
                             format: date-time
                             type: string
                           imageID:
@@ -293,16 +294,15 @@ spec:
                             description: Represents the image pulling task phase.
                             type: string
                           progress:
-                            description: Represents the pulling progress of this tag,
-                              which is between 0-100. There is no guarantee of monotonic
-                              consistency, and it may be a rollback due to retry during
-                              pulling.
+                            description: |-
+                              Represents the pulling progress of this tag, which is between 0-100. There is no guarantee
+                              of monotonic consistency, and it may be a rollback due to retry during pulling.
                             format: int32
                             type: integer
                           startTime:
-                            description: Represents time when the pulling task was
-                              acknowledged by the image puller. It is not guaranteed
-                              to be set in happens-before order across separate operations.
+                            description: |-
+                              Represents time when the pulling task was acknowledged by the image puller.
+                              It is not guaranteed to be set in happens-before order across separate operations.
                               It is represented in RFC3339 form and is in UTC.
                             format: date-time
                             type: string
@@ -340,10 +340,4 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}

--- a/charts/kruise/templates/apps.kruise.io_nodepodprobes.yaml
+++ b/charts/kruise/templates/apps.kruise.io_nodepodprobes.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.crds.managed }}
-
+ 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: nodepodprobes.apps.kruise.io
 spec:
   group: apps.kruise.io
@@ -23,14 +22,19 @@ spec:
         description: NodePodProbe is the Schema for the NodePodProbe API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -40,6 +44,9 @@ spec:
               podProbes:
                 items:
                   properties:
+                    IP:
+                      description: pod ip
+                      type: string
                     name:
                       description: pod name
                       type: string
@@ -61,37 +68,53 @@ spec:
                             description: container probe spec
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
+                                description: Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory
-                                      for the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it
-                                      is not run inside a shell, so traditional shell
-                                      instructions ('|', etc) won't work. To use a
-                                      shell, you need to explicitly call out to that
-                                      shell. Exit status of 0 is treated as live/healthy
-                                      and non-zero is unhealthy.
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the
-                                  probe to be considered failed after having succeeded.
+                                description: |-
+                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                   Defaults to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
                               httpGet:
                                 description: HTTPGet specifies the http request to
                                   perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults
-                                      to the pod IP. You probably want to set "Host"
-                                      in httpHeaders instead.
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
                                     description: Custom headers to set in the request.
@@ -101,7 +124,9 @@ spec:
                                         to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                           type: string
                                         value:
                                           description: The header field value
@@ -118,39 +143,40 @@ spec:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
                                     type: string
                                 required:
                                 - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                  has started before liveness probes are initiated.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: |-
+                                  Number of seconds after the container has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the
-                                  probe. Default to 10 seconds. Minimum value is 1.
+                                description: |-
+                                  How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the
-                                  probe to be considered successful after having failed.
-                                  Defaults to 1. Must be 1 for liveness and startup.
-                                  Minimum value is 1.
+                                description: |-
+                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                  a TCP port. TCP hooks not yet supported TODO: implement
-                                  a realistic TCP lifecycle hook'
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to,
@@ -160,35 +186,33 @@ spec:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
                               terminationGracePeriodSeconds:
-                                description: Optional duration in seconds the pod
-                                  needs to terminate gracefully upon probe failure.
-                                  The grace period is the duration in seconds after
-                                  the processes running in the pod are sent a termination
-                                  signal and the time when the processes are forcibly
-                                  halted with a kill signal. Set this value longer
-                                  than the expected cleanup time for your process.
-                                  If this value is nil, the pod's terminationGracePeriodSeconds
-                                  will be used. Otherwise, this value overrides the
-                                  value provided by the pod spec. Value must be non-negative
-                                  integer. The value zero indicates stop immediately
-                                  via the kill signal (no opportunity to shut down).
-                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
-                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                                  is used if unset.
+                                description: |-
+                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                  Set this value longer than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                  value overrides the value provided by the pod spec.
+                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                  the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                 format: int64
                                 type: integer
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                  times out. Defaults to 1 second. Minimum value is
-                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: |-
+                                  Number of seconds after which the probe times out.
+                                  Defaults to 1 second. Minimum value is 1.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 format: int32
                                 type: integer
                             type: object
@@ -202,6 +226,7 @@ spec:
                       description: pod uid
                       type: string
                   required:
+                  - IP
                   - name
                   - namespace
                   - uid
@@ -234,9 +259,9 @@ spec:
                             format: date-time
                             type: string
                           message:
-                            description: If Status=True, Message records the return
-                              result of Probe. If Status=False, Message records Probe's
-                              error message
+                            description: |-
+                              If Status=True, Message records the return result of Probe.
+                              If Status=False, Message records Probe's error message
                             type: string
                           name:
                             description: Name is podProbeMarker.Name#probe.Name
@@ -264,10 +289,4 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}

--- a/charts/kruise/templates/apps.kruise.io_persistentpodstates.yaml
+++ b/charts/kruise/templates/apps.kruise.io_persistentpodstates.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.crds.managed }}
-
+ 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: persistentpodstates.apps.kruise.io
 spec:
   group: apps.kruise.io
@@ -23,14 +22,19 @@ spec:
         description: PersistentPodState is the Schema for the PersistentPodState API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -49,13 +53,14 @@ spec:
                   type: object
                 type: array
               persistentPodStateRetentionPolicy:
-                description: PersistentPodStateRetentionPolicy describes the policy
-                  used for PodState. The default policy of 'WhenScaled' causes when
-                  scale down statefulSet, deleting it.
+                description: |-
+                  PersistentPodStateRetentionPolicy describes the policy used for PodState.
+                  The default policy of 'WhenScaled' causes when scale down statefulSet, deleting it.
                 type: string
               preferredPersistentTopology:
-                description: Pod rebuilt topology preferred for node labels, with
-                  xx weight for example  kubernetes.io/hostname, failure-domain.beta.kubernetes.io/zone
+                description: |-
+                  Pod rebuilt topology preferred for node labels, with xx weight
+                  for example  kubernetes.io/hostname, failure-domain.beta.kubernetes.io/zone
                 items:
                   properties:
                     preference:
@@ -78,8 +83,9 @@ spec:
                   type: object
                 type: array
               requiredPersistentTopology:
-                description: Pod rebuilt topology required for node labels for example
-                  kubernetes.io/hostname, failure-domain.beta.kubernetes.io/zone
+                description: |-
+                  Pod rebuilt topology required for node labels
+                  for example kubernetes.io/hostname, failure-domain.beta.kubernetes.io/zone
                 properties:
                   nodeTopologyKeys:
                     description: A list of node selector requirements by node's labels.
@@ -90,9 +96,9 @@ spec:
                 - nodeTopologyKeys
                 type: object
               targetRef:
-                description: TargetReference contains enough information to let you
-                  identify an workload for PersistentPodState Selector and TargetReference
-                  are mutually exclusive, TargetReference is priority to take effect
+                description: |-
+                  TargetReference contains enough information to let you identify an workload for PersistentPodState
+                  Selector and TargetReference are mutually exclusive, TargetReference is priority to take effect
                   current only support StatefulSet
                 properties:
                   apiVersion:
@@ -115,9 +121,9 @@ spec:
           status:
             properties:
               observedGeneration:
-                description: observedGeneration is the most recent generation observed
-                  for this PersistentPodState. It corresponds to the PersistentPodState's
-                  generation, which is updated on mutation by the API Server.
+                description: |-
+                  observedGeneration is the most recent generation observed for this PersistentPodState. It corresponds to the
+                  PersistentPodState's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
               podStates:
@@ -134,12 +140,14 @@ spec:
                     nodeTopologyLabels:
                       additionalProperties:
                         type: string
-                      description: node topology labels key=value for example kubernetes.io/hostname=node-1
+                      description: |-
+                        node topology labels key=value
+                        for example kubernetes.io/hostname=node-1
                       type: object
                   type: object
-                description: 'When the pod is ready, record some status information
-                  of the pod, such as: labels, annotations, topologies, etc. map[string]PodState
-                  -> map[Pod.Name]PodState'
+                description: |-
+                  When the pod is ready, record some status information of the pod, such as: labels, annotations, topologies, etc.
+                  map[string]PodState -> map[Pod.Name]PodState
                 type: object
             required:
             - observedGeneration
@@ -149,10 +157,4 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}

--- a/charts/kruise/templates/apps.kruise.io_podprobemarkers.yaml
+++ b/charts/kruise/templates/apps.kruise.io_podprobemarkers.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.crds.managed }}
-
+ 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: podprobemarkers.apps.kruise.io
 spec:
   group: apps.kruise.io
@@ -23,14 +22,19 @@ spec:
         description: PodProbeMarker is the Schema for the PodProbeMarker API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -38,20 +42,21 @@ spec:
             description: PodProbeMarkerSpec defines the desired state of PodProbeMarker
             properties:
               probes:
-                description: Custom container probe, current only support Exec().
+                description: |-
+                  Custom container probe, current only support Exec().
                   Probe Result will record in Pod.Status.Conditions, and condition.type=probe.name.
-                  condition.status=True indicates probe success condition.status=False
-                  indicates probe fails
+                  condition.status=True indicates probe success
+                  condition.status=False indicates probe fails
                 items:
                   properties:
                     containerName:
                       description: container name
                       type: string
                     markerPolicy:
-                      description: 'According to the execution result of ContainerProbe,
-                        perform specific actions, such as: patch Pod labels, annotations,
-                        ReadinessGate Condition It cannot be null at the same time
-                        as PodConditionType.'
+                      description: |-
+                        According to the execution result of ContainerProbe, perform specific actions,
+                        such as: patch Pod labels, annotations, ReadinessGate Condition
+                        It cannot be null at the same time as PodConditionType.
                       items:
                         properties:
                           annotations:
@@ -65,12 +70,11 @@ spec:
                             description: Patch Labels pod.labels
                             type: object
                           state:
-                            description: 'probe status, True or False For example:
-                              State=Succeeded, annotations[controller.kubernetes.io/pod-deletion-cost]
-                              = ''10''. State=Failed, annotations[controller.kubernetes.io/pod-deletion-cost]
-                              = ''-10''. In addition, if State=Failed is not defined,
-                              Exec execution fails, and the annotations[controller.kubernetes.io/pod-deletion-cost]
-                              will be Deleted'
+                            description: |-
+                              probe status, True or False
+                              For example: State=Succeeded, annotations[controller.kubernetes.io/pod-deletion-cost] = '10'.
+                              State=Failed, annotations[controller.kubernetes.io/pod-deletion-cost] = '-10'.
+                              In addition, if State=Failed is not defined, Exec execution fails, and the annotations[controller.kubernetes.io/pod-deletion-cost] will be Deleted
                             type: string
                         required:
                         - state
@@ -81,47 +85,61 @@ spec:
                         different containers, they cannot be the same)
                       type: string
                     podConditionType:
-                      description: If it is not empty, the Probe execution result
-                        will be recorded on the Pod condition. It cannot be null at
-                        the same time as MarkerPolicy. For example PodConditionType=game.kruise.io/healthy,
-                        pod.status.condition.type = game.kruise.io/healthy. When probe
-                        is Succeeded, pod.status.condition.status = True. Otherwise,
-                        when the probe fails to execute, pod.status.condition.status
-                        = False.
+                      description: |-
+                        If it is not empty, the Probe execution result will be recorded on the Pod condition.
+                        It cannot be null at the same time as MarkerPolicy.
+                        For example PodConditionType=game.kruise.io/healthy, pod.status.condition.type = game.kruise.io/healthy.
+                        When probe is Succeeded, pod.status.condition.status = True. Otherwise, when the probe fails to execute, pod.status.condition.status = False.
                       type: string
                     probe:
                       description: container probe spec
                       properties:
                         exec:
-                          description: One and only one of the following should be
-                            specified. Exec specifies the action to take.
+                          description: Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute
-                                inside the container, the working directory for the
-                                command  is root ('/') in the container's filesystem.
-                                The command is simply exec'd, it is not run inside
-                                a shell, so traditional shell instructions ('|', etc)
-                                won't work. To use a shell, you need to explicitly
-                                call out to that shell. Exit status of 0 is treated
-                                as live/healthy and non-zero is unhealthy.
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                a shell, you need to explicitly call out to that shell.
+                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
+                        grpc:
+                          description: GRPC specifies an action involving a GRPC port.
+                          properties:
+                            port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
+                              format: int32
+                              type: integer
+                            service:
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                If this is not specified, the default behavior is defined by gRPC.
+                              type: string
+                          required:
+                          - port
+                          type: object
                         httpGet:
                           description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
                               description: Custom headers to set in the request. HTTP
@@ -131,7 +149,9 @@ spec:
                                   to be used in HTTP probes
                                 properties:
                                   name:
-                                    description: The header field name
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
                                     description: The header field value
@@ -148,39 +168,40 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on
-                                the container. Number must be in the range 1 to 65535.
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
                                 Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host.
+                              description: |-
+                                Scheme to use for connecting to the host.
                                 Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe.
+                          description: |-
+                            How often (in seconds) to perform the probe.
                             Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness and startup. Minimum value
-                            is 1.
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: 'TCPSocket specifies an action involving a
-                            TCP port. TCP hooks not yet supported TODO: implement
-                            a realistic TCP lifecycle hook'
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults
@@ -190,34 +211,33 @@ spec:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on
-                                the container. Number must be in the range 1 to 65535.
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
                                 Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
-                          description: Optional duration in seconds the pod needs
-                            to terminate gracefully upon probe failure. The grace
-                            period is the duration in seconds after the processes
-                            running in the pod are sent a termination signal and the
-                            time when the processes are forcibly halted with a kill
-                            signal. Set this value longer than the expected cleanup
-                            time for your process. If this value is nil, the pod's
-                            terminationGracePeriodSeconds will be used. Otherwise,
-                            this value overrides the value provided by the pod spec.
-                            Value must be non-negative integer. The value zero indicates
-                            stop immediately via the kill signal (no opportunity to
-                            shut down). This is a beta field and requires enabling
-                            ProbeTerminationGracePeriod feature gate. Minimum value
-                            is 1. spec.terminationGracePeriodSeconds is used if unset.
+                          description: |-
+                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                            The grace period is the duration in seconds after the processes running in the pod are sent
+                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                            Set this value longer than the expected cleanup time for your process.
+                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                            value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates stop immediately via
+                            the kill signal (no opportunity to shut down).
+                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                           format: int64
                           type: integer
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                           format: int32
                           type: integer
                       type: object
@@ -228,32 +248,33 @@ spec:
                   type: object
                 type: array
               selector:
-                description: 'Selector is a label query over pods that should exec
-                  custom probe It must match the pod template''s labels. More info:
-                  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                description: |-
+                  Selector is a label query over pods that should exec custom probe
+                  It must match the pod template's labels.
+                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
@@ -266,13 +287,13 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
             required:
             - probes
             - selector
@@ -284,9 +305,9 @@ spec:
                 format: int64
                 type: integer
               observedGeneration:
-                description: observedGeneration is the most recent generation observed
-                  for this PodProbeMarker. It corresponds to the PodProbeMarker's
-                  generation, which is updated on mutation by the API Server.
+                description: |-
+                  observedGeneration is the most recent generation observed for this PodProbeMarker. It corresponds to the
+                  PodProbeMarker's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
             required:
@@ -297,10 +318,4 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}

--- a/charts/kruise/templates/apps.kruise.io_resourcedistributions.yaml
+++ b/charts/kruise/templates/apps.kruise.io_resourcedistributions.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.crds.managed }}
-
+ 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: resourcedistributions.apps.kruise.io
 spec:
   group: apps.kruise.io
@@ -35,13 +34,23 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ResourceDistribution is the Schema for the resourcedistributions API.
+        description: ResourceDistribution is the Schema for the resourcedistributions
+          API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -49,22 +58,29 @@ spec:
             description: ResourceDistributionSpec defines the desired state of ResourceDistribution.
             properties:
               resource:
-                description: Resource must be the complete yaml that users want to distribute.
+                description: Resource must be the complete yaml that users want to
+                  distribute.
                 type: object
                 x-kubernetes-embedded-resource: true
                 x-kubernetes-preserve-unknown-fields: true
               targets:
-                description: Targets defines the namespaces that users want to distribute to.
+                description: Targets defines the namespaces that users want to distribute
+                  to.
                 properties:
                   allNamespaces:
-                    description: If AllNamespaces is true, Resource will be distributed to the all namespaces (except some forbidden namespaces, such as "kube-system" and "kube-public").
+                    description: |-
+                      If AllNamespaces is true, Resource will be distributed to the all namespaces
+                      (except some forbidden namespaces, such as "kube-system" and "kube-public").
                     type: boolean
                   excludedNamespaces:
-                    description: If ExcludedNamespaces is not empty, Resource will never be distributed to the listed namespaces. ExcludedNamespaces has the highest priority.
+                    description: |-
+                      If ExcludedNamespaces is not empty, Resource will never be distributed to the listed namespaces.
+                      ExcludedNamespaces has the highest priority.
                     properties:
                       list:
                         items:
-                          description: ResourceDistributionNamespace contains a namespace name
+                          description: ResourceDistributionNamespace contains a namespace
+                            name
                           properties:
                             name:
                               description: Namespace name
@@ -73,11 +89,13 @@ spec:
                         type: array
                     type: object
                   includedNamespaces:
-                    description: If IncludedNamespaces is not empty, Resource will be distributed to the listed namespaces.
+                    description: If IncludedNamespaces is not empty, Resource will
+                      be distributed to the listed namespaces.
                     properties:
                       list:
                         items:
-                          description: ResourceDistributionNamespace contains a namespace name
+                          description: ResourceDistributionNamespace contains a namespace
+                            name
                           properties:
                             name:
                               description: Namespace name
@@ -86,21 +104,32 @@ spec:
                         type: array
                     type: object
                   namespaceLabelSelector:
-                    description: If NamespaceLabelSelector is not empty, Resource will be distributed to the matched namespaces.
+                    description: If NamespaceLabelSelector is not empty, Resource
+                      will be distributed to the matched namespaces.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
                               items:
                                 type: string
                               type: array
@@ -112,33 +141,44 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
+                    x-kubernetes-map-type: atomic
                 type: object
             required:
             - resource
             - targets
             type: object
           status:
-            description: ResourceDistributionStatus defines the observed state of ResourceDistribution. ResourceDistributionStatus is recorded by kruise, users' modification is invalid and meaningless.
+            description: |-
+              ResourceDistributionStatus defines the observed state of ResourceDistribution.
+              ResourceDistributionStatus is recorded by kruise, users' modification is invalid and meaningless.
             properties:
               conditions:
-                description: Conditions describe the condition when Resource creating, updating and deleting.
+                description: Conditions describe the condition when Resource creating,
+                  updating and deleting.
                 items:
-                  description: ResourceDistributionCondition allows a row to be marked with additional information.
+                  description: ResourceDistributionCondition allows a row to be marked
+                    with additional information.
                   properties:
                     failedNamespace:
-                      description: FailedNamespaces describe all failed namespaces when Status is False
+                      description: FailedNamespaces describe all failed namespaces
+                        when Status is False
                       items:
                         type: string
                       type: array
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time the condition transitioned from one status to another.
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     reason:
-                      description: Reason describe human readable message indicating details about last transition.
+                      description: Reason describe human readable message indicating
+                        details about last transition.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
@@ -160,7 +200,8 @@ spec:
                 format: int32
                 type: integer
               observedGeneration:
-                description: ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                description: ObservedGeneration represents the .metadata.generation
+                  that the condition was set based upon.
                 format: int64
                 type: integer
               succeeded:
@@ -173,10 +214,4 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}

--- a/charts/kruise/templates/apps.kruise.io_sidecarsets.yaml
+++ b/charts/kruise/templates/apps.kruise.io_sidecarsets.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.crds.managed }}
-
+ 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sidecarsets.apps.kruise.io
 spec:
   group: apps.kruise.io
@@ -43,14 +42,19 @@ spec:
         description: SidecarSet is the Schema for the sidecarsets API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -64,23 +68,25 @@ spec:
                   description: SidecarContainer defines the container of Sidecar
                   properties:
                     podInjectPolicy:
-                      description: The rules that injected SidecarContainer into Pod.spec.containers,
-                        not takes effect in initContainers If BeforeAppContainer,
-                        the SidecarContainer will be injected in front of the pod.spec.containers
-                        otherwise it will be injected into the back. default BeforeAppContainerType
+                      description: |-
+                        The rules that injected SidecarContainer into Pod.spec.containers,
+                        not takes effect in initContainers
+                        If BeforeAppContainer, the SidecarContainer will be injected in front of the pod.spec.containers
+                        otherwise it will be injected into the back.
+                        default BeforeAppContainerType
                       type: string
                     shareVolumePolicy:
-                      description: If ShareVolumePolicy is enabled, the sidecar container
-                        will share the other container's VolumeMounts in the pod(don't
-                        contains the injected sidecar container).
+                      description: |-
+                        If ShareVolumePolicy is enabled, the sidecar container will share the other container's VolumeMounts
+                        in the pod(don't contains the injected sidecar container).
                       properties:
                         type:
                           type: string
                       type: object
                     transferEnv:
-                      description: TransferEnv will transfer env info from other container
-                        SourceContainerName is pod.spec.container[x].name; EnvName
-                        is pod.spec.container[x].Env.name
+                      description: |-
+                        TransferEnv will transfer env info from other container
+                        SourceContainerName is pod.spec.container[x].name; EnvName is pod.spec.container[x].Env.name
                       items:
                         properties:
                           envName:
@@ -108,6 +114,7 @@ spec:
                                 required:
                                 - fieldPath
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                         type: object
                       type: array
@@ -116,16 +123,17 @@ spec:
                         HotUpgrade'
                       properties:
                         hotUpgradeEmptyImage:
-                          description: when HotUpgrade, HotUpgradeEmptyImage is used
-                            to complete the hot upgrading process HotUpgradeEmptyImage
-                            is consistent of sidecar container in Command, Args, Liveness
-                            probe, etc. but it does no actual work.
+                          description: |-
+                            when HotUpgrade, HotUpgradeEmptyImage is used to complete the hot upgrading process
+                            HotUpgradeEmptyImage is consistent of sidecar container in Command, Args, Liveness probe, etc.
+                            but it does no actual work.
                           type: string
                         upgradeType:
-                          description: when sidecar container is stateless, use ColdUpgrade
-                            otherwise HotUpgrade are more HotUpgrade. examples for
-                            istio envoy container is suitable for HotUpgrade default
-                            is ColdUpgrade
+                          description: |-
+                            when sidecar container is stateless, use ColdUpgrade
+                            otherwise HotUpgrade are more HotUpgrade.
+                            examples for istio envoy container is suitable for HotUpgrade
+                            default is ColdUpgrade
                           type: string
                       type: object
                   type: object
@@ -135,41 +143,47 @@ spec:
                 description: List of the names of secrets required by pulling sidecar
                   container images
                 items:
-                  description: LocalObjectReference contains enough information to
-                    let you locate the referenced object inside the same namespace.
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
+                  x-kubernetes-map-type: atomic
                 type: array
               initContainers:
-                description: InitContainers is the list of init containers to be injected
-                  into the selected pod We will inject those containers by their name
-                  in ascending order We only inject init containers when a new pod
-                  is created, it does not apply to any existing pod
+                description: |-
+                  InitContainers is the list of init containers to be injected into the selected pod
+                  We will inject those containers by their name in ascending order
+                  We only inject init containers when a new pod is created, it does not apply to any existing pod
                 items:
                   description: SidecarContainer defines the container of Sidecar
                   properties:
                     podInjectPolicy:
-                      description: The rules that injected SidecarContainer into Pod.spec.containers,
-                        not takes effect in initContainers If BeforeAppContainer,
-                        the SidecarContainer will be injected in front of the pod.spec.containers
-                        otherwise it will be injected into the back. default BeforeAppContainerType
+                      description: |-
+                        The rules that injected SidecarContainer into Pod.spec.containers,
+                        not takes effect in initContainers
+                        If BeforeAppContainer, the SidecarContainer will be injected in front of the pod.spec.containers
+                        otherwise it will be injected into the back.
+                        default BeforeAppContainerType
                       type: string
                     shareVolumePolicy:
-                      description: If ShareVolumePolicy is enabled, the sidecar container
-                        will share the other container's VolumeMounts in the pod(don't
-                        contains the injected sidecar container).
+                      description: |-
+                        If ShareVolumePolicy is enabled, the sidecar container will share the other container's VolumeMounts
+                        in the pod(don't contains the injected sidecar container).
                       properties:
                         type:
                           type: string
                       type: object
                     transferEnv:
-                      description: TransferEnv will transfer env info from other container
-                        SourceContainerName is pod.spec.container[x].name; EnvName
-                        is pod.spec.container[x].Env.name
+                      description: |-
+                        TransferEnv will transfer env info from other container
+                        SourceContainerName is pod.spec.container[x].name; EnvName is pod.spec.container[x].Env.name
                       items:
                         properties:
                           envName:
@@ -197,6 +211,7 @@ spec:
                                 required:
                                 - fieldPath
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                         type: object
                       type: array
@@ -205,16 +220,17 @@ spec:
                         HotUpgrade'
                       properties:
                         hotUpgradeEmptyImage:
-                          description: when HotUpgrade, HotUpgradeEmptyImage is used
-                            to complete the hot upgrading process HotUpgradeEmptyImage
-                            is consistent of sidecar container in Command, Args, Liveness
-                            probe, etc. but it does no actual work.
+                          description: |-
+                            when HotUpgrade, HotUpgradeEmptyImage is used to complete the hot upgrading process
+                            HotUpgradeEmptyImage is consistent of sidecar container in Command, Args, Liveness probe, etc.
+                            but it does no actual work.
                           type: string
                         upgradeType:
-                          description: when sidecar container is stateless, use ColdUpgrade
-                            otherwise HotUpgrade are more HotUpgrade. examples for
-                            istio envoy container is suitable for HotUpgrade default
-                            is ColdUpgrade
+                          description: |-
+                            when sidecar container is stateless, use ColdUpgrade
+                            otherwise HotUpgrade are more HotUpgrade.
+                            examples for istio envoy container is suitable for HotUpgrade
+                            default is ColdUpgrade
                           type: string
                       type: object
                   type: object
@@ -225,26 +241,30 @@ spec:
                   is injected into pods
                 properties:
                   paused:
-                    description: Paused indicates that SidecarSet will suspend injection
-                      into Pods If Paused is true, the sidecarSet will not be injected
-                      to newly created Pods, but the injected sidecar container remains
-                      updating and running. default is false
+                    description: |-
+                      Paused indicates that SidecarSet will suspend injection into Pods
+                      If Paused is true, the sidecarSet will not be injected to newly created Pods,
+                      but the injected sidecar container remains updating and running.
+                      default is false
                     type: boolean
                   revision:
-                    description: Revision can help users rolling update SidecarSet
-                      safely. If users set this filed, SidecarSet will try to inject
-                      specific revision according to different policies.
+                    description: |-
+                      Revision can help users rolling update SidecarSet safely. If users set
+                      this filed, SidecarSet will try to inject specific revision according to
+                      different policies.
                     properties:
                       customVersion:
-                        description: CustomVersion corresponds to label 'apps.kruise.io/sidecarset-custom-version'
-                          of (History) SidecarSet. SidecarSet will select the specific
-                          ControllerRevision via this CustomVersion, and then restore
-                          the history SidecarSet to inject specific version of the
-                          sidecar to pods.
+                        description: |-
+                          CustomVersion corresponds to label 'apps.kruise.io/sidecarset-custom-version' of (History) SidecarSet.
+                          SidecarSet will select the specific ControllerRevision via this CustomVersion, and then restore the
+                          history SidecarSet to inject specific version of the sidecar to pods.
                         type: string
                       policy:
+                        default: Always
                         description: Policy describes the behavior of revision injection.
-                          Defaults to Always.
+                        enum:
+                        - Always
+                        - Partial
                         type: string
                       revisionName:
                         description: RevisionName corresponds to a specific ControllerRevision
@@ -253,55 +273,37 @@ spec:
                     type: object
                 type: object
               namespace:
-                description: Namespace sidecarSet will only match the pods in the
-                  namespace otherwise, match pods in all namespaces(in cluster)
+                description: |-
+                  Namespace sidecarSet will only match the pods in the namespace
+                  otherwise, match pods in all namespaces(in cluster)
                 type: string
-              patchPodMetadata:
-                description: SidecarSet support to inject & in-place update metadata
-                  in pod.
-                items:
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: annotations
-                      type: object
-                    patchPolicy:
-                      description: labels map[string]string `json:"labels,omitempty"`
-                        patch pod metadata policy, Default is "Retain"
-                      type: string
-                  type: object
-                type: array
-              revisionHistoryLimit:
-                description: RevisionHistoryLimit indicates the maximum quantity of
-                  stored revisions about the SidecarSet. default value is 10
-                format: int32
-                type: integer
-              selector:
-                description: selector is a label query over pods that should be injected
+              namespaceSelector:
+                description: |-
+                  NamespaceSelector select which namespaces to inject sidecar containers.
+                  Default to the empty LabelSelector, which matches everything.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
@@ -314,13 +316,80 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
+              patchPodMetadata:
+                description: SidecarSet support to inject & in-place update metadata
+                  in pod.
+                items:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: annotations
+                      type: object
+                    patchPolicy:
+                      description: |-
+                        labels map[string]string `json:"labels,omitempty"`
+                        patch pod metadata policy, Default is "Retain"
+                      type: string
+                  type: object
+                type: array
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit indicates the maximum quantity of stored revisions about the SidecarSet.
+                  default value is 10
+                format: int32
+                type: integer
+              selector:
+                description: selector is a label query over pods that should be injected
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
               updateStrategy:
                 description: The sidecarset updateStrategy to use to replace existing
                   pods with new ones.
@@ -329,36 +398,126 @@ spec:
                     anyOf:
                     - type: integer
                     - type: string
-                    description: 'The maximum number of SidecarSet pods that can be
-                      unavailable during the update. Value can be an absolute number
-                      (ex: 5) or a percentage of total number of SidecarSet pods at
-                      the start of the update (ex: 10%). Absolute number is calculated
-                      from percentage by rounding up. This cannot be 0. Default value
-                      is 1.'
+                    description: |-
+                      The maximum number of SidecarSet pods that can be unavailable during the
+                      update. Value can be an absolute number (ex: 5) or a percentage of total
+                      number of SidecarSet pods at the start of the update (ex: 10%). Absolute
+                      number is calculated from percentage by rounding up.
+                      This cannot be 0.
+                      Default value is 1.
                     x-kubernetes-int-or-string: true
                   partition:
                     anyOf:
                     - type: integer
                     - type: string
-                    description: Partition is the desired number of pods in old revisions.
-                      It means when partition is set during pods updating, (replicas
-                      - partition) number of pods will be updated. Default value is
-                      0.
+                    description: |-
+                      Partition is the desired number of pods in old revisions. It means when partition
+                      is set during pods updating, (replicas - partition) number of pods will be updated.
+                      Default value is 0.
                     x-kubernetes-int-or-string: true
                   paused:
-                    description: Paused indicates that the SidecarSet is paused to
-                      update the injected pods, but it don't affect the webhook inject
-                      sidecar container into the newly created pods. default is false
+                    description: |-
+                      Paused indicates that the SidecarSet is paused to update the injected pods,
+                      For the impact on the injection behavior for newly created Pods, please refer to the comments of Selector.
                     type: boolean
+                  priorityStrategy:
+                    description: |-
+                      Priorities are the rules for calculating the priority of updating pods.
+                      Each pod to be updated, will pass through these terms and get a sum of weights.
+                    properties:
+                      orderPriority:
+                        description: |-
+                          Order priority terms, pods will be sorted by the value of orderedKey.
+                          For example:
+                          ```
+                          orderPriority:
+                          - orderedKey: key1
+                          - orderedKey: key2
+                          ```
+                          First, all pods which have key1 in labels will be sorted by the value of key1.
+                          Then, the left pods which have no key1 but have key2 in labels will be sorted by
+                          the value of key2 and put behind those pods have key1.
+                        items:
+                          description: UpdatePriorityOrderTerm defines order priority.
+                          properties:
+                            orderedKey:
+                              description: |-
+                                Calculate priority by value of this key.
+                                Values of this key, will be sorted by GetInt(val). GetInt method will find the last int in value,
+                                such as getting 5 in value '5', getting 10 in value 'sts-10'.
+                              type: string
+                          required:
+                          - orderedKey
+                          type: object
+                        type: array
+                      weightPriority:
+                        description: Weight priority terms, pods will be sorted by
+                          the sum of all terms weight.
+                        items:
+                          description: UpdatePriorityWeightTerm defines weight priority.
+                          properties:
+                            matchSelector:
+                              description: MatchSelector is used to select by pod's
+                                labels.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                matchExpressions, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - matchSelector
+                          - weight
+                          type: object
+                        type: array
+                    type: object
                   scatterStrategy:
-                    description: ScatterStrategy defines the scatter rules to make
-                      pods been scattered when update. This will avoid pods with the
-                      same key-value to be updated in one batch. - Note that pods
-                      will be scattered after priority sort. So, although priority
-                      strategy and scatter strategy can be applied together, we suggest
-                      to use either one of them. - If scatterStrategy is used, we
-                      suggest to just use one term. Otherwise, the update order can
-                      be hard to understand.
+                    description: |-
+                      ScatterStrategy defines the scatter rules to make pods been scattered when update.
+                      This will avoid pods with the same key-value to be updated in one batch.
+                      - Note that pods will be scattered after priority sort. So, although priority strategy and scatter strategy can be applied together, we suggest to use either one of them.
+                      - If scatterStrategy is used, we suggest to just use one term. Otherwise, the update order can be hard to understand.
                     items:
                       properties:
                         key:
@@ -371,32 +530,38 @@ spec:
                       type: object
                     type: array
                   selector:
-                    description: If selector is not nil, this upgrade will only update
-                      the selected pods.
+                    description: |-
+                      If selector is not nil, this upgrade will only update the selected pods.
+
+
+                      Starting from Kruise 1.8.0, the updateStrategy.Selector affects the version of the Sidecar container
+                      injected into newly created Pods by a SidecarSet configured with an injectionStrategy.
+                      In most cases, all newly created Pods are injected with the specified Sidecar version as configured in injectionStrategy.revision,
+                      which is consistent with previous versions.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector
                           requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
                               description: key is the label key that the selector
                                 applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
                               items:
                                 type: string
                               type: array
@@ -408,19 +573,19 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
+                    x-kubernetes-map-type: atomic
                   type:
-                    description: Type is NotUpdate, the SidecarSet don't update the
-                      injected pods, it will only inject sidecar container into the
-                      newly created pods. Type is RollingUpdate, the SidecarSet will
-                      update the injected pods to the latest version on RollingUpdate
-                      Strategy. default is RollingUpdate
+                    description: |-
+                      Type is NotUpdate, the SidecarSet don't update the injected pods,
+                      it will only inject sidecar container into the newly created pods.
+                      Type is RollingUpdate, the SidecarSet will update the injected pods to the latest version on RollingUpdate Strategy.
+                      default is RollingUpdate
                     type: string
                 type: object
               volumes:
@@ -431,10 +596,10 @@ spec:
             description: SidecarSetStatus defines the observed state of SidecarSet
             properties:
               collisionCount:
-                description: CollisionCount is the count of hash collisions for the
-                  SidecarSet. The SidecarSet controller uses this field as a collision
-                  avoidance mechanism when it needs to create the name for the newest
-                  ControllerRevision.
+                description: |-
+                  CollisionCount is the count of hash collisions for the SidecarSet. The SidecarSet controller
+                  uses this field as a collision avoidance mechanism when it needs to create the name for the
+                  newest ControllerRevision.
                 format: int32
                 type: integer
               latestRevision:
@@ -448,9 +613,9 @@ spec:
                 format: int32
                 type: integer
               observedGeneration:
-                description: observedGeneration is the most recent generation observed
-                  for this SidecarSet. It corresponds to the SidecarSet's generation,
-                  which is updated on mutation by the API Server.
+                description: |-
+                  observedGeneration is the most recent generation observed for this SidecarSet. It corresponds to the
+                  SidecarSet's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
               readyPods:
@@ -478,10 +643,4 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}

--- a/charts/kruise/templates/apps.kruise.io_statefulsets.yaml
+++ b/charts/kruise/templates/apps.kruise.io_statefulsets.yaml
@@ -1,11 +1,14 @@
 {{- if .Values.crds.managed }}
-
+ 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.14.0
+{{- if .Values.externalCerts.annotations }}
+{{ toYaml .Values.externalCerts.annotations | indent 4 }}
+{{- end }}
   name: statefulsets.apps.kruise.io
 spec:
   conversion:
@@ -14,7 +17,7 @@ spec:
       clientConfig:
         service:
           name: kruise-webhook-service
-          namespace: {{ .Values.installation.namespace }}
+          namespace: kruise-system
           path: /convert
       conversionReviewVersions:
       - v1
@@ -70,14 +73,19 @@ spec:
         description: StatefulSet is the Schema for the statefulsets API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -85,59 +93,61 @@ spec:
             description: StatefulSetSpec defines the desired state of StatefulSet
             properties:
               podManagementPolicy:
-                description: podManagementPolicy controls how pods are created during
-                  initial scale up, when replacing pods on nodes, or when scaling
-                  down. The default policy is `OrderedReady`, where pods are created
-                  in increasing order (pod-0, then pod-1, etc) and the controller
-                  will wait until each pod is ready before continuing. When scaling
-                  down, the pods are removed in the opposite order. The alternative
-                  policy is `Parallel` which will create pods in parallel to match
-                  the desired scale without waiting, and on scale down will delete
+                description: |-
+                  podManagementPolicy controls how pods are created during initial scale up,
+                  when replacing pods on nodes, or when scaling down. The default policy is
+                  `OrderedReady`, where pods are created in increasing order (pod-0, then
+                  pod-1, etc) and the controller will wait until each pod is ready before
+                  continuing. When scaling down, the pods are removed in the opposite order.
+                  The alternative policy is `Parallel` which will create pods in parallel
+                  to match the desired scale without waiting, and on scale down will delete
                   all pods at once.
                 type: string
               replicas:
-                description: 'replicas is the desired number of replicas of the given
-                  Template. These are replicas in the sense that they are instantiations
-                  of the same Template, but individual replicas also have a consistent
-                  identity. If unspecified, defaults to 1. TODO: Consider a rename
-                  of this field.'
+                description: |-
+                  replicas is the desired number of replicas of the given Template.
+                  These are replicas in the sense that they are instantiations of the
+                  same Template, but individual replicas also have a consistent identity.
+                  If unspecified, defaults to 1.
+                  TODO: Consider a rename of this field.
                 format: int32
                 type: integer
               revisionHistoryLimit:
-                description: revisionHistoryLimit is the maximum number of revisions
-                  that will be maintained in the StatefulSet's revision history. The
-                  revision history consists of all revisions not represented by a
-                  currently applied StatefulSetSpec version. The default value is
-                  10.
+                description: |-
+                  revisionHistoryLimit is the maximum number of revisions that will
+                  be maintained in the StatefulSet's revision history. The revision history
+                  consists of all revisions not represented by a currently applied
+                  StatefulSetSpec version. The default value is 10.
                 format: int32
                 type: integer
               selector:
-                description: 'selector is a label query over pods that should match
-                  the replica count. It must match the pod template''s labels. More
-                  info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                description: |-
+                  selector is a label query over pods that should match the replica count.
+                  It must match the pod template's labels.
+                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
@@ -150,30 +160,33 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               serviceName:
-                description: 'serviceName is the name of the service that governs
-                  this StatefulSet. This service must exist before the StatefulSet,
-                  and is responsible for the network identity of the set. Pods get
-                  DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local
-                  where "pod-specific-string" is managed by the StatefulSet controller.'
+                description: |-
+                  serviceName is the name of the service that governs this StatefulSet.
+                  This service must exist before the StatefulSet, and is responsible for
+                  the network identity of the set. Pods get DNS/hostnames that follow the
+                  pattern: pod-specific-string.serviceName.default.svc.cluster.local
+                  where "pod-specific-string" is managed by the StatefulSet controller.
                 type: string
               template:
-                description: template is the object that describes the pod that will
-                  be created if insufficient replicas are detected. Each pod stamped
-                  out by the StatefulSet will fulfill this Template, but have a unique
-                  identity from the rest of the StatefulSet.
+                description: |-
+                  template is the object that describes the pod that will be created if
+                  insufficient replicas are detected. Each pod stamped out by the StatefulSet
+                  will fulfill this Template, but have a unique identity from the rest
+                  of the StatefulSet.
                 x-kubernetes-preserve-unknown-fields: true
               updateStrategy:
-                description: updateStrategy indicates the StatefulSetUpdateStrategy
-                  that will be employed to update Pods in the StatefulSet when a revision
-                  is made to Template.
+                description: |-
+                  updateStrategy indicates the StatefulSetUpdateStrategy that will be
+                  employed to update Pods in the StatefulSet when a revision is made to
+                  Template.
                 properties:
                   rollingUpdate:
                     description: RollingUpdate is used to communicate parameters when
@@ -184,9 +197,9 @@ spec:
                           in-place update.
                         properties:
                           gracePeriodSeconds:
-                            description: GracePeriodSeconds is the timespan between
-                              set Pod status to not-ready and update images in Pod
-                              spec when in-place update a Pod.
+                            description: |-
+                              GracePeriodSeconds is the timespan between set Pod status to not-ready and update images in Pod spec
+                              when in-place update a Pod.
                             format: int32
                             type: integer
                         type: object
@@ -194,70 +207,73 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'The maximum number of pods that can be unavailable
-                          during the update. Value can be an absolute number (ex:
-                          5) or a percentage of desired pods (ex: 10%). Absolute number
-                          is calculated from percentage by rounding down. Also, maxUnavailable
-                          can just be allowed to work with Parallel podManagementPolicy.
-                          Defaults to 1.'
+                        description: |-
+                          The maximum number of pods that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          Also, maxUnavailable can just be allowed to work with Parallel podManagementPolicy.
+                          Defaults to 1.
                         x-kubernetes-int-or-string: true
                       minReadySeconds:
-                        description: MinReadySeconds indicates how long will the pod
-                          be considered ready after it's updated. MinReadySeconds
-                          works with both OrderedReady and Parallel podManagementPolicy.
-                          It affects the pod scale up speed when the podManagementPolicy
-                          is set to be OrderedReady. Combined with MaxUnavailable,
-                          it affects the pod update speed regardless of podManagementPolicy.
+                        description: |-
+                          MinReadySeconds indicates how long will the pod be considered ready after it's updated.
+                          MinReadySeconds works with both OrderedReady and Parallel podManagementPolicy.
+                          It affects the pod scale up speed when the podManagementPolicy is set to be OrderedReady.
+                          Combined with MaxUnavailable, it affects the pod update speed regardless of podManagementPolicy.
                           Default value is 0, max is 300.
                         format: int32
                         type: integer
                       partition:
-                        description: 'Partition indicates the ordinal at which the
-                          StatefulSet should be partitioned by default. But if unorderedUpdate
-                          has been set:   - Partition indicates the number of pods
-                          with non-updated revisions when rolling update.   - It means
-                          controller will update $(replicas - partition) number of
-                          pod. Default value is 0.'
+                        description: |-
+                          Partition indicates the ordinal at which the StatefulSet should be partitioned by default.
+                          But if unorderedUpdate has been set:
+                            - Partition indicates the number of pods with non-updated revisions when rolling update.
+                            - It means controller will update $(replicas - partition) number of pod.
+                          Default value is 0.
                         format: int32
                         type: integer
                       paused:
-                        description: Paused indicates that the StatefulSet is paused.
+                        description: |-
+                          Paused indicates that the StatefulSet is paused.
                           Default value is false
                         type: boolean
                       podUpdatePolicy:
-                        description: PodUpdatePolicy indicates how pods should be
-                          updated Default value is "ReCreate"
+                        description: |-
+                          PodUpdatePolicy indicates how pods should be updated
+                          Default value is "ReCreate"
                         type: string
                       unorderedUpdate:
-                        description: UnorderedUpdate contains strategies for non-ordered
-                          update. If it is not nil, pods will be updated with non-ordered
-                          sequence. Noted that UnorderedUpdate can only be allowed
-                          to work with Parallel podManagementPolicy
+                        description: |-
+                          UnorderedUpdate contains strategies for non-ordered update.
+                          If it is not nil, pods will be updated with non-ordered sequence.
+                          Noted that UnorderedUpdate can only be allowed to work with Parallel podManagementPolicy
                         properties:
                           priorityStrategy:
-                            description: Priorities are the rules for calculating
-                              the priority of updating pods. Each pod to be updated,
-                              will pass through these terms and get a sum of weights.
+                            description: |-
+                              Priorities are the rules for calculating the priority of updating pods.
+                              Each pod to be updated, will pass through these terms and get a sum of weights.
                             properties:
                               orderPriority:
-                                description: 'Order priority terms, pods will be sorted
-                                  by the value of orderedKey. For example: ``` orderPriority:
-                                  - orderedKey: key1 - orderedKey: key2 ``` First,
-                                  all pods which have key1 in labels will be sorted
-                                  by the value of key1. Then, the left pods which
-                                  have no key1 but have key2 in labels will be sorted
-                                  by the value of key2 and put behind those pods have
-                                  key1.'
+                                description: |-
+                                  Order priority terms, pods will be sorted by the value of orderedKey.
+                                  For example:
+                                  ```
+                                  orderPriority:
+                                  - orderedKey: key1
+                                  - orderedKey: key2
+                                  ```
+                                  First, all pods which have key1 in labels will be sorted by the value of key1.
+                                  Then, the left pods which have no key1 but have key2 in labels will be sorted by
+                                  the value of key2 and put behind those pods have key1.
                                 items:
                                   description: UpdatePriorityOrderTerm defines order
                                     priority.
                                   properties:
                                     orderedKey:
-                                      description: Calculate priority by value of
-                                        this key. Values of this key, will be sorted
-                                        by GetInt(val). GetInt method will find the
-                                        last int in value, such as getting 5 in value
-                                        '5', getting 10 in value 'sts-10'.
+                                      description: |-
+                                        Calculate priority by value of this key.
+                                        Values of this key, will be sorted by GetInt(val). GetInt method will find the last int in value,
+                                        such as getting 5 in value '5', getting 10 in value 'sts-10'.
                                       type: string
                                   required:
                                   - orderedKey
@@ -279,30 +295,25 @@ spec:
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -314,14 +325,13 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     weight:
                                       description: Weight associated with matching
                                         the corresponding matchExpressions, in the
@@ -337,19 +347,20 @@ spec:
                         type: object
                     type: object
                   type:
-                    description: Type indicates the type of the StatefulSetUpdateStrategy.
+                    description: |-
+                      Type indicates the type of the StatefulSetUpdateStrategy.
                       Default is RollingUpdate.
                     type: string
                 type: object
               volumeClaimTemplates:
-                description: 'volumeClaimTemplates is a list of claims that pods are
-                  allowed to reference. The StatefulSet controller is responsible
-                  for mapping network identities to claims in a way that maintains
-                  the identity of a pod. Every claim in this list must have at least
-                  one matching (by name) volumeMount in one container in the template.
-                  A claim in this list takes precedence over any volumes in the template,
-                  with the same name. TODO: Define the behavior if a claim already
-                  exists with the same name.'
+                description: |-
+                  volumeClaimTemplates is a list of claims that pods are allowed to reference.
+                  The StatefulSet controller is responsible for mapping network identities to
+                  claims in a way that maintains the identity of a pod. Every claim in
+                  this list must have at least one matching (by name) volumeMount in one
+                  container in the template. A claim in this list takes precedence over
+                  any volumes in the template, with the same name.
+                  TODO: Define the behavior if a claim already exists with the same name.
                 x-kubernetes-preserve-unknown-fields: true
             required:
             - selector
@@ -359,15 +370,16 @@ spec:
             description: StatefulSetStatus defines the observed state of StatefulSet
             properties:
               availableReplicas:
-                description: AvailableReplicas is the number of Pods created by the
-                  StatefulSet controller that have been ready for minReadySeconds.
+                description: |-
+                  AvailableReplicas is the number of Pods created by the StatefulSet controller that have been ready for
+                  minReadySeconds.
                 format: int32
                 type: integer
               collisionCount:
-                description: collisionCount is the count of hash collisions for the
-                  StatefulSet. The StatefulSet controller uses this field as a collision
-                  avoidance mechanism when it needs to create the name for the newest
-                  ControllerRevision.
+                description: |-
+                  collisionCount is the count of hash collisions for the StatefulSet. The StatefulSet controller
+                  uses this field as a collision avoidance mechanism when it needs to create the name for the
+                  newest ControllerRevision.
                 format: int32
                 type: integer
               conditions:
@@ -401,23 +413,24 @@ spec:
                   type: object
                 type: array
               currentReplicas:
-                description: currentReplicas is the number of Pods created by the
-                  StatefulSet controller from the StatefulSet version indicated by
-                  currentRevision.
+                description: |-
+                  currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version
+                  indicated by currentRevision.
                 format: int32
                 type: integer
               currentRevision:
-                description: currentRevision, if not empty, indicates the version
-                  of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+                description: |-
+                  currentRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the
+                  sequence [0,currentReplicas).
                 type: string
               labelSelector:
                 description: LabelSelector is label selectors for query over pods
                   that should match the replica count used by HPA.
                 type: string
               observedGeneration:
-                description: observedGeneration is the most recent generation observed
-                  for this StatefulSet. It corresponds to the StatefulSet's generation,
-                  which is updated on mutation by the API Server.
+                description: |-
+                  observedGeneration is the most recent generation observed for this StatefulSet. It corresponds to the
+                  StatefulSet's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
               readyReplicas:
@@ -431,13 +444,14 @@ spec:
                 format: int32
                 type: integer
               updateRevision:
-                description: updateRevision, if not empty, indicates the version of
-                  the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+                description: |-
+                  updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence
+                  [replicas-updatedReplicas,replicas)
                 type: string
               updatedReplicas:
-                description: updatedReplicas is the number of Pods created by the
-                  StatefulSet controller from the StatefulSet version indicated by
-                  updateRevision.
+                description: |-
+                  updatedReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version
+                  indicated by updateRevision.
                 format: int32
                 type: integer
             required:
@@ -496,14 +510,19 @@ spec:
         description: StatefulSet is the Schema for the statefulsets API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -527,12 +546,12 @@ spec:
                           type: string
                         type: object
                       markPodNotReady:
-                        description: 'MarkPodNotReady = true means: - Pod will be
-                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
-                          - Pod will be restored to ''Ready'' at Updated state if
-                          it was set to ''NotReady'' at preparingUpdate state. Currently,
-                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
-                          hook. Default to false.'
+                        description: |-
+                          MarkPodNotReady = true means:
+                          - Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.
+                          Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook.
+                          Default to false.
                         type: boolean
                     type: object
                   preDelete:
@@ -547,12 +566,12 @@ spec:
                           type: string
                         type: object
                       markPodNotReady:
-                        description: 'MarkPodNotReady = true means: - Pod will be
-                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
-                          - Pod will be restored to ''Ready'' at Updated state if
-                          it was set to ''NotReady'' at preparingUpdate state. Currently,
-                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
-                          hook. Default to false.'
+                        description: |-
+                          MarkPodNotReady = true means:
+                          - Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.
+                          Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook.
+                          Default to false.
                         type: boolean
                     type: object
                   preNormal:
@@ -568,118 +587,146 @@ spec:
                           type: string
                         type: object
                       markPodNotReady:
-                        description: 'MarkPodNotReady = true means: - Pod will be
-                          set to ''NotReady'' at preparingDelete/preparingUpdate state.
-                          - Pod will be restored to ''Ready'' at Updated state if
-                          it was set to ''NotReady'' at preparingUpdate state. Currently,
-                          MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete
-                          hook. Default to false.'
+                        description: |-
+                          MarkPodNotReady = true means:
+                          - Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
+                          - Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.
+                          Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook.
+                          Default to false.
                         type: boolean
                     type: object
                 type: object
+              ordinals:
+                description: |-
+                  ordinals controls the numbering of replica indices in a StatefulSet. The
+                  default ordinals behavior assigns a "0" index to the first replica and
+                  increments the index by one for each additional replica requested. Using
+                  the ordinals field requires the StatefulSetStartOrdinal feature gate to be
+                  enabled, which is beta.
+                properties:
+                  start:
+                    description: |-
+                      start is the number representing the first replica's index. It may be used
+                      to number replicas from an alternate index (eg: 1-indexed) over the default
+                      0-indexed names, or to orchestrate progressive movement of replicas from
+                      one StatefulSet to another.
+                      If set, replica indices will be in the range:
+                        [.spec.ordinals.start, .spec.ordinals.start + .spec.replicas).
+                      If unset, defaults to 0. Replica indices will be in the range:
+                        [0, .spec.replicas).
+                    format: int32
+                    type: integer
+                type: object
               persistentVolumeClaimRetentionPolicy:
-                description: PersistentVolumeClaimRetentionPolicy describes the policy
-                  used for PVCs created from the StatefulSet VolumeClaimTemplates.
-                  This requires the StatefulSetAutoDeletePVC feature gate to be enabled,
-                  which is alpha.
+                description: |-
+                  PersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from
+                  the StatefulSet VolumeClaimTemplates. This requires the
+                  StatefulSetAutoDeletePVC feature gate to be enabled, which is alpha.
                 properties:
                   whenDeleted:
-                    description: WhenDeleted specifies what happens to PVCs created
-                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
-                      deleted. The default policy of `Retain` causes PVCs to not be
-                      affected by StatefulSet deletion. The `Delete` policy causes
-                      those PVCs to be deleted.
+                    description: |-
+                      WhenDeleted specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                      of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                      `Delete` policy causes those PVCs to be deleted.
                     type: string
                   whenScaled:
-                    description: WhenScaled specifies what happens to PVCs created
-                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
-                      scaled down. The default policy of `Retain` causes PVCs to not
-                      be affected by a scaledown. The `Delete` policy causes the associated
-                      PVCs for any excess pods above the replica count to be deleted.
+                    description: |-
+                      WhenScaled specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                      policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                      `Delete` policy causes the associated PVCs for any excess pods above
+                      the replica count to be deleted.
                     type: string
                 type: object
               podManagementPolicy:
-                description: podManagementPolicy controls how pods are created during
-                  initial scale up, when replacing pods on nodes, or when scaling
-                  down. The default policy is `OrderedReady`, where pods are created
-                  in increasing order (pod-0, then pod-1, etc) and the controller
-                  will wait until each pod is ready before continuing. When scaling
-                  down, the pods are removed in the opposite order. The alternative
-                  policy is `Parallel` which will create pods in parallel to match
-                  the desired scale without waiting, and on scale down will delete
+                description: |-
+                  podManagementPolicy controls how pods are created during initial scale up,
+                  when replacing pods on nodes, or when scaling down. The default policy is
+                  `OrderedReady`, where pods are created in increasing order (pod-0, then
+                  pod-1, etc) and the controller will wait until each pod is ready before
+                  continuing. When scaling down, the pods are removed in the opposite order.
+                  The alternative policy is `Parallel` which will create pods in parallel
+                  to match the desired scale without waiting, and on scale down will delete
                   all pods at once.
                 type: string
               replicas:
-                description: 'replicas is the desired number of replicas of the given
-                  Template. These are replicas in the sense that they are instantiations
-                  of the same Template, but individual replicas also have a consistent
-                  identity. If unspecified, defaults to 1. TODO: Consider a rename
-                  of this field.'
+                description: |-
+                  replicas is the desired number of replicas of the given Template.
+                  These are replicas in the sense that they are instantiations of the
+                  same Template, but individual replicas also have a consistent identity.
+                  If unspecified, defaults to 1.
+                  TODO: Consider a rename of this field.
                 format: int32
                 type: integer
               reserveOrdinals:
-                description: 'reserveOrdinals controls the ordinal numbers that should
-                  be reserved, and the replicas will always be the expectation number
-                  of running Pods. For a sts with replicas=3 and its Pods in [0, 1,
-                  2]: - If you want to migrate Pod-1 and reserve this ordinal, just
-                  set spec.reserveOrdinal to [1].   Then controller will delete Pod-1
-                  and create Pod-3 (existing Pods will be [0, 2, 3]) - If you just
-                  want to delete Pod-1, you should set spec.reserveOrdinal to [1]
-                  and spec.replicas to 2.   Then controller will delete Pod-1 (existing
-                  Pods will be [0, 2])'
+                description: |-
+                  reserveOrdinals controls the ordinal numbers that should be reserved, and the replicas
+                  will always be the expectation number of running Pods.
+                  For a sts with replicas=3 and its Pods in [0, 1, 2]:
+                  - If you want to migrate Pod-1 and reserve this ordinal, just set spec.reserveOrdinal to [1].
+                    Then controller will delete Pod-1 and create Pod-3 (existing Pods will be [0, 2, 3])
+                  - If you just want to delete Pod-1, you should set spec.reserveOrdinal to [1] and spec.replicas to 2.
+                    Then controller will delete Pod-1 (existing Pods will be [0, 2])
+                  You can also use ranges along with numbers, such as [1, 3-5], which is a shortcut for [1, 3, 4, 5].
                 items:
-                  type: integer
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  x-kubernetes-int-or-string: true
                 type: array
               revisionHistoryLimit:
-                description: revisionHistoryLimit is the maximum number of revisions
-                  that will be maintained in the StatefulSet's revision history. The
-                  revision history consists of all revisions not represented by a
-                  currently applied StatefulSetSpec version. The default value is
-                  10.
+                description: |-
+                  revisionHistoryLimit is the maximum number of revisions that will
+                  be maintained in the StatefulSet's revision history. The revision history
+                  consists of all revisions not represented by a currently applied
+                  StatefulSetSpec version. The default value is 10.
                 format: int32
                 type: integer
               scaleStrategy:
-                description: scaleStrategy indicates the StatefulSetScaleStrategy
-                  that will be employed to scale Pods in the StatefulSet.
+                description: |-
+                  scaleStrategy indicates the StatefulSetScaleStrategy that will be
+                  employed to scale Pods in the StatefulSet.
                 properties:
                   maxUnavailable:
                     anyOf:
                     - type: integer
                     - type: string
-                    description: 'The maximum number of pods that can be unavailable
-                      during scaling. Value can be an absolute number (ex: 5) or a
-                      percentage of desired pods (ex: 10%). Absolute number is calculated
-                      from percentage by rounding down. It can just be allowed to
-                      work with Parallel podManagementPolicy.'
+                    description: |-
+                      The maximum number of pods that can be unavailable during scaling.
+                      Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                      Absolute number is calculated from percentage by rounding down.
+                      It can just be allowed to work with Parallel podManagementPolicy.
                     x-kubernetes-int-or-string: true
                 type: object
               selector:
-                description: 'selector is a label query over pods that should match
-                  the replica count. It must match the pod template''s labels. More
-                  info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                description: |-
+                  selector is a label query over pods that should match the replica count.
+                  It must match the pod template's labels.
+                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
@@ -692,30 +739,33 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               serviceName:
-                description: 'serviceName is the name of the service that governs
-                  this StatefulSet. This service must exist before the StatefulSet,
-                  and is responsible for the network identity of the set. Pods get
-                  DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local
-                  where "pod-specific-string" is managed by the StatefulSet controller.'
+                description: |-
+                  serviceName is the name of the service that governs this StatefulSet.
+                  This service must exist before the StatefulSet, and is responsible for
+                  the network identity of the set. Pods get DNS/hostnames that follow the
+                  pattern: pod-specific-string.serviceName.default.svc.cluster.local
+                  where "pod-specific-string" is managed by the StatefulSet controller.
                 type: string
               template:
-                description: template is the object that describes the pod that will
-                  be created if insufficient replicas are detected. Each pod stamped
-                  out by the StatefulSet will fulfill this Template, but have a unique
-                  identity from the rest of the StatefulSet.
+                description: |-
+                  template is the object that describes the pod that will be created if
+                  insufficient replicas are detected. Each pod stamped out by the StatefulSet
+                  will fulfill this Template, but have a unique identity from the rest
+                  of the StatefulSet.
                 x-kubernetes-preserve-unknown-fields: true
               updateStrategy:
-                description: updateStrategy indicates the StatefulSetUpdateStrategy
-                  that will be employed to update Pods in the StatefulSet when a revision
-                  is made to Template.
+                description: |-
+                  updateStrategy indicates the StatefulSetUpdateStrategy that will be
+                  employed to update Pods in the StatefulSet when a revision is made to
+                  Template.
                 properties:
                   rollingUpdate:
                     description: RollingUpdate is used to communicate parameters when
@@ -726,9 +776,9 @@ spec:
                           in-place update.
                         properties:
                           gracePeriodSeconds:
-                            description: GracePeriodSeconds is the timespan between
-                              set Pod status to not-ready and update images in Pod
-                              spec when in-place update a Pod.
+                            description: |-
+                              GracePeriodSeconds is the timespan between set Pod status to not-ready and update images in Pod spec
+                              when in-place update a Pod.
                             format: int32
                             type: integer
                         type: object
@@ -736,70 +786,71 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'The maximum number of pods that can be unavailable
-                          during the update. Value can be an absolute number (ex:
-                          5) or a percentage of desired pods (ex: 10%). Absolute number
-                          is calculated from percentage by rounding down. Also, maxUnavailable
-                          can just be allowed to work with Parallel podManagementPolicy.
-                          Defaults to 1.'
+                        description: |-
+                          The maximum number of pods that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          Also, maxUnavailable can just be allowed to work with Parallel podManagementPolicy.
+                          Defaults to 1.
                         x-kubernetes-int-or-string: true
                       minReadySeconds:
-                        description: MinReadySeconds indicates how long will the pod
-                          be considered ready after it's updated. MinReadySeconds
-                          works with both OrderedReady and Parallel podManagementPolicy.
-                          It affects the pod scale up speed when the podManagementPolicy
-                          is set to be OrderedReady. Combined with MaxUnavailable,
-                          it affects the pod update speed regardless of podManagementPolicy.
+                        description: |-
+                          MinReadySeconds indicates how long will the pod be considered ready after it's updated.
+                          MinReadySeconds works with both OrderedReady and Parallel podManagementPolicy.
+                          It affects the pod scale up speed when the podManagementPolicy is set to be OrderedReady.
+                          Combined with MaxUnavailable, it affects the pod update speed regardless of podManagementPolicy.
                           Default value is 0, max is 300.
                         format: int32
                         type: integer
                       partition:
-                        description: 'Partition indicates the ordinal at which the
-                          StatefulSet should be partitioned by default. But if unorderedUpdate
-                          has been set:   - Partition indicates the number of pods
-                          with non-updated revisions when rolling update.   - It means
-                          controller will update $(replicas - partition) number of
-                          pod. Default value is 0.'
+                        description: |-
+                          Partition indicates the number of pods the StatefulSet should be partitioned by default.
+                            - It means controller will update $(replicas - partition) number of pod.
+                          Default value is 0.
                         format: int32
                         type: integer
                       paused:
-                        description: Paused indicates that the StatefulSet is paused.
+                        description: |-
+                          Paused indicates that the StatefulSet is paused.
                           Default value is false
                         type: boolean
                       podUpdatePolicy:
-                        description: PodUpdatePolicy indicates how pods should be
-                          updated Default value is "ReCreate"
+                        description: |-
+                          PodUpdatePolicy indicates how pods should be updated
+                          Default value is "ReCreate"
                         type: string
                       unorderedUpdate:
-                        description: UnorderedUpdate contains strategies for non-ordered
-                          update. If it is not nil, pods will be updated with non-ordered
-                          sequence. Noted that UnorderedUpdate can only be allowed
-                          to work with Parallel podManagementPolicy
+                        description: |-
+                          UnorderedUpdate contains strategies for non-ordered update.
+                          If it is not nil, pods will be updated with non-ordered sequence.
+                          Noted that UnorderedUpdate can only be allowed to work with Parallel podManagementPolicy
                         properties:
                           priorityStrategy:
-                            description: Priorities are the rules for calculating
-                              the priority of updating pods. Each pod to be updated,
-                              will pass through these terms and get a sum of weights.
+                            description: |-
+                              Priorities are the rules for calculating the priority of updating pods.
+                              Each pod to be updated, will pass through these terms and get a sum of weights.
                             properties:
                               orderPriority:
-                                description: 'Order priority terms, pods will be sorted
-                                  by the value of orderedKey. For example: ``` orderPriority:
-                                  - orderedKey: key1 - orderedKey: key2 ``` First,
-                                  all pods which have key1 in labels will be sorted
-                                  by the value of key1. Then, the left pods which
-                                  have no key1 but have key2 in labels will be sorted
-                                  by the value of key2 and put behind those pods have
-                                  key1.'
+                                description: |-
+                                  Order priority terms, pods will be sorted by the value of orderedKey.
+                                  For example:
+                                  ```
+                                  orderPriority:
+                                  - orderedKey: key1
+                                  - orderedKey: key2
+                                  ```
+                                  First, all pods which have key1 in labels will be sorted by the value of key1.
+                                  Then, the left pods which have no key1 but have key2 in labels will be sorted by
+                                  the value of key2 and put behind those pods have key1.
                                 items:
                                   description: UpdatePriorityOrderTerm defines order
                                     priority.
                                   properties:
                                     orderedKey:
-                                      description: Calculate priority by value of
-                                        this key. Values of this key, will be sorted
-                                        by GetInt(val). GetInt method will find the
-                                        last int in value, such as getting 5 in value
-                                        '5', getting 10 in value 'sts-10'.
+                                      description: |-
+                                        Calculate priority by value of this key.
+                                        Values of this key, will be sorted by GetInt(val). GetInt method will find the last int in value,
+                                        such as getting 5 in value '5', getting 10 in value 'sts-10'.
                                       type: string
                                   required:
                                   - orderedKey
@@ -821,30 +872,25 @@ spec:
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -856,14 +902,13 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     weight:
                                       description: Weight associated with matching
                                         the corresponding matchExpressions, in the
@@ -879,20 +924,33 @@ spec:
                         type: object
                     type: object
                   type:
-                    description: Type indicates the type of the StatefulSetUpdateStrategy.
+                    description: |-
+                      Type indicates the type of the StatefulSetUpdateStrategy.
                       Default is RollingUpdate.
                     type: string
                 type: object
               volumeClaimTemplates:
-                description: 'volumeClaimTemplates is a list of claims that pods are
-                  allowed to reference. The StatefulSet controller is responsible
-                  for mapping network identities to claims in a way that maintains
-                  the identity of a pod. Every claim in this list must have at least
-                  one matching (by name) volumeMount in one container in the template.
-                  A claim in this list takes precedence over any volumes in the template,
-                  with the same name. TODO: Define the behavior if a claim already
-                  exists with the same name.'
+                description: |-
+                  volumeClaimTemplates is a list of claims that pods are allowed to reference.
+                  The StatefulSet controller is responsible for mapping network identities to
+                  claims in a way that maintains the identity of a pod. Every claim in
+                  this list must have at least one matching (by name) volumeMount in one
+                  container in the template. A claim in this list takes precedence over
+                  any volumes in the template, with the same name.
+                  TODO: Define the behavior if a claim already exists with the same name.
                 x-kubernetes-preserve-unknown-fields: true
+              volumeClaimUpdateStrategy:
+                description: |-
+                  VolumeClaimUpdateStrategy specifies the strategy for updating VolumeClaimTemplates within a StatefulSet.
+                  This field is currently only effective if the StatefulSetAutoResizePVCGate is enabled.
+                properties:
+                  type:
+                    description: |-
+                      Type specifies the type of update strategy, possible values include:
+                      OnPodRollingUpdateVolumeClaimUpdateStrategyType: Apply the update strategy during pod rolling updates.
+                      OnPVCDeleteVolumeClaimUpdateStrategyType: Apply the update strategy when a PersistentVolumeClaim is deleted.
+                    type: string
+                type: object
             required:
             - selector
             - template
@@ -901,15 +959,16 @@ spec:
             description: StatefulSetStatus defines the observed state of StatefulSet
             properties:
               availableReplicas:
-                description: AvailableReplicas is the number of Pods created by the
-                  StatefulSet controller that have been ready for minReadySeconds.
+                description: |-
+                  AvailableReplicas is the number of Pods created by the StatefulSet controller that have been ready for
+                  minReadySeconds.
                 format: int32
                 type: integer
               collisionCount:
-                description: collisionCount is the count of hash collisions for the
-                  StatefulSet. The StatefulSet controller uses this field as a collision
-                  avoidance mechanism when it needs to create the name for the newest
-                  ControllerRevision.
+                description: |-
+                  collisionCount is the count of hash collisions for the StatefulSet. The StatefulSet controller
+                  uses this field as a collision avoidance mechanism when it needs to create the name for the
+                  newest ControllerRevision.
                 format: int32
                 type: integer
               conditions:
@@ -943,23 +1002,24 @@ spec:
                   type: object
                 type: array
               currentReplicas:
-                description: currentReplicas is the number of Pods created by the
-                  StatefulSet controller from the StatefulSet version indicated by
-                  currentRevision.
+                description: |-
+                  currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version
+                  indicated by currentRevision.
                 format: int32
                 type: integer
               currentRevision:
-                description: currentRevision, if not empty, indicates the version
-                  of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+                description: |-
+                  currentRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the
+                  sequence [0,currentReplicas).
                 type: string
               labelSelector:
                 description: LabelSelector is label selectors for query over pods
                   that should match the replica count used by HPA.
                 type: string
               observedGeneration:
-                description: observedGeneration is the most recent generation observed
-                  for this StatefulSet. It corresponds to the StatefulSet's generation,
-                  which is updated on mutation by the API Server.
+                description: |-
+                  observedGeneration is the most recent generation observed for this StatefulSet. It corresponds to the
+                  StatefulSet's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
               readyReplicas:
@@ -973,20 +1033,64 @@ spec:
                 format: int32
                 type: integer
               updateRevision:
-                description: updateRevision, if not empty, indicates the version of
-                  the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+                description: |-
+                  updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence
+                  [replicas-updatedReplicas,replicas)
                 type: string
+              updatedAvailableReplicas:
+                description: |-
+                  updatedAvailableReplicas is the number of updated Pods created by the StatefulSet controller that have a Ready condition
+                  for atleast minReadySeconds.
+                format: int32
+                type: integer
               updatedReadyReplicas:
                 description: updatedReadyReplicas is the number of updated Pods created
                   by the StatefulSet controller that have a Ready Condition.
                 format: int32
                 type: integer
               updatedReplicas:
-                description: updatedReplicas is the number of Pods created by the
-                  StatefulSet controller from the StatefulSet version indicated by
-                  updateRevision.
+                description: |-
+                  updatedReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version
+                  indicated by updateRevision.
                 format: int32
                 type: integer
+              volumeClaims:
+                description: |-
+                  VolumeClaims represents the status of compatibility between existing PVCs
+                  and their respective templates. It tracks whether the PersistentVolumeClaims have been updated
+                  to match any changes made to the volumeClaimTemplates, ensuring synchronization
+                  between the defined templates and the actual PersistentVolumeClaims in use.
+                items:
+                  description: |-
+                    VolumeClaimStatus describes the status of a volume claim template.
+                    It provides details about the compatibility and readiness of the volume claim.
+                  properties:
+                    compatibleReadyReplicas:
+                      description: |-
+                        CompatibleReadyReplicas is the number of replicas that are both ready and compatible with the volume claim.
+                        It highlights that these replicas are not only compatible but also ready to be put into service immediately.
+                        Compatibility is determined by whether the pvc spec storage requests are greater than or equal to the template spec storage requests
+                        The "ready" status is determined by whether the PVC status capacity is greater than or equal to the PVC spec storage requests.
+                      format: int32
+                      type: integer
+                    compatibleReplicas:
+                      description: |-
+                        CompatibleReplicas is the number of replicas currently compatible with the volume claim.
+                        It indicates how many replicas can function properly, being compatible with this volume claim.
+                        Compatibility is determined by whether the PVC spec storage requests are greater than or equal to the template spec storage requests
+                      format: int32
+                      type: integer
+                    volumeClaimName:
+                      description: |-
+                        VolumeClaimName is the name of the volume claim.
+                        This is a unique identifier used to reference a specific volume claim.
+                      type: string
+                  required:
+                  - compatibleReadyReplicas
+                  - compatibleReplicas
+                  - volumeClaimName
+                  type: object
+                type: array
             required:
             - availableReplicas
             - currentReplicas
@@ -1003,10 +1107,4 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}

--- a/charts/kruise/templates/apps.kruise.io_uniteddeployments.yaml
+++ b/charts/kruise/templates/apps.kruise.io_uniteddeployments.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.crds.managed }}
-
+ 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: uniteddeployments.apps.kruise.io
 spec:
   group: apps.kruise.io
@@ -49,14 +48,19 @@ spec:
         description: UnitedDeployment is the Schema for the uniteddeployments API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -64,41 +68,44 @@ spec:
             description: UnitedDeploymentSpec defines the desired state of UnitedDeployment.
             properties:
               replicas:
-                description: Replicas is the total desired replicas of all the subsets.
+                description: |-
+                  Replicas is the total desired replicas of all the subsets.
                   If unspecified, defaults to 1.
                 format: int32
                 type: integer
               revisionHistoryLimit:
-                description: Indicates the number of histories to be conserved. If
-                  unspecified, defaults to 10.
+                description: |-
+                  Indicates the number of histories to be conserved.
+                  If unspecified, defaults to 10.
                 format: int32
                 type: integer
               selector:
-                description: Selector is a label query over pods that should match
-                  the replica count. It must match the pod template's labels.
+                description: |-
+                  Selector is a label query over pods that should match the replica count.
+                  It must match the pod template's labels.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
@@ -111,13 +118,13 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               template:
                 description: Template describes the subset that will be created.
                 properties:
@@ -147,13 +154,12 @@ spec:
                                       type: string
                                     type: object
                                   markPodNotReady:
-                                    description: 'MarkPodNotReady = true means: -
-                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
-                                      state. - Pod will be restored to ''Ready'' at
-                                      Updated state if it was set to ''NotReady''
-                                      at preparingUpdate state. Currently, MarkPodNotReady
-                                      only takes effect on InPlaceUpdate & PreDelete
-                                      hook. Default to false.'
+                                    description: |-
+                                      MarkPodNotReady = true means:
+                                      - Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
+                                      - Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.
+                                      Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook.
+                                      Default to false.
                                     type: boolean
                                 type: object
                               preDelete:
@@ -169,13 +175,12 @@ spec:
                                       type: string
                                     type: object
                                   markPodNotReady:
-                                    description: 'MarkPodNotReady = true means: -
-                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
-                                      state. - Pod will be restored to ''Ready'' at
-                                      Updated state if it was set to ''NotReady''
-                                      at preparingUpdate state. Currently, MarkPodNotReady
-                                      only takes effect on InPlaceUpdate & PreDelete
-                                      hook. Default to false.'
+                                    description: |-
+                                      MarkPodNotReady = true means:
+                                      - Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
+                                      - Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.
+                                      Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook.
+                                      Default to false.
                                     type: boolean
                                 type: object
                               preNormal:
@@ -191,111 +196,130 @@ spec:
                                       type: string
                                     type: object
                                   markPodNotReady:
-                                    description: 'MarkPodNotReady = true means: -
-                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
-                                      state. - Pod will be restored to ''Ready'' at
-                                      Updated state if it was set to ''NotReady''
-                                      at preparingUpdate state. Currently, MarkPodNotReady
-                                      only takes effect on InPlaceUpdate & PreDelete
-                                      hook. Default to false.'
+                                    description: |-
+                                      MarkPodNotReady = true means:
+                                      - Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
+                                      - Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.
+                                      Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook.
+                                      Default to false.
                                     type: boolean
                                 type: object
                             type: object
+                          ordinals:
+                            description: |-
+                              ordinals controls the numbering of replica indices in a StatefulSet. The
+                              default ordinals behavior assigns a "0" index to the first replica and
+                              increments the index by one for each additional replica requested. Using
+                              the ordinals field requires the StatefulSetStartOrdinal feature gate to be
+                              enabled, which is beta.
+                            properties:
+                              start:
+                                description: |-
+                                  start is the number representing the first replica's index. It may be used
+                                  to number replicas from an alternate index (eg: 1-indexed) over the default
+                                  0-indexed names, or to orchestrate progressive movement of replicas from
+                                  one StatefulSet to another.
+                                  If set, replica indices will be in the range:
+                                    [.spec.ordinals.start, .spec.ordinals.start + .spec.replicas).
+                                  If unset, defaults to 0. Replica indices will be in the range:
+                                    [0, .spec.replicas).
+                                format: int32
+                                type: integer
+                            type: object
                           persistentVolumeClaimRetentionPolicy:
-                            description: PersistentVolumeClaimRetentionPolicy describes
-                              the policy used for PVCs created from the StatefulSet
-                              VolumeClaimTemplates. This requires the StatefulSetAutoDeletePVC
-                              feature gate to be enabled, which is alpha.
+                            description: |-
+                              PersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from
+                              the StatefulSet VolumeClaimTemplates. This requires the
+                              StatefulSetAutoDeletePVC feature gate to be enabled, which is alpha.
                             properties:
                               whenDeleted:
-                                description: WhenDeleted specifies what happens to
-                                  PVCs created from StatefulSet VolumeClaimTemplates
-                                  when the StatefulSet is deleted. The default policy
-                                  of `Retain` causes PVCs to not be affected by StatefulSet
-                                  deletion. The `Delete` policy causes those PVCs
-                                  to be deleted.
+                                description: |-
+                                  WhenDeleted specifies what happens to PVCs created from StatefulSet
+                                  VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                                  of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                                  `Delete` policy causes those PVCs to be deleted.
                                 type: string
                               whenScaled:
-                                description: WhenScaled specifies what happens to
-                                  PVCs created from StatefulSet VolumeClaimTemplates
-                                  when the StatefulSet is scaled down. The default
-                                  policy of `Retain` causes PVCs to not be affected
-                                  by a scaledown. The `Delete` policy causes the associated
-                                  PVCs for any excess pods above the replica count
-                                  to be deleted.
+                                description: |-
+                                  WhenScaled specifies what happens to PVCs created from StatefulSet
+                                  VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                                  policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                                  `Delete` policy causes the associated PVCs for any excess pods above
+                                  the replica count to be deleted.
                                 type: string
                             type: object
                           podManagementPolicy:
-                            description: podManagementPolicy controls how pods are
-                              created during initial scale up, when replacing pods
-                              on nodes, or when scaling down. The default policy is
-                              `OrderedReady`, where pods are created in increasing
-                              order (pod-0, then pod-1, etc) and the controller will
-                              wait until each pod is ready before continuing. When
-                              scaling down, the pods are removed in the opposite order.
-                              The alternative policy is `Parallel` which will create
-                              pods in parallel to match the desired scale without
-                              waiting, and on scale down will delete all pods at once.
+                            description: |-
+                              podManagementPolicy controls how pods are created during initial scale up,
+                              when replacing pods on nodes, or when scaling down. The default policy is
+                              `OrderedReady`, where pods are created in increasing order (pod-0, then
+                              pod-1, etc) and the controller will wait until each pod is ready before
+                              continuing. When scaling down, the pods are removed in the opposite order.
+                              The alternative policy is `Parallel` which will create pods in parallel
+                              to match the desired scale without waiting, and on scale down will delete
+                              all pods at once.
                             type: string
                           replicas:
-                            description: 'replicas is the desired number of replicas
-                              of the given Template. These are replicas in the sense
-                              that they are instantiations of the same Template, but
-                              individual replicas also have a consistent identity.
-                              If unspecified, defaults to 1. TODO: Consider a rename
-                              of this field.'
+                            description: |-
+                              replicas is the desired number of replicas of the given Template.
+                              These are replicas in the sense that they are instantiations of the
+                              same Template, but individual replicas also have a consistent identity.
+                              If unspecified, defaults to 1.
+                              TODO: Consider a rename of this field.
                             format: int32
                             type: integer
                           reserveOrdinals:
-                            description: 'reserveOrdinals controls the ordinal numbers
-                              that should be reserved, and the replicas will always
-                              be the expectation number of running Pods. For a sts
-                              with replicas=3 and its Pods in [0, 1, 2]: - If you
-                              want to migrate Pod-1 and reserve this ordinal, just
-                              set spec.reserveOrdinal to [1].   Then controller will
-                              delete Pod-1 and create Pod-3 (existing Pods will be
-                              [0, 2, 3]) - If you just want to delete Pod-1, you should
-                              set spec.reserveOrdinal to [1] and spec.replicas to
-                              2.   Then controller will delete Pod-1 (existing Pods
-                              will be [0, 2])'
+                            description: |-
+                              reserveOrdinals controls the ordinal numbers that should be reserved, and the replicas
+                              will always be the expectation number of running Pods.
+                              For a sts with replicas=3 and its Pods in [0, 1, 2]:
+                              - If you want to migrate Pod-1 and reserve this ordinal, just set spec.reserveOrdinal to [1].
+                                Then controller will delete Pod-1 and create Pod-3 (existing Pods will be [0, 2, 3])
+                              - If you just want to delete Pod-1, you should set spec.reserveOrdinal to [1] and spec.replicas to 2.
+                                Then controller will delete Pod-1 (existing Pods will be [0, 2])
+                              You can also use ranges along with numbers, such as [1, 3-5], which is a shortcut for [1, 3, 4, 5].
                             items:
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
                             type: array
                           revisionHistoryLimit:
-                            description: revisionHistoryLimit is the maximum number
-                              of revisions that will be maintained in the StatefulSet's
-                              revision history. The revision history consists of all
-                              revisions not represented by a currently applied StatefulSetSpec
-                              version. The default value is 10.
+                            description: |-
+                              revisionHistoryLimit is the maximum number of revisions that will
+                              be maintained in the StatefulSet's revision history. The revision history
+                              consists of all revisions not represented by a currently applied
+                              StatefulSetSpec version. The default value is 10.
                             format: int32
                             type: integer
                           scaleStrategy:
-                            description: scaleStrategy indicates the StatefulSetScaleStrategy
-                              that will be employed to scale Pods in the StatefulSet.
+                            description: |-
+                              scaleStrategy indicates the StatefulSetScaleStrategy that will be
+                              employed to scale Pods in the StatefulSet.
                             properties:
                               maxUnavailable:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: 'The maximum number of pods that can
-                                  be unavailable during scaling. Value can be an absolute
-                                  number (ex: 5) or a percentage of desired pods (ex:
-                                  10%). Absolute number is calculated from percentage
-                                  by rounding down. It can just be allowed to work
-                                  with Parallel podManagementPolicy.'
+                                description: |-
+                                  The maximum number of pods that can be unavailable during scaling.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  Absolute number is calculated from percentage by rounding down.
+                                  It can just be allowed to work with Parallel podManagementPolicy.
                                 x-kubernetes-int-or-string: true
                             type: object
                           selector:
-                            description: 'selector is a label query over pods that
-                              should match the replica count. It must match the pod
-                              template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                            description: |-
+                              selector is a label query over pods that should match the replica count.
+                              It must match the pod template's labels.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
                                   requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
                                     relates the key and values.
                                   properties:
                                     key:
@@ -303,17 +327,16 @@ spec:
                                         applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -325,33 +348,33 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
+                            x-kubernetes-map-type: atomic
                           serviceName:
-                            description: 'serviceName is the name of the service that
-                              governs this StatefulSet. This service must exist before
-                              the StatefulSet, and is responsible for the network
-                              identity of the set. Pods get DNS/hostnames that follow
-                              the pattern: pod-specific-string.serviceName.default.svc.cluster.local
-                              where "pod-specific-string" is managed by the StatefulSet
-                              controller.'
+                            description: |-
+                              serviceName is the name of the service that governs this StatefulSet.
+                              This service must exist before the StatefulSet, and is responsible for
+                              the network identity of the set. Pods get DNS/hostnames that follow the
+                              pattern: pod-specific-string.serviceName.default.svc.cluster.local
+                              where "pod-specific-string" is managed by the StatefulSet controller.
                             type: string
                           template:
-                            description: template is the object that describes the
-                              pod that will be created if insufficient replicas are
-                              detected. Each pod stamped out by the StatefulSet will
-                              fulfill this Template, but have a unique identity from
-                              the rest of the StatefulSet.
+                            description: |-
+                              template is the object that describes the pod that will be created if
+                              insufficient replicas are detected. Each pod stamped out by the StatefulSet
+                              will fulfill this Template, but have a unique identity from the rest
+                              of the StatefulSet.
                             x-kubernetes-preserve-unknown-fields: true
                           updateStrategy:
-                            description: updateStrategy indicates the StatefulSetUpdateStrategy
-                              that will be employed to update Pods in the StatefulSet
-                              when a revision is made to Template.
+                            description: |-
+                              updateStrategy indicates the StatefulSetUpdateStrategy that will be
+                              employed to update Pods in the StatefulSet when a revision is made to
+                              Template.
                             properties:
                               rollingUpdate:
                                 description: RollingUpdate is used to communicate
@@ -362,10 +385,9 @@ spec:
                                       for in-place update.
                                     properties:
                                       gracePeriodSeconds:
-                                        description: GracePeriodSeconds is the timespan
-                                          between set Pod status to not-ready and
-                                          update images in Pod spec when in-place
-                                          update a Pod.
+                                        description: |-
+                                          GracePeriodSeconds is the timespan between set Pod status to not-ready and update images in Pod spec
+                                          when in-place update a Pod.
                                         format: int32
                                         type: integer
                                     type: object
@@ -373,81 +395,71 @@ spec:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: 'The maximum number of pods that
-                                      can be unavailable during the update. Value
-                                      can be an absolute number (ex: 5) or a percentage
-                                      of desired pods (ex: 10%). Absolute number is
-                                      calculated from percentage by rounding down.
-                                      Also, maxUnavailable can just be allowed to
-                                      work with Parallel podManagementPolicy. Defaults
-                                      to 1.'
+                                    description: |-
+                                      The maximum number of pods that can be unavailable during the update.
+                                      Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                      Absolute number is calculated from percentage by rounding down.
+                                      Also, maxUnavailable can just be allowed to work with Parallel podManagementPolicy.
+                                      Defaults to 1.
                                     x-kubernetes-int-or-string: true
                                   minReadySeconds:
-                                    description: MinReadySeconds indicates how long
-                                      will the pod be considered ready after it's
-                                      updated. MinReadySeconds works with both OrderedReady
-                                      and Parallel podManagementPolicy. It affects
-                                      the pod scale up speed when the podManagementPolicy
-                                      is set to be OrderedReady. Combined with MaxUnavailable,
-                                      it affects the pod update speed regardless of
-                                      podManagementPolicy. Default value is 0, max
-                                      is 300.
+                                    description: |-
+                                      MinReadySeconds indicates how long will the pod be considered ready after it's updated.
+                                      MinReadySeconds works with both OrderedReady and Parallel podManagementPolicy.
+                                      It affects the pod scale up speed when the podManagementPolicy is set to be OrderedReady.
+                                      Combined with MaxUnavailable, it affects the pod update speed regardless of podManagementPolicy.
+                                      Default value is 0, max is 300.
                                     format: int32
                                     type: integer
                                   partition:
-                                    description: 'Partition indicates the ordinal
-                                      at which the StatefulSet should be partitioned
-                                      by default. But if unorderedUpdate has been
-                                      set:   - Partition indicates the number of pods
-                                      with non-updated revisions when rolling update.   -
-                                      It means controller will update $(replicas -
-                                      partition) number of pod. Default value is 0.'
+                                    description: |-
+                                      Partition indicates the number of pods the StatefulSet should be partitioned by default.
+                                        - It means controller will update $(replicas - partition) number of pod.
+                                      Default value is 0.
                                     format: int32
                                     type: integer
                                   paused:
-                                    description: Paused indicates that the StatefulSet
-                                      is paused. Default value is false
+                                    description: |-
+                                      Paused indicates that the StatefulSet is paused.
+                                      Default value is false
                                     type: boolean
                                   podUpdatePolicy:
-                                    description: PodUpdatePolicy indicates how pods
-                                      should be updated Default value is "ReCreate"
+                                    description: |-
+                                      PodUpdatePolicy indicates how pods should be updated
+                                      Default value is "ReCreate"
                                     type: string
                                   unorderedUpdate:
-                                    description: UnorderedUpdate contains strategies
-                                      for non-ordered update. If it is not nil, pods
-                                      will be updated with non-ordered sequence. Noted
-                                      that UnorderedUpdate can only be allowed to
-                                      work with Parallel podManagementPolicy
+                                    description: |-
+                                      UnorderedUpdate contains strategies for non-ordered update.
+                                      If it is not nil, pods will be updated with non-ordered sequence.
+                                      Noted that UnorderedUpdate can only be allowed to work with Parallel podManagementPolicy
                                     properties:
                                       priorityStrategy:
-                                        description: Priorities are the rules for
-                                          calculating the priority of updating pods.
-                                          Each pod to be updated, will pass through
-                                          these terms and get a sum of weights.
+                                        description: |-
+                                          Priorities are the rules for calculating the priority of updating pods.
+                                          Each pod to be updated, will pass through these terms and get a sum of weights.
                                         properties:
                                           orderPriority:
-                                            description: 'Order priority terms, pods
-                                              will be sorted by the value of orderedKey.
-                                              For example: ``` orderPriority: - orderedKey:
-                                              key1 - orderedKey: key2 ``` First, all
-                                              pods which have key1 in labels will
-                                              be sorted by the value of key1. Then,
-                                              the left pods which have no key1 but
-                                              have key2 in labels will be sorted by
-                                              the value of key2 and put behind those
-                                              pods have key1.'
+                                            description: |-
+                                              Order priority terms, pods will be sorted by the value of orderedKey.
+                                              For example:
+                                              ```
+                                              orderPriority:
+                                              - orderedKey: key1
+                                              - orderedKey: key2
+                                              ```
+                                              First, all pods which have key1 in labels will be sorted by the value of key1.
+                                              Then, the left pods which have no key1 but have key2 in labels will be sorted by
+                                              the value of key2 and put behind those pods have key1.
                                             items:
                                               description: UpdatePriorityOrderTerm
                                                 defines order priority.
                                               properties:
                                                 orderedKey:
-                                                  description: Calculate priority
-                                                    by value of this key. Values of
-                                                    this key, will be sorted by GetInt(val).
-                                                    GetInt method will find the last
-                                                    int in value, such as getting
-                                                    5 in value '5', getting 10 in
-                                                    value 'sts-10'.
+                                                  description: |-
+                                                    Calculate priority by value of this key.
+                                                    Values of this key, will be sorted by GetInt(val). GetInt method will find the last int in value,
+                                                    such as getting 5 in value '5', getting 10 in value 'sts-10'.
                                                   type: string
                                               required:
                                               - orderedKey
@@ -471,10 +483,8 @@ spec:
                                                         requirements. The requirements
                                                         are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
                                                           relates the key and values.
                                                         properties:
                                                           key:
@@ -483,24 +493,15 @@ spec:
                                                               applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
                                                               merge patch.
                                                             items:
                                                               type: string
@@ -513,18 +514,13 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                       type: object
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 weight:
                                                   description: Weight associated with
                                                     matching the corresponding matchExpressions,
@@ -540,22 +536,33 @@ spec:
                                     type: object
                                 type: object
                               type:
-                                description: Type indicates the type of the StatefulSetUpdateStrategy.
+                                description: |-
+                                  Type indicates the type of the StatefulSetUpdateStrategy.
                                   Default is RollingUpdate.
                                 type: string
                             type: object
                           volumeClaimTemplates:
-                            description: 'volumeClaimTemplates is a list of claims
-                              that pods are allowed to reference. The StatefulSet
-                              controller is responsible for mapping network identities
-                              to claims in a way that maintains the identity of a
-                              pod. Every claim in this list must have at least one
-                              matching (by name) volumeMount in one container in the
-                              template. A claim in this list takes precedence over
-                              any volumes in the template, with the same name. TODO:
-                              Define the behavior if a claim already exists with the
-                              same name.'
+                            description: |-
+                              volumeClaimTemplates is a list of claims that pods are allowed to reference.
+                              The StatefulSet controller is responsible for mapping network identities to
+                              claims in a way that maintains the identity of a pod. Every claim in
+                              this list must have at least one matching (by name) volumeMount in one
+                              container in the template. A claim in this list takes precedence over
+                              any volumes in the template, with the same name.
+                              TODO: Define the behavior if a claim already exists with the same name.
                             x-kubernetes-preserve-unknown-fields: true
+                          volumeClaimUpdateStrategy:
+                            description: |-
+                              VolumeClaimUpdateStrategy specifies the strategy for updating VolumeClaimTemplates within a StatefulSet.
+                              This field is currently only effective if the StatefulSetAutoResizePVCGate is enabled.
+                            properties:
+                              type:
+                                description: |-
+                                  Type specifies the type of update strategy, possible values include:
+                                  OnPodRollingUpdateVolumeClaimUpdateStrategyType: Apply the update strategy during pod rolling updates.
+                                  OnPVCDeleteVolumeClaimUpdateStrategyType: Apply the update strategy when a PersistentVolumeClaim is deleted.
+                                type: string
+                            type: object
                         required:
                         - selector
                         - template
@@ -589,13 +596,12 @@ spec:
                                       type: string
                                     type: object
                                   markPodNotReady:
-                                    description: 'MarkPodNotReady = true means: -
-                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
-                                      state. - Pod will be restored to ''Ready'' at
-                                      Updated state if it was set to ''NotReady''
-                                      at preparingUpdate state. Currently, MarkPodNotReady
-                                      only takes effect on InPlaceUpdate & PreDelete
-                                      hook. Default to false.'
+                                    description: |-
+                                      MarkPodNotReady = true means:
+                                      - Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
+                                      - Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.
+                                      Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook.
+                                      Default to false.
                                     type: boolean
                                 type: object
                               preDelete:
@@ -611,13 +617,12 @@ spec:
                                       type: string
                                     type: object
                                   markPodNotReady:
-                                    description: 'MarkPodNotReady = true means: -
-                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
-                                      state. - Pod will be restored to ''Ready'' at
-                                      Updated state if it was set to ''NotReady''
-                                      at preparingUpdate state. Currently, MarkPodNotReady
-                                      only takes effect on InPlaceUpdate & PreDelete
-                                      hook. Default to false.'
+                                    description: |-
+                                      MarkPodNotReady = true means:
+                                      - Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
+                                      - Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.
+                                      Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook.
+                                      Default to false.
                                     type: boolean
                                 type: object
                               preNormal:
@@ -633,79 +638,78 @@ spec:
                                       type: string
                                     type: object
                                   markPodNotReady:
-                                    description: 'MarkPodNotReady = true means: -
-                                      Pod will be set to ''NotReady'' at preparingDelete/preparingUpdate
-                                      state. - Pod will be restored to ''Ready'' at
-                                      Updated state if it was set to ''NotReady''
-                                      at preparingUpdate state. Currently, MarkPodNotReady
-                                      only takes effect on InPlaceUpdate & PreDelete
-                                      hook. Default to false.'
+                                    description: |-
+                                      MarkPodNotReady = true means:
+                                      - Pod will be set to 'NotReady' at preparingDelete/preparingUpdate state.
+                                      - Pod will be restored to 'Ready' at Updated state if it was set to 'NotReady' at preparingUpdate state.
+                                      Currently, MarkPodNotReady only takes effect on InPlaceUpdate & PreDelete hook.
+                                      Default to false.
                                     type: boolean
                                 type: object
                             type: object
                           minReadySeconds:
-                            description: Minimum number of seconds for which a newly
-                              created pod should be ready without any of its container
-                              crashing, for it to be considered available. Defaults
-                              to 0 (pod will be considered available as soon as it
-                              is ready)
+                            description: |-
+                              Minimum number of seconds for which a newly created pod should be ready
+                              without any of its container crashing, for it to be considered available.
+                              Defaults to 0 (pod will be considered available as soon as it is ready)
                             format: int32
                             type: integer
                           replicas:
-                            description: Replicas is the desired number of replicas
-                              of the given Template. These are replicas in the sense
-                              that they are instantiations of the same Template. If
-                              unspecified, defaults to 1.
+                            description: |-
+                              Replicas is the desired number of replicas of the given Template.
+                              These are replicas in the sense that they are instantiations of the
+                              same Template.
+                              If unspecified, defaults to 1.
                             format: int32
                             type: integer
                           revisionHistoryLimit:
-                            description: RevisionHistoryLimit is the maximum number
-                              of revisions that will be maintained in the CloneSet's
-                              revision history. The revision history consists of all
-                              revisions not represented by a currently applied CloneSetSpec
-                              version. The default value is 10.
+                            description: |-
+                              RevisionHistoryLimit is the maximum number of revisions that will
+                              be maintained in the CloneSet's revision history. The revision history
+                              consists of all revisions not represented by a currently applied
+                              CloneSetSpec version. The default value is 10.
                             format: int32
                             type: integer
                           scaleStrategy:
-                            description: ScaleStrategy indicates the ScaleStrategy
-                              that will be employed to create and delete Pods in the
-                              CloneSet.
+                            description: |-
+                              ScaleStrategy indicates the ScaleStrategy that will be employed to
+                              create and delete Pods in the CloneSet.
                             properties:
                               disablePVCReuse:
-                                description: Indicate if cloneSet will reuse already
-                                  existed pvc to rebuild a new pod
+                                description: |-
+                                  Indicate if cloneSet will reuse already existed pvc to
+                                  rebuild a new pod
                                 type: boolean
                               maxUnavailable:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: The maximum number of pods that can be
-                                  unavailable for scaled pods. This field can control
-                                  the changes rate of replicas for CloneSet so as
-                                  to minimize the impact for users' service. The scale
-                                  will fail if the number of unavailable pods were
-                                  greater than this MaxUnavailable at scaling up.
+                                description: |-
+                                  The maximum number of pods that can be unavailable for scaled pods.
+                                  This field can control the changes rate of replicas for CloneSet so as to minimize the impact for users' service.
+                                  The scale will fail if the number of unavailable pods were greater than this MaxUnavailable at scaling up.
                                   MaxUnavailable works only when scaling up.
                                 x-kubernetes-int-or-string: true
                               podsToDelete:
-                                description: PodsToDelete is the names of Pod should
-                                  be deleted. Note that this list will be truncated
-                                  for non-existing pod names.
+                                description: |-
+                                  PodsToDelete is the names of Pod should be deleted.
+                                  Note that this list will be truncated for non-existing pod names.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           selector:
-                            description: 'Selector is a label query over pods that
-                              should match the replica count. It must match the pod
-                              template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                            description: |-
+                              Selector is a label query over pods that should match the replica count.
+                              It must match the pod template's labels.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
                                   requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
                                     relates the key and values.
                                   properties:
                                     key:
@@ -713,17 +717,16 @@ spec:
                                         applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -735,30 +738,30 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
+                            x-kubernetes-map-type: atomic
                           template:
                             description: Template describes the pods that will be
                               created.
                             x-kubernetes-preserve-unknown-fields: true
                           updateStrategy:
-                            description: UpdateStrategy indicates the UpdateStrategy
-                              that will be employed to update Pods in the CloneSet
-                              when a revision is made to Template.
+                            description: |-
+                              UpdateStrategy indicates the UpdateStrategy that will be employed to
+                              update Pods in the CloneSet when a revision is made to Template.
                             properties:
                               inPlaceUpdateStrategy:
                                 description: InPlaceUpdateStrategy contains strategies
                                   for in-place update.
                                 properties:
                                   gracePeriodSeconds:
-                                    description: GracePeriodSeconds is the timespan
-                                      between set Pod status to not-ready and update
-                                      images in Pod spec when in-place update a Pod.
+                                    description: |-
+                                      GracePeriodSeconds is the timespan between set Pod status to not-ready and update images in Pod spec
+                                      when in-place update a Pod.
                                     format: int32
                                     type: integer
                                 type: object
@@ -766,67 +769,65 @@ spec:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: 'The maximum number of pods that can
-                                  be scheduled above the desired replicas during update
-                                  or specified delete. Value can be an absolute number
-                                  (ex: 5) or a percentage of desired pods (ex: 10%).
-                                  Absolute number is calculated from percentage by
-                                  rounding up. Defaults to 0.'
+                                description: |-
+                                  The maximum number of pods that can be scheduled above the desired replicas during update or specified delete.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  Absolute number is calculated from percentage by rounding up.
+                                  Defaults to 0.
                                 x-kubernetes-int-or-string: true
                               maxUnavailable:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: 'The maximum number of pods that can
-                                  be unavailable during update or scale. Value can
-                                  be an absolute number (ex: 5) or a percentage of
-                                  desired pods (ex: 10%). Absolute number is calculated
-                                  from percentage by rounding up by default. When
-                                  maxSurge > 0, absolute number is calculated from
-                                  percentage by rounding down. Defaults to 20%.'
+                                description: |-
+                                  The maximum number of pods that can be unavailable during update or scale.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  Absolute number is calculated from percentage by rounding up by default.
+                                  When maxSurge > 0, absolute number is calculated from percentage by rounding down.
+                                  Defaults to 20%.
                                 x-kubernetes-int-or-string: true
                               partition:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: 'Partition is the desired number of pods
-                                  in old revisions. Value can be an absolute number
-                                  (ex: 5) or a percentage of desired pods (ex: 10%).
-                                  Absolute number is calculated from percentage by
-                                  rounding up by default. It means when partition
-                                  is set during pods updating, (replicas - partition
-                                  value) number of pods will be updated. Default value
-                                  is 0.'
+                                description: |-
+                                  Partition is the desired number of pods in old revisions.
+                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                  Absolute number is calculated from percentage by rounding up by default.
+                                  It means when partition is set during pods updating, (replicas - partition value) number of pods will be updated.
+                                  Default value is 0.
                                 x-kubernetes-int-or-string: true
                               paused:
-                                description: Paused indicates that the CloneSet is
-                                  paused. Default value is false
+                                description: |-
+                                  Paused indicates that the CloneSet is paused.
+                                  Default value is false
                                 type: boolean
                               priorityStrategy:
-                                description: Priorities are the rules for calculating
-                                  the priority of updating pods. Each pod to be updated,
-                                  will pass through these terms and get a sum of weights.
+                                description: |-
+                                  Priorities are the rules for calculating the priority of updating pods.
+                                  Each pod to be updated, will pass through these terms and get a sum of weights.
                                 properties:
                                   orderPriority:
-                                    description: 'Order priority terms, pods will
-                                      be sorted by the value of orderedKey. For example:
-                                      ``` orderPriority: - orderedKey: key1 - orderedKey:
-                                      key2 ``` First, all pods which have key1 in
-                                      labels will be sorted by the value of key1.
-                                      Then, the left pods which have no key1 but have
-                                      key2 in labels will be sorted by the value of
-                                      key2 and put behind those pods have key1.'
+                                    description: |-
+                                      Order priority terms, pods will be sorted by the value of orderedKey.
+                                      For example:
+                                      ```
+                                      orderPriority:
+                                      - orderedKey: key1
+                                      - orderedKey: key2
+                                      ```
+                                      First, all pods which have key1 in labels will be sorted by the value of key1.
+                                      Then, the left pods which have no key1 but have key2 in labels will be sorted by
+                                      the value of key2 and put behind those pods have key1.
                                     items:
                                       description: UpdatePriorityOrderTerm defines
                                         order priority.
                                       properties:
                                         orderedKey:
-                                          description: Calculate priority by value
-                                            of this key. Values of this key, will
-                                            be sorted by GetInt(val). GetInt method
-                                            will find the last int in value, such
-                                            as getting 5 in value '5', getting 10
-                                            in value 'sts-10'.
+                                          description: |-
+                                            Calculate priority by value of this key.
+                                            Values of this key, will be sorted by GetInt(val). GetInt method will find the last int in value,
+                                            such as getting 5 in value '5', getting 10 in value 'sts-10'.
                                           type: string
                                       required:
                                       - orderedKey
@@ -848,10 +849,9 @@ spec:
                                                 of label selector requirements. The
                                                 requirements are ANDed.
                                               items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
                                                     description: key is the label
@@ -859,20 +859,16 @@ spec:
                                                       to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -884,16 +880,13 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         weight:
                                           description: Weight associated with matching
                                             the corresponding matchExpressions, in
@@ -907,15 +900,11 @@ spec:
                                     type: array
                                 type: object
                               scatterStrategy:
-                                description: ScatterStrategy defines the scatter rules
-                                  to make pods been scattered when update. This will
-                                  avoid pods with the same key-value to be updated
-                                  in one batch. - Note that pods will be scattered
-                                  after priority sort. So, although priority strategy
-                                  and scatter strategy can be applied together, we
-                                  suggest to use either one of them. - If scatterStrategy
-                                  is used, we suggest to just use one term. Otherwise,
-                                  the update order can be hard to understand.
+                                description: |-
+                                  ScatterStrategy defines the scatter rules to make pods been scattered when update.
+                                  This will avoid pods with the same key-value to be updated in one batch.
+                                  - Note that pods will be scattered after priority sort. So, although priority strategy and scatter strategy can be applied together, we suggest to use either one of them.
+                                  - If scatterStrategy is used, we suggest to just use one term. Otherwise, the update order can be hard to understand.
                                 items:
                                   properties:
                                     key:
@@ -928,14 +917,15 @@ spec:
                                   type: object
                                 type: array
                               type:
-                                description: Type indicates the type of the CloneSetUpdateStrategy.
+                                description: |-
+                                  Type indicates the type of the CloneSetUpdateStrategy.
                                   Default is ReCreate.
                                 type: string
                             type: object
                           volumeClaimTemplates:
-                            description: VolumeClaimTemplates is a list of claims
-                              that pods are allowed to reference. Note that PVC will
-                              be deleted when its pod has been deleted.
+                            description: |-
+                              VolumeClaimTemplates is a list of claims that pods are allowed to reference.
+                              Note that PVC will be deleted when its pod has been deleted.
                             x-kubernetes-preserve-unknown-fields: true
                         required:
                         - selector
@@ -969,51 +959,103 @@ spec:
                 description: Topology describes the pods distribution detail between
                   each of subsets.
                 properties:
+                  scheduleStrategy:
+                    description: ScheduleStrategy indicates the strategy the UnitedDeployment
+                      used to preform the schedule between each of subsets.
+                    properties:
+                      adaptive:
+                        description: Adaptive is used to communicate parameters when
+                          Type is AdaptiveUnitedDeploymentScheduleStrategyType.
+                        properties:
+                          rescheduleCriticalSeconds:
+                            description: |-
+                              RescheduleCriticalSeconds indicates how long controller will reschedule a schedule failed Pod to the subset that has
+                              redundant capacity after the subset where the Pod lives. If a Pod was scheduled failed and still in an unschedulabe status
+                              over RescheduleCriticalSeconds duration, the controller will reschedule it to a suitable subset. Default is 30 seconds.
+                            format: int32
+                            type: integer
+                          unschedulableLastSeconds:
+                            description: |-
+                              UnschedulableLastSeconds is used to set the number of seconds for a Subset to recover from an unschedulable state,
+                              with a default value of 300 seconds.
+                            format: int32
+                            type: integer
+                        type: object
+                      type:
+                        description: |-
+                          Type indicates the type of the UnitedDeploymentScheduleStrategy.
+                          Default is Fixed
+                        enum:
+                        - Adaptive
+                        - Fixed
+                        - ""
+                        type: string
+                    type: object
                   subsets:
-                    description: Contains the details of each subset. Each element
-                      in this array represents one subset which will be provisioned
-                      and managed by UnitedDeployment.
+                    description: |-
+                      Contains the details of each subset. Each element in this array represents one subset
+                      which will be provisioned and managed by UnitedDeployment.
                     items:
                       description: Subset defines the detail of a subset.
                       properties:
+                        maxReplicas:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            Indicates the upper bounded replicas of the subset.
+                            MaxReplicas must be more than or equal to MinReplicas.
+                            MaxReplicas == nil means no limitation.
+                            Please ensure that at least one subset has empty MaxReplicas(no limitation) to avoid stuck scaling.
+                            Defaults to nil.
+                          x-kubernetes-int-or-string: true
+                        minReplicas:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            Indicates the lower bounded replicas of the subset.
+                            MinReplicas must be more than or equal to 0 if it is set.
+                            Controller will prioritize satisfy minReplicas for each subset
+                            according to the order of Topology.Subsets.
+                            Defaults to 0.
+                          x-kubernetes-int-or-string: true
                         name:
-                          description: Indicates subset name as a DNS_LABEL, which
-                            will be used to generate subset workload name prefix in
-                            the format '<deployment-name>-<subset-name>-'. Name should
-                            be unique between all of the subsets under one UnitedDeployment.
+                          description: |-
+                            Indicates subset name as a DNS_LABEL, which will be used to generate
+                            subset workload name prefix in the format '<deployment-name>-<subset-name>-'.
+                            Name should be unique between all of the subsets under one UnitedDeployment.
                           type: string
                         nodeSelectorTerm:
-                          description: Indicates the node selector to form the subset.
-                            Depending on the node selector, pods provisioned could
-                            be distributed across multiple groups of nodes. A subset's
-                            nodeSelectorTerm is not allowed to be updated.
+                          description: |-
+                            Indicates the node selector to form the subset. Depending on the node selector,
+                            pods provisioned could be distributed across multiple groups of nodes.
+                            A subset's nodeSelectorTerm is not allowed to be updated.
                           properties:
                             matchExpressions:
                               description: A list of node selector requirements by
                                 node's labels.
                               items:
-                                description: A node selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
+                                description: |-
+                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                  that relates the key and values.
                                 properties:
                                   key:
                                     description: The label key that the selector applies
                                       to.
                                     type: string
                                   operator:
-                                    description: Represents a key's relationship to
-                                      a set of values. Valid operators are In, NotIn,
-                                      Exists, DoesNotExist. Gt, and Lt.
+                                    description: |-
+                                      Represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: An array of string values. If the
-                                      operator is In or NotIn, the values array must
-                                      be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator
-                                      is Gt or Lt, the values array must have a single
-                                      element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      An array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                      array must have a single element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1026,28 +1068,26 @@ spec:
                               description: A list of node selector requirements by
                                 node's fields.
                               items:
-                                description: A node selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
+                                description: |-
+                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                  that relates the key and values.
                                 properties:
                                   key:
                                     description: The label key that the selector applies
                                       to.
                                     type: string
                                   operator:
-                                    description: Represents a key's relationship to
-                                      a set of values. Valid operators are In, NotIn,
-                                      Exists, DoesNotExist. Gt, and Lt.
+                                    description: |-
+                                      Represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: An array of string values. If the
-                                      operator is In or NotIn, the values array must
-                                      be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator
-                                      is Gt or Lt, the values array must have a single
-                                      element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      An array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                      array must have a single element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1057,60 +1097,62 @@ spec:
                                 type: object
                               type: array
                           type: object
+                          x-kubernetes-map-type: atomic
+                        patch:
+                          description: |-
+                            Patch indicates patching to the templateSpec.
+                            Patch takes precedence over other fields
+                            If the Patch also modifies the Replicas, NodeSelectorTerm or Tolerations, use value in the Patch
+                          x-kubernetes-preserve-unknown-fields: true
                         replicas:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: Indicates the number of the pod to be created
-                            under this subset. Replicas could also be percentage like
-                            '10%', which means 10% of UnitedDeployment replicas of
-                            pods will be distributed under this subset. If nil, the
-                            number of replicas in this subset is determined by controller.
-                            Controller will try to keep all the subsets with nil replicas
-                            have average pods.
+                          description: |-
+                            Indicates the number of the pod to be created under this subset. Replicas could also be
+                            percentage like '10%', which means 10% of UnitedDeployment replicas of pods will be distributed
+                            under this subset. If nil, the number of replicas in this subset is determined by controller.
+                            Controller will try to keep all the subsets with nil replicas have average pods.
+                            Replicas and MinReplicas/MaxReplicas are mutually exclusive in a UnitedDeployment.
                           x-kubernetes-int-or-string: true
                         tolerations:
-                          description: Indicates the tolerations the pods under this
-                            subset have. A subset's tolerations is not allowed to
-                            be updated.
+                          description: |-
+                            Indicates the tolerations the pods under this subset have.
+                            A subset's tolerations is not allowed to be updated.
                           items:
-                            description: The pod this Toleration is attached to tolerates
-                              any taint that matches the triple <key,value,effect>
-                              using the matching operator <operator>.
+                            description: |-
+                              The pod this Toleration is attached to tolerates any taint that matches
+                              the triple <key,value,effect> using the matching operator <operator>.
                             properties:
                               effect:
-                                description: Effect indicates the taint effect to
-                                  match. Empty means match all taint effects. When
-                                  specified, allowed values are NoSchedule, PreferNoSchedule
-                                  and NoExecute.
+                                description: |-
+                                  Effect indicates the taint effect to match. Empty means match all taint effects.
+                                  When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                 type: string
                               key:
-                                description: Key is the taint key that the toleration
-                                  applies to. Empty means match all taint keys. If
-                                  the key is empty, operator must be Exists; this
-                                  combination means to match all values and all keys.
+                                description: |-
+                                  Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                  If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                 type: string
                               operator:
-                                description: Operator represents a key's relationship
-                                  to the value. Valid operators are Exists and Equal.
-                                  Defaults to Equal. Exists is equivalent to wildcard
-                                  for value, so that a pod can tolerate all taints
-                                  of a particular category.
+                                description: |-
+                                  Operator represents a key's relationship to the value.
+                                  Valid operators are Exists and Equal. Defaults to Equal.
+                                  Exists is equivalent to wildcard for value, so that a pod can
+                                  tolerate all taints of a particular category.
                                 type: string
                               tolerationSeconds:
-                                description: TolerationSeconds represents the period
-                                  of time the toleration (which must be of effect
-                                  NoExecute, otherwise this field is ignored) tolerates
-                                  the taint. By default, it is not set, which means
-                                  tolerate the taint forever (do not evict). Zero
-                                  and negative values will be treated as 0 (evict
-                                  immediately) by the system.
+                                description: |-
+                                  TolerationSeconds represents the period of time the toleration (which must be
+                                  of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                  it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                  negative values will be treated as 0 (evict immediately) by the system.
                                 format: int64
                                 type: integer
                               value:
-                                description: Value is the taint value the toleration
-                                  matches to. If the operator is Exists, the value
-                                  should be empty, otherwise just a regular string.
+                                description: |-
+                                  Value is the taint value the toleration matches to.
+                                  If the operator is Exists, the value should be empty, otherwise just a regular string.
                                 type: string
                             type: object
                           type: array
@@ -1120,8 +1162,9 @@ spec:
                     type: array
                 type: object
               updateStrategy:
-                description: UpdateStrategy indicates the strategy the UnitedDeployment
-                  use to preform the update, when template is changed.
+                description: |-
+                  UpdateStrategy indicates the strategy the UnitedDeployment use to preform the update,
+                  when template is changed.
                 properties:
                   manualUpdate:
                     description: Includes all of the parameters a Manual update strategy
@@ -1135,8 +1178,9 @@ spec:
                         type: object
                     type: object
                   type:
-                    description: Type of UnitedDeployment update strategy. Default
-                      is Manual.
+                    description: |-
+                      Type of UnitedDeployment update strategy.
+                      Default is Manual.
                     type: string
                 type: object
             required:
@@ -1146,9 +1190,10 @@ spec:
             description: UnitedDeploymentStatus defines the observed state of UnitedDeployment.
             properties:
               collisionCount:
-                description: Count of hash collisions for the UnitedDeployment. The
-                  UnitedDeployment controller uses this field as a collision avoidance
-                  mechanism when it needs to create the name for the newest ControllerRevision.
+                description: |-
+                  Count of hash collisions for the UnitedDeployment. The UnitedDeployment controller
+                  uses this field as a collision avoidance mechanism when it needs to
+                  create the name for the newest ControllerRevision.
                 format: int32
                 type: integer
               conditions:
@@ -1164,7 +1209,7 @@ spec:
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
+                      description: A human-readable message indicating details about
                         the transition.
                       type: string
                     reason:
@@ -1182,10 +1227,14 @@ spec:
                 description: CurrentRevision, if not empty, indicates the current
                   version of the UnitedDeployment.
                 type: string
+              labelSelector:
+                description: LabelSelector is label selectors for query over pods
+                  that should match the replica count used by HPA.
+                type: string
               observedGeneration:
-                description: ObservedGeneration is the most recent generation observed
-                  for this UnitedDeployment. It corresponds to the UnitedDeployment's
-                  generation, which is updated on mutation by the API Server.
+                description: |-
+                  ObservedGeneration is the most recent generation observed for this UnitedDeployment. It corresponds to the
+                  UnitedDeployment's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
               readyReplicas:
@@ -1203,6 +1252,44 @@ spec:
                 description: Records the topology detail information of the replicas
                   of each subset.
                 type: object
+              subsetStatuses:
+                description: Record the conditions of each subset.
+                items:
+                  properties:
+                    conditions:
+                      description: Conditions is an array of current observed subset
+                        conditions.
+                      items:
+                        properties:
+                          lastTransitionTime:
+                            format: date-time
+                            type: string
+                          message:
+                            type: string
+                          reason:
+                            type: string
+                          status:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    name:
+                      description: Subset name specified in Topology.Subsets
+                      type: string
+                    partition:
+                      description: Records the current partition. Currently unused.
+                      format: int32
+                      type: integer
+                    replicas:
+                      description: Recores the current replicas. Currently unused.
+                      format: int32
+                      type: integer
+                  type: object
+                type: array
               updateStatus:
                 description: Records the information of update progress.
                 properties:
@@ -1235,14 +1322,8 @@ spec:
     storage: true
     subresources:
       scale:
-        labelSelectorPath: .status.selector
+        labelSelectorPath: .status.labelSelector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}

--- a/charts/kruise/templates/apps.kruise.io_workloadspreads.yaml
+++ b/charts/kruise/templates/apps.kruise.io_workloadspreads.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.crds.managed }}
-
+ 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: workloadspreads.apps.kruise.io
 spec:
   group: apps.kruise.io
@@ -39,10 +38,19 @@ spec:
         description: WorkloadSpread is the Schema for the WorkloadSpread API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -50,21 +58,32 @@ spec:
             description: WorkloadSpreadSpec defines the desired state of WorkloadSpread.
             properties:
               scheduleStrategy:
-                description: ScheduleStrategy indicates the strategy the WorkloadSpread used to preform the schedule between each of subsets.
+                description: ScheduleStrategy indicates the strategy the WorkloadSpread
+                  used to preform the schedule between each of subsets.
                 properties:
                   adaptive:
-                    description: Adaptive is used to communicate parameters when Type is AdaptiveWorkloadSpreadScheduleStrategyType.
+                    description: Adaptive is used to communicate parameters when Type
+                      is AdaptiveWorkloadSpreadScheduleStrategyType.
                     properties:
                       disableSimulationSchedule:
-                        description: DisableSimulationSchedule indicates whether to disable the feature of simulation schedule. Default is false. Webhook can take a simple general predicates to check whether Pod can be scheduled into this subset, but it just considers the Node resource and cannot replace scheduler to do richer predicates practically.
+                        description: |-
+                          DisableSimulationSchedule indicates whether to disable the feature of simulation schedule.
+                          Default is false.
+                          Webhook can take a simple general predicates to check whether Pod can be scheduled into this subset,
+                          but it just considers the Node resource and cannot replace scheduler to do richer predicates practically.
                         type: boolean
                       rescheduleCriticalSeconds:
-                        description: RescheduleCriticalSeconds indicates how long controller will reschedule a schedule failed Pod to the subset that has redundant capacity after the subset where the Pod lives. If a Pod was scheduled failed and still in a unschedulabe status over RescheduleCriticalSeconds duration, the controller will reschedule it to a suitable subset.
+                        description: |-
+                          RescheduleCriticalSeconds indicates how long controller will reschedule a schedule failed Pod to the subset that has
+                          redundant capacity after the subset where the Pod lives. If a Pod was scheduled failed and still in a unschedulabe status
+                          over RescheduleCriticalSeconds duration, the controller will reschedule it to a suitable subset.
                         format: int32
                         type: integer
                     type: object
                   type:
-                    description: Type indicates the type of the WorkloadSpreadScheduleStrategy. Default is Fixed
+                    description: |-
+                      Type indicates the type of the WorkloadSpreadScheduleStrategy.
+                      Default is Fixed
                     enum:
                     - Adaptive
                     - Fixed
@@ -72,7 +91,8 @@ spec:
                     type: string
                 type: object
               subsets:
-                description: Subsets describes the pods distribution details between each of subsets.
+                description: Subsets describes the pods distribution details between
+                  each of subsets.
                 items:
                   description: WorkloadSpreadSubset defines the details of a subset.
                   properties:
@@ -80,35 +100,52 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: MaxReplicas indicates the desired max replicas of this subset.
+                      description: MaxReplicas indicates the desired max replicas
+                        of this subset.
                       x-kubernetes-int-or-string: true
                     name:
-                      description: Name should be unique between all of the subsets under one WorkloadSpread.
+                      description: Name should be unique between all of the subsets
+                        under one WorkloadSpread.
                       type: string
                     patch:
                       description: Patch indicates patching podTemplate to the Pod.
                       x-kubernetes-preserve-unknown-fields: true
                     preferredNodeSelectorTerms:
-                      description: Indicates the node preferred selector to form the subset.
+                      description: Indicates the node preferred selector to form the
+                        subset.
                       items:
-                        description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                        description: |-
+                          An empty preferred scheduling term matches all objects with implicit weight 0
+                          (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                         properties:
                           preference:
-                            description: A node selector term, associated with the corresponding weight.
+                            description: A node selector term, associated with the
+                              corresponding weight.
                             properties:
                               matchExpressions:
-                                description: A list of node selector requirements by node's labels.
+                                description: A list of node selector requirements
+                                  by node's labels.
                                 items:
-                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  description: |-
+                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                    that relates the key and values.
                                   properties:
                                     key:
-                                      description: The label key that the selector applies to.
+                                      description: The label key that the selector
+                                        applies to.
                                       type: string
                                     operator:
-                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      description: |-
+                                        Represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                       type: string
                                     values:
-                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                      description: |-
+                                        An array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will be interpreted as an integer.
+                                        This array is replaced during a strategic merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -118,18 +155,29 @@ spec:
                                   type: object
                                 type: array
                               matchFields:
-                                description: A list of node selector requirements by node's fields.
+                                description: A list of node selector requirements
+                                  by node's fields.
                                 items:
-                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  description: |-
+                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                    that relates the key and values.
                                   properties:
                                     key:
-                                      description: The label key that the selector applies to.
+                                      description: The label key that the selector
+                                        applies to.
                                       type: string
                                     operator:
-                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                      description: |-
+                                        Represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                       type: string
                                     values:
-                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                      description: |-
+                                        An array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                        array must have a single element, which will be interpreted as an integer.
+                                        This array is replaced during a strategic merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -139,8 +187,10 @@ spec:
                                   type: object
                                 type: array
                             type: object
+                            x-kubernetes-map-type: atomic
                           weight:
-                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                            description: Weight associated with matching the corresponding
+                              nodeSelectorTerm, in the range 1-100.
                             format: int32
                             type: integer
                         required:
@@ -149,21 +199,33 @@ spec:
                         type: object
                       type: array
                     requiredNodeSelectorTerm:
-                      description: Indicates the node required selector to form the subset.
+                      description: Indicates the node required selector to form the
+                        subset.
                       properties:
                         matchExpressions:
-                          description: A list of node selector requirements by node's labels.
+                          description: A list of node selector requirements by node's
+                            labels.
                           items:
-                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A node selector requirement is a selector that contains values, a key, and an operator
+                              that relates the key and values.
                             properties:
                               key:
-                                description: The label key that the selector applies to.
+                                description: The label key that the selector applies
+                                  to.
                                 type: string
                               operator:
-                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                 type: string
                               values:
-                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -173,18 +235,29 @@ spec:
                             type: object
                           type: array
                         matchFields:
-                          description: A list of node selector requirements by node's fields.
+                          description: A list of node selector requirements by node's
+                            fields.
                           items:
-                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A node selector requirement is a selector that contains values, a key, and an operator
+                              that relates the key and values.
                             properties:
                               key:
-                                description: The label key that the selector applies to.
+                                description: The label key that the selector applies
+                                  to.
                                 type: string
                               operator:
-                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                 type: string
                               values:
-                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -194,26 +267,44 @@ spec:
                             type: object
                           type: array
                       type: object
+                      x-kubernetes-map-type: atomic
                     tolerations:
-                      description: Indicates the tolerations the pods under this subset have.
+                      description: Indicates the tolerations the pods under this subset
+                        have.
                       items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists and Equal. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
                             type: string
                         type: object
                       type: array
@@ -221,8 +312,72 @@ spec:
                   - name
                   type: object
                 type: array
+              targetFilter:
+                description: |-
+                  TargetFilter allows WorkloadSpread to manage only a portion of the Pods in the TargetReference:
+                  by specifying the criteria for the Pods to be managed through a label selector,
+                  and by specifying how to obtain the total number of these selected Pods from the workload using replicasPaths.
+                properties:
+                  replicasPathList:
+                    description: |-
+                      ReplicasPathList is a list of resource paths used to specify how to determine the total number of replicas of
+                      the target workload after filtering. If this list is not empty, WorkloadSpread will look for the corresponding
+                      values in the target resource according to each path, and treat the sum of these values as the total number of replicas after filtering.
+
+
+                      The replicas path is a dot-separated path, similar to "spec.replicas". If there are arrays, you can use numbers to denote indexes, like "subsets.1.replicas".
+                      The real values of these paths must be integers.
+                    items:
+                      type: string
+                    type: array
+                  selector:
+                    description: Selector is used to filter the Pods to be managed.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
               targetRef:
-                description: TargetReference is the target workload that WorkloadSpread want to control.
+                description: TargetReference is the target workload that WorkloadSpread
+                  want to control.
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -246,30 +401,38 @@ spec:
             description: WorkloadSpreadStatus defines the observed state of WorkloadSpread.
             properties:
               observedGeneration:
-                description: ObservedGeneration is the most recent generation observed for this WorkloadSpread. It corresponds to the WorkloadSpread's generation, which is updated on mutation by the API Server.
+                description: |-
+                  ObservedGeneration is the most recent generation observed for this WorkloadSpread. It corresponds to the
+                  WorkloadSpread's generation, which is updated on mutation by the API Server.
                 format: int64
                 type: integer
               subsetStatuses:
-                description: Contains the status of each subset. Each element in this array represents one subset
+                description: Contains the status of each subset. Each element in this
+                  array represents one subset
                 items:
-                  description: WorkloadSpreadSubsetStatus defines the observed state of subset
+                  description: WorkloadSpreadSubsetStatus defines the observed state
+                    of subset
                   properties:
                     conditions:
-                      description: Conditions is an array of current observed subset conditions.
+                      description: Conditions is an array of current observed subset
+                        conditions.
                       items:
                         properties:
                           lastTransitionTime:
-                            description: Last time the condition transitioned from one status to another.
+                            description: Last time the condition transitioned from
+                              one status to another.
                             format: date-time
                             type: string
                           message:
-                            description: A human readable message indicating details about the transition.
+                            description: A human readable message indicating details
+                              about the transition.
                             type: string
                           reason:
                             description: The reason for the condition's last transition.
                             type: string
                           status:
-                            description: Status of the condition, one of True, False, Unknown.
+                            description: Status of the condition, one of True, False,
+                              Unknown.
                             type: string
                           type:
                             description: Type of in place set condition.
@@ -283,23 +446,40 @@ spec:
                       additionalProperties:
                         format: date-time
                         type: string
-                      description: CreatingPods contains information about pods whose creation was processed by the webhook handler but not yet been observed by the WorkloadSpread controller. A pod will be in this map from the time when the webhook handler processed the creation request to the time when the pod is seen by controller. The key in the map is the name of the pod and the value is the time when the webhook handler process the creation request. If the real creation didn't happen and a pod is still in this map, it will be removed from the list automatically by WorkloadSpread controller after some time. If everything goes smooth this map should be empty for the most of the time. Large number of entries in the map may indicate problems with pod creations.
+                      description: |-
+                        CreatingPods contains information about pods whose creation was processed by
+                        the webhook handler but not yet been observed by the WorkloadSpread controller.
+                        A pod will be in this map from the time when the webhook handler processed the
+                        creation request to the time when the pod is seen by controller.
+                        The key in the map is the name of the pod and the value is the time when the webhook
+                        handler process the creation request. If the real creation didn't happen and a pod is
+                        still in this map, it will be removed from the list automatically by WorkloadSpread controller
+                        after some time.
+                        If everything goes smooth this map should be empty for the most of the time.
+                        Large number of entries in the map may indicate problems with pod creations.
                       type: object
                     deletingPods:
                       additionalProperties:
                         format: date-time
                         type: string
-                      description: DeletingPods is similar with CreatingPods and it contains information about pod deletion.
+                      description: DeletingPods is similar with CreatingPods and it
+                        contains information about pod deletion.
                       type: object
                     missingReplicas:
-                      description: MissingReplicas is the number of active replicas belong to this subset not be found. MissingReplicas > 0 indicates the subset is still missing MissingReplicas pods to create MissingReplicas = 0 indicates the subset already has enough pods, there is no need to create MissingReplicas = -1 indicates the subset's MaxReplicas not set, then there is no limit for pods number
+                      description: |-
+                        MissingReplicas is the number of active replicas belong to this subset not be found.
+                        MissingReplicas > 0 indicates the subset is still missing MissingReplicas pods to create
+                        MissingReplicas = 0 indicates the subset already has enough pods, there is no need to create
+                        MissingReplicas = -1 indicates the subset's MaxReplicas not set, then there is no limit for pods number
                       format: int32
                       type: integer
                     name:
-                      description: Name should be unique between all of the subsets under one WorkloadSpread.
+                      description: Name should be unique between all of the subsets
+                        under one WorkloadSpread.
                       type: string
                     replicas:
-                      description: Replicas is the most recently observed number of active replicas for subset.
+                      description: Replicas is the most recently observed number of
+                        active replicas for subset.
                       format: int32
                       type: integer
                   required:
@@ -308,16 +488,97 @@ spec:
                   - replicas
                   type: object
                 type: array
+              versionedSubsetStatuses:
+                additionalProperties:
+                  items:
+                    description: WorkloadSpreadSubsetStatus defines the observed state
+                      of subset
+                    properties:
+                      conditions:
+                        description: Conditions is an array of current observed subset
+                          conditions.
+                        items:
+                          properties:
+                            lastTransitionTime:
+                              description: Last time the condition transitioned from
+                                one status to another.
+                              format: date-time
+                              type: string
+                            message:
+                              description: A human readable message indicating details
+                                about the transition.
+                              type: string
+                            reason:
+                              description: The reason for the condition's last transition.
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              type: string
+                            type:
+                              description: Type of in place set condition.
+                              type: string
+                          required:
+                          - status
+                          - type
+                          type: object
+                        type: array
+                      creatingPods:
+                        additionalProperties:
+                          format: date-time
+                          type: string
+                        description: |-
+                          CreatingPods contains information about pods whose creation was processed by
+                          the webhook handler but not yet been observed by the WorkloadSpread controller.
+                          A pod will be in this map from the time when the webhook handler processed the
+                          creation request to the time when the pod is seen by controller.
+                          The key in the map is the name of the pod and the value is the time when the webhook
+                          handler process the creation request. If the real creation didn't happen and a pod is
+                          still in this map, it will be removed from the list automatically by WorkloadSpread controller
+                          after some time.
+                          If everything goes smooth this map should be empty for the most of the time.
+                          Large number of entries in the map may indicate problems with pod creations.
+                        type: object
+                      deletingPods:
+                        additionalProperties:
+                          format: date-time
+                          type: string
+                        description: DeletingPods is similar with CreatingPods and
+                          it contains information about pod deletion.
+                        type: object
+                      missingReplicas:
+                        description: |-
+                          MissingReplicas is the number of active replicas belong to this subset not be found.
+                          MissingReplicas > 0 indicates the subset is still missing MissingReplicas pods to create
+                          MissingReplicas = 0 indicates the subset already has enough pods, there is no need to create
+                          MissingReplicas = -1 indicates the subset's MaxReplicas not set, then there is no limit for pods number
+                        format: int32
+                        type: integer
+                      name:
+                        description: Name should be unique between all of the subsets
+                          under one WorkloadSpread.
+                        type: string
+                      replicas:
+                        description: Replicas is the most recently observed number
+                          of active replicas for subset.
+                        format: int32
+                        type: integer
+                    required:
+                    - missingReplicas
+                    - name
+                    - replicas
+                    type: object
+                  type: array
+                description: |-
+                  VersionedSubsetStatuses is to solve rolling-update problems, where the creation of new-version pod
+                  may be earlier than deletion of old-version pod. We have to calculate the pod subset distribution for
+                  each version.
+                type: object
             type: object
         type: object
     served: true
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+
 {{- end }}

--- a/charts/kruise/templates/manager.yaml
+++ b/charts/kruise/templates/manager.yaml
@@ -3,9 +3,14 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: openkruise
   name: {{ .Values.installation.namespace }}
 {{- end }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kruise-daemon-config
 ---
 apiVersion: v1
 kind: Service
@@ -14,6 +19,7 @@ metadata:
   namespace: {{ .Values.installation.namespace }}
 spec:
 {{ ( include "webhookServiceSpec" . ) | indent 2 }}
+{{- if and (not (contains "EnableExternalCerts=true" .Values.featureGates)) (not (contains "AllAlpha=true" .Values.featureGates)) }}
 ---
 apiVersion: v1
 kind: Secret
@@ -21,6 +27,7 @@ metadata:
   name: kruise-webhook-certs
   namespace: {{ .Values.installation.namespace }}
 {{ ( include "webhookSecretData" . ) }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -59,10 +66,21 @@ spec:
             - --v={{ .Values.manager.log.level }}
             - --feature-gates={{ .Values.featureGates }}
             - --sync-period={{ .Values.manager.resyncPeriod }}
+            {{- if .Values.manager.loggingFormat }}
+            - --logging-format={{ .Values.manager.loggingFormat }}
+            {{- end }}
           command:
             - /manager
           image: {{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              drop:
+                - all
+              add: [ 'NET_BIND_SERVICE' ]
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
           name: manager
           env:
 {{- if .Values.enableKubeCacheMutationDetector }}
@@ -75,8 +93,6 @@ spec:
                   fieldPath: metadata.namespace
             - name: WEBHOOK_PORT
               value: "{{ .Values.manager.webhook.port }}"
-            - name: WEBHOOK_CONFIGURATION_FAILURE_POLICY_PODS
-              value: {{ .Values.webhookConfiguration.failurePolicy.pods }}
           ports:
             - containerPort: {{ .Values.manager.webhook.port }}
               name: webhook-server
@@ -95,7 +111,7 @@ spec:
             {{- toYaml .Values.manager.resources | nindent 12 }}
       hostNetwork: {{ .Values.manager.hostNetwork }}
       terminationGracePeriodSeconds: 10
-      serviceAccountName:  {{ .Values.manager.serviceAccountName | default "kruise-manager" | quote }}
+      serviceAccountName: kruise-manager
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -112,6 +128,17 @@ spec:
         nodeAffinity:
 {{ toYaml . | indent 10 }}
 {{- end }}
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            control-plane: controller-manager
+{{- if and ( eq (int .Capabilities.KubeVersion.Major) 1) ( gt (int .Capabilities.KubeVersion.Minor) 26 ) }}
+        matchLabelKeys:
+        - pod-template-hash
+{{- end }}
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable:  ScheduleAnyway
 
 {{- if .Values.manager.nodeSelector }}
       nodeSelector:
@@ -123,7 +150,6 @@ spec:
 {{ toYaml .Values.manager.tolerations | indent 8 }}
 {{- end }}
 ---
-{{- if not .Values.manager.serviceAccountName }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -134,9 +160,7 @@ metadata:
 {{- end }}
   namespace: {{ .Values.installation.namespace }}
 {{ ( include "serviceAccountManager" . ) }}
-{{- end }}
 ---
-{{- if not .Values.daemon.serviceAccountName }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -147,7 +171,6 @@ metadata:
 {{- end }}
   namespace: {{ .Values.installation.namespace }}
 {{ ( include "serviceAccountDaemon" . ) }}
-{{- end }}
 ---
 {{ if contains "KruiseDaemon=false" .Values.featureGates }}{{ else }}
 apiVersion: apps/v1
@@ -192,8 +215,24 @@ spec:
         - --addr=:{{ .Values.daemon.port }}
         - --feature-gates={{ .Values.featureGates }}
         - --socket-file={{ .Values.daemon.socketFile }}
+{{- if not .Values.daemon.enablePprof }}
+        - --enable-pprof=false
+{{- else }}
+        - --enable-pprof=true
+        - --pprof-addr={{ .Values.daemon.pprofAddr }}
+{{- end }}
+{{- if .Values.daemon.credentialProvider.enable }}
+        - --plugin-config-file=/credential-provider-config/CredentialProviderPlugin.yaml
+        - --plugin-bin-dir=/credential-provider-plugin
+{{- end }}
         image: {{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}
-        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        imagePullPolicy: Always
+        securityContext:
+          capabilities:
+            drop:
+              - all
+            add: [ 'NET_BIND_SERVICE' ]
+          allowPrivilegeEscalation: false
         name: daemon
         env:
 {{- if .Values.enableKubeCacheMutationDetector }}
@@ -224,14 +263,43 @@ spec:
         - mountPath: /hostvarrun
           name: runtime-socket
           readOnly: true
+{{- if .Values.daemon.credentialProvider.enable }}
+        - name: credential-provider-plugin-config
+          mountPath: /credential-provider-config
+          readOnly: true
+        - name: credential-provider-plugin
+          mountPath: /credential-provider-plugin
+          readOnly: true
+        {{- if ne .Values.daemon.credentialProvider.awsCredentialsDir "" }}
+        - name: aws-credentials-dir
+          mountPath: /root/.aws
+          readOnly: true
+        {{- end }}
+{{- end }}
       tolerations:
       - operator: Exists
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       terminationGracePeriodSeconds: 10
-      serviceAccountName: {{ .Values.daemon.serviceAccountName | default "kruise-daemon" | quote }}
+      serviceAccountName: kruise-daemon
       volumes:
       - hostPath:
           path: {{ .Values.daemon.socketLocation }}
           type: ""
         name: runtime-socket
+{{- if .Values.daemon.credentialProvider.enable }}
+      - name: credential-provider-plugin-config
+        configMap:
+          name: {{ .Values.daemon.credentialProvider.configmap }}
+      - hostPath:
+          path: {{ .Values.daemon.credentialProvider.hostPath }}
+          type: ""
+        name: credential-provider-plugin
+      {{- if ne .Values.daemon.credentialProvider.awsCredentialsDir "" }}
+      - hostPath:
+          path: {{ .Values.daemon.credentialProvider.awsCredentialsDir }}
+          type: ""
+        name: aws-credentials-dir
+      {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/kruise/templates/policy.kruise.io_podunavailablebudgets.yaml
+++ b/charts/kruise/templates/policy.kruise.io_podunavailablebudgets.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.crds.managed }}
-
+ 
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: podunavailablebudgets.policy.kruise.io
 spec:
   group: policy.kruise.io
@@ -20,7 +19,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: UnavailableAllowed number of pod unavailable that are currently allowed
+    - description: UnavailableAllowed number of pod unavailable that are currently
+        allowed
       jsonPath: .status.unavailableAllowed
       name: Allowed
       type: integer
@@ -39,13 +39,23 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: PodUnavailableBudget is the Schema for the podunavailablebudgets API
+        description: PodUnavailableBudget is the Schema for the podunavailablebudgets
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -56,30 +66,45 @@ spec:
                 anyOf:
                 - type: integer
                 - type: string
-                description: Delete pod, evict pod or update pod specification is allowed if at most "maxUnavailable" pods selected by "selector" or "targetRef"  are unavailable after the above operation for pod. MaxUnavailable and MinAvailable are mutually exclusive, MaxUnavailable is priority to take effect
+                description: |-
+                  Delete pod, evict pod or update pod specification is allowed if at most "maxUnavailable" pods selected by
+                  "selector" or "targetRef"  are unavailable after the above operation for pod.
+                  MaxUnavailable and MinAvailable are mutually exclusive, MaxUnavailable is priority to take effect
                 x-kubernetes-int-or-string: true
               minAvailable:
                 anyOf:
                 - type: integer
                 - type: string
-                description: Delete pod, evict pod or update pod specification is allowed if at least "minAvailable" pods selected by "selector" or "targetRef" will still be available after the above operation for pod.
+                description: |-
+                  Delete pod, evict pod or update pod specification is allowed if at least "minAvailable" pods selected by
+                  "selector" or "targetRef" will still be available after the above operation for pod.
                 x-kubernetes-int-or-string: true
               selector:
                 description: Selector label query over pods managed by the budget
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies to.
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
                             type: string
                           type: array
@@ -91,11 +116,17 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               targetRef:
-                description: TargetReference contains enough information to let you identify an workload for PodUnavailableBudget Selector and TargetReference are mutually exclusive, TargetReference is priority to take effect
+                description: |-
+                  TargetReference contains enough information to let you identify an workload for PodUnavailableBudget
+                  Selector and TargetReference are mutually exclusive, TargetReference is priority to take effect
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -109,39 +140,49 @@ spec:
                 type: object
             type: object
           status:
-            description: PodUnavailableBudgetStatus defines the observed state of PodUnavailableBudget
+            description: PodUnavailableBudgetStatus defines the observed state of
+              PodUnavailableBudget
             properties:
               currentAvailable:
                 description: CurrentAvailable current number of available pods
                 format: int32
                 type: integer
               desiredAvailable:
-                description: DesiredAvailable minimum desired number of available pods
+                description: DesiredAvailable minimum desired number of available
+                  pods
                 format: int32
                 type: integer
               disruptedPods:
                 additionalProperties:
                   format: date-time
                   type: string
-                description: DisruptedPods contains information about pods whose eviction or deletion was processed by the API handler but has not yet been observed by the PodUnavailableBudget.
+                description: |-
+                  DisruptedPods contains information about pods whose eviction or deletion was
+                  processed by the API handler but has not yet been observed by the PodUnavailableBudget.
                 type: object
               observedGeneration:
-                description: Most recent generation observed when updating this PUB status. UnavailableAllowed and other status information is valid only if observedGeneration equals to PUB's object generation.
+                description: |-
+                  Most recent generation observed when updating this PUB status. UnavailableAllowed and other
+                  status information is valid only if observedGeneration equals to PUB's object generation.
                 format: int64
                 type: integer
               totalReplicas:
-                description: TotalReplicas total number of pods counted by this unavailable budget
+                description: TotalReplicas total number of pods counted by this unavailable
+                  budget
                 format: int32
                 type: integer
               unavailableAllowed:
-                description: UnavailableAllowed number of pod unavailable that are currently allowed
+                description: UnavailableAllowed number of pod unavailable that are
+                  currently allowed
                 format: int32
                 type: integer
               unavailablePods:
                 additionalProperties:
                   format: date-time
                   type: string
-                description: UnavailablePods contains information about pods whose specification changed(inplace-update pod), once pod is available(consistent and ready) again, it will be removed from the list.
+                description: |-
+                  UnavailablePods contains information about pods whose specification changed(inplace-update pod),
+                  once pod is available(consistent and ready) again, it will be removed from the list.
                 type: object
             required:
             - currentAvailable
@@ -154,10 +195,4 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end }}

--- a/charts/kruise/templates/pre_delete_hook_job.yaml
+++ b/charts/kruise/templates/pre_delete_hook_job.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kruise-helm-hook-role
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "1"
+rules:
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - clonesets
+    verbs:
+      - list
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - daemonsets
+    verbs:
+      - list
+  - apiGroups:
+      - apps.kruise.io
+    resources:
+      - statefulsets
+    verbs:
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kruise-helm-hook-rolebinding
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "2"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kruise-helm-hook-role
+subjects:
+  - kind: ServiceAccount
+    name: kruise-helm-hook
+    namespace: {{ .Values.installation.namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-finalizer"
+  namespace: {{ .Values.installation.namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    kruise: helm-finalizer
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "4"
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-finalizer"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        kruise: helm-finalizer
+    spec:
+      restartPolicy: Never
+      serviceAccountName: kruise-helm-hook
+      containers:
+        - name: pre-delete-job
+          image: {{ .Values.helmHooks.image.repository }}:{{ .Values.helmHooks.image.tag }}
+          imagePullPolicy: IfNotPresent
+---
+# write a service account named kruise-helm-hook:
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kruise-helm-hook
+  namespace: {{ .Values.installation.namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "3"

--- a/charts/kruise/templates/rbac_role.yaml
+++ b/charts/kruise/templates/rbac_role.yaml
@@ -1,30 +1,9 @@
-{{- if not .Values.manager.serviceAccountName }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kruise-leader-election-role
   namespace: {{ .Values.installation.namespace }}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - configmaps/status
-  verbs:
-  - get
-  - update
-  - patch
 - apiGroups:
   - coordination.k8s.io
   resources:
@@ -43,33 +22,96 @@ rules:
   - events
   verbs:
   - create
-{{- end }}
 ---
-{{- if not .Values.manager.serviceAccountName }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kruise-manager-role
+  creationTimestamp: null
+  name: kruise-daemon-role
 rules:
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - nodeimages
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - nodeimages/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:
-  - configmaps
+  - events
   verbs:
   - create
-  - delete
+  - update
+  - patch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - containerrecreaterequests
+  verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - containerrecreaterequests/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - patch
   - update
   - watch
 - apiGroups:
   - ""
   resources:
-  - namespaces
+  - pods/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - nodepodprobes
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - nodepodprobes/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kruise-manager-role
+rules:
 - apiGroups:
   - ""
   resources:
@@ -82,7 +124,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  {{ toYaml .Values.installation.roleListGroups }}
+{{ toYaml .Values.installation.roleListGroups | nindent 2}}
   resources:
   - '*'
   verbs:
@@ -102,8 +144,6 @@ rules:
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - admissionregistration.k8s.io
@@ -112,8 +152,6 @@ rules:
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - apiextensions.k8s.io
@@ -122,8 +160,6 @@ rules:
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - apps
@@ -206,6 +242,12 @@ rules:
 - apiGroups:
   - apps.kruise.io
   resources:
+  - advancedcronjobs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
   - advancedcronjobs/status
   verbs:
   - get
@@ -223,6 +265,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - broadcastjobs/finalizers
+  verbs:
+  - update
 - apiGroups:
   - apps.kruise.io
   resources:
@@ -246,6 +294,12 @@ rules:
 - apiGroups:
   - apps.kruise.io
   resources:
+  - clonesets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
   - clonesets/status
   verbs:
   - get
@@ -263,6 +317,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - containerrecreaterequests/finalizers
+  verbs:
+  - update
 - apiGroups:
   - apps.kruise.io
   resources:
@@ -286,6 +346,12 @@ rules:
 - apiGroups:
   - apps.kruise.io
   resources:
+  - daemonsets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
   - daemonsets/status
   verbs:
   - get
@@ -305,7 +371,41 @@ rules:
 - apiGroups:
   - apps.kruise.io
   resources:
+  - ephemeraljobs/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
   - ephemeraljobs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - imagelistpulljobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - imagelistpulljobs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - imagelistpulljobs/status
   verbs:
   - get
   - patch
@@ -322,6 +422,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - imagepulljobs/finalizers
+  verbs:
+  - update
 - apiGroups:
   - apps.kruise.io
   resources:
@@ -345,6 +451,12 @@ rules:
 - apiGroups:
   - apps.kruise.io
   resources:
+  - nodeimages/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
   - nodeimages/status
   verbs:
   - get
@@ -362,6 +474,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - nodepodprobes/finalizers
+  verbs:
+  - update
 - apiGroups:
   - apps.kruise.io
   resources:
@@ -385,6 +503,12 @@ rules:
 - apiGroups:
   - apps.kruise.io
   resources:
+  - persistentpodstates/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
   - persistentpodstates/status
   verbs:
   - get
@@ -405,6 +529,12 @@ rules:
 - apiGroups:
   - apps.kruise.io
   resources:
+  - podprobemarkers/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
   - podprobemarkers/status
   verbs:
   - get
@@ -418,6 +548,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - resourcedistributions/finalizers
+  verbs:
+  - update
 - apiGroups:
   - apps.kruise.io
   resources:
@@ -441,6 +577,12 @@ rules:
 - apiGroups:
   - apps.kruise.io
   resources:
+  - sidecarsets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
   - sidecarsets/status
   verbs:
   - get
@@ -458,6 +600,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - statefulsets/finalizers
+  verbs:
+  - update
 - apiGroups:
   - apps.kruise.io
   resources:
@@ -481,6 +629,12 @@ rules:
 - apiGroups:
   - apps.kruise.io
   resources:
+  - uniteddeployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - apps.kruise.io
+  resources:
   - uniteddeployments/status
   verbs:
   - get
@@ -496,6 +650,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - workloadspreads/finalizers
+  verbs:
+  - update
 - apiGroups:
   - apps.kruise.io
   resources:
@@ -551,6 +711,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get
@@ -597,18 +765,6 @@ rules:
   - patch
   - update
 - apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - policy.kruise.io
   resources:
   - podunavailablebudgets
@@ -623,107 +779,28 @@ rules:
 - apiGroups:
   - policy.kruise.io
   resources:
+  - podunavailablebudgets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - policy.kruise.io
+  resources:
   - podunavailablebudgets/status
   verbs:
   - get
   - patch
   - update
+{{- if (contains "StatefulSetAutoResizePVCGate=true" .Values.featureGates) }}
+- apiGroups:
+    - storage.k8s.io
+  resources:
+    - storageclasses
+  verbs:
+    - get
+    - list
+    - watch
 {{- end }}
 ---
-{{- if not .Values.daemon.serviceAccountName }}
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  name: kruise-daemon-role
-rules:
-- apiGroups:
-  - apps.kruise.io
-  resources:
-  - nodeimages
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps.kruise.io
-  resources:
-  - nodeimages/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - update
-  - patch
-- apiGroups:
-  - apps.kruise.io
-  resources:
-  - containerrecreaterequests
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps.kruise.io
-  resources:
-  - containerrecreaterequests/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps.kruise.io
-  resources:
-  - nodepodprobes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps.kruise.io
-  resources:
-  - nodepodprobes/status
-  verbs:
-  - get
-  - patch
-  - update
-{{- end }}
----
-{{- if not .Values.manager.serviceAccountName }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -734,12 +811,10 @@ roleRef:
   kind: Role
   name: kruise-leader-election-role
 subjects:
-  - kind: ServiceAccount
-    name: kruise-manager
-    namespace: {{ .Values.installation.namespace }}
-{{- end }}
+- kind: ServiceAccount
+  name: kruise-manager
+  namespace: {{ .Values.installation.namespace }}
 ---
-{{- if not .Values.manager.serviceAccountName }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -749,12 +824,10 @@ roleRef:
   kind: ClusterRole
   name: kruise-manager-role
 subjects:
-  - kind: ServiceAccount
-    name: kruise-manager
-    namespace: {{ .Values.installation.namespace }}
-{{- end }}
+- kind: ServiceAccount
+  name: kruise-manager
+  namespace: {{ .Values.installation.namespace }}
 ---
-{{- if not .Values.daemon.serviceAccountName }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -764,7 +837,228 @@ roleRef:
   kind: ClusterRole
   name: kruise-daemon-role
 subjects:
-  - kind: ServiceAccount
-    name: kruise-daemon
-    namespace: {{ .Values.installation.namespace }}
+- kind: ServiceAccount
+  name: kruise-daemon
+  namespace: {{ .Values.installation.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kruise-webhook-role
+  namespace: {{ .Values.installation.namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+{{- if not (contains "EnableExternalCerts=true" .Values.featureGates) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kruise-certs-role
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  resourceNames:
+  - kruise-mutating-webhook-configuration
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  resourceNames:
+  - kruise-validating-webhook-configuration
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  resourceNames:
+  - statefulsets.apps.kruise.io
+  verbs:
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kruise-certs-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kruise-certs-role
+subjects:
+- kind: ServiceAccount
+  name: kruise-manager
+  namespace: {{ .Values.installation.namespace }}
 {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kruise-webhook-rolebinding
+  namespace: {{ .Values.installation.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kruise-webhook-role
+subjects:
+- kind: ServiceAccount
+  name: kruise-manager
+  namespace: {{ .Values.installation.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: kruise-daemon-secret-role
+  namespace: kruise-daemon-config
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kruise-daemon-secret-rolebinding
+  namespace: kruise-daemon-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kruise-daemon-secret-role
+subjects:
+- kind: ServiceAccount
+  name: kruise-daemon
+  namespace: {{ .Values.installation.namespace }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-kruise-view
+  labels:
+    # Add these permissions to the "view" default role.
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups: ["apps.kruise.io"]
+  resources:
+    - advancedcronjobs
+    - advancedcronjobs/status
+    - broadcastjobs
+    - broadcastjobs/status
+    - clonesets
+    - clonesets/scale
+    - clonesets/status
+    - containerrecreaterequests
+    - containerrecreaterequests/status
+    - daemonsets
+    - daemonsets/status
+    - imagelistpulljobs
+    - imagelistpulljobs/status
+    - imagepulljobs
+    - imagepulljobs/status
+    - nodeimages
+    - nodeimages/status
+    - nodepodprobes
+    - nodepodprobes/status
+    - persistentpodstates
+    - persistentpodstates/status
+    - podprobemarkers
+    - podprobemarkers/status
+    - sidecarsets
+    - sidecarsets/status
+    - statefulsets
+    - statefulsets/scale
+    - statefulsets/status
+    - uniteddeployments
+    - uniteddeployments/scale
+    - uniteddeployments/status
+    - workloadspreads
+    - workloadspreads/status
+  verbs:
+    - get
+    - list
+    - watch
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-kruise-edit
+  labels:
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["apps.kruise.io"]
+  resources:
+    - advancedcronjobs
+    - broadcastjobs
+    - clonesets
+    - clonesets/scale
+    - containerrecreaterequests
+    - daemonsets
+    - imagelistpulljobs
+    - imagepulljobs
+    - nodeimages
+    - nodepodprobes
+    - persistentpodstates
+    - podprobemarkers
+    - sidecarsets
+    - statefulsets
+    - statefulsets/scale
+    - uniteddeployments
+    - uniteddeployments/scale
+    - workloadspreads
+  verbs:
+    - create
+    - delete
+    - deletecollection
+    - patch
+    - update
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-kruise-admin
+  labels:
+    # Add these permissions to the "admin" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups: ["apps.kruise.io"]
+  resources:
+    - resourcedistributions/status
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups: ["apps.kruise.io"]
+  resources:
+    - resourcedistributions
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - deletecollection
+    - patch
+    - update

--- a/charts/kruise/templates/webhookconfiguration.yaml
+++ b/charts/kruise/templates/webhookconfiguration.yaml
@@ -1,271 +1,289 @@
-{{- if .Values.webhookConfiguration.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: kruise-mutating-webhook-configuration
   annotations:
     template: ""
-webhooks:
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /mutate-apps-kruise-io-v1alpha1-advancedcronjob
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: madvancedcronjob.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - advancedcronjobs
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /mutate-apps-kruise-io-v1alpha1-broadcastjob
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: mbroadcastjob.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - broadcastjobs
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /mutate-apps-kruise-io-v1alpha1-cloneset
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: mcloneset.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - clonesets
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /mutate-apps-kruise-io-v1alpha1-containerrecreaterequest
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: mcontainerrecreaterequest.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - containerrecreaterequests
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /mutate-apps-kruise-io-v1alpha1-daemonset
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: mdaemonset.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - daemonsets
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /mutate-apps-kruise-io-v1alpha1-imagepulljob
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: mimagepulljob.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - imagepulljobs
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /mutate-apps-kruise-io-v1alpha1-nodeimage
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: mnodeimage.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - nodeimages
-{{ if contains "PodWebhook=false" .Values.featureGates }}{{ else }}
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /mutate-pod
-  failurePolicy: {{ .Values.webhookConfiguration.failurePolicy.pods }}
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: mpod.kb.io
-  namespaceSelector:
-    matchExpressions:
-    - key: control-plane
-      operator: DoesNotExist
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    resources:
-    - pods
+{{- if .Values.externalCerts.annotations }}
+{{ toYaml .Values.externalCerts.annotations | indent 4 }}
 {{- end }}
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /mutate-apps-kruise-io-v1alpha1-sidecarset
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: msidecarset.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - sidecarsets
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /mutate-apps-kruise-io-statefulset
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: mstatefulset.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - statefulsets
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /mutate-apps-kruise-io-v1alpha1-uniteddeployment
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: muniteddeployment.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - uniteddeployments
-
+webhooks:
+{{- if not (contains "PodWebhook=false" .Values.featureGates) }}
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-pod
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    failurePolicy: Fail
+    name: mpod.kb.io
+    namespaceSelector:
+      matchExpressions:
+        - key: control-plane
+          operator: NotIn
+          values:
+            - openkruise
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+{{- end }}
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-apps-kruise-io-v1alpha1-advancedcronjob
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: madvancedcronjob.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - advancedcronjobs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-apps-kruise-io-v1alpha1-broadcastjob
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: mbroadcastjob.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - broadcastjobs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-apps-kruise-io-v1alpha1-cloneset
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: mcloneset.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - clonesets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-apps-kruise-io-v1alpha1-containerrecreaterequest
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: mcontainerrecreaterequest.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - containerrecreaterequests
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-apps-kruise-io-v1alpha1-daemonset
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: mdaemonset.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - daemonsets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-apps-kruise-io-v1alpha1-imagelistpulljob
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: mimagelistpulljob.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - imagelistpulljobs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-apps-kruise-io-v1alpha1-imagepulljob
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: mimagepulljob.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - imagepulljobs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-apps-kruise-io-v1alpha1-nodeimage
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: mnodeimage.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - nodeimages
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-apps-kruise-io-v1alpha1-sidecarset
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: msidecarset.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - sidecarsets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-apps-kruise-io-statefulset
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: mstatefulset.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - statefulsets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /mutate-apps-kruise-io-v1alpha1-uniteddeployment
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: muniteddeployment.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - uniteddeployments
+    sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -273,521 +291,625 @@ metadata:
   name: kruise-validating-webhook-configuration
   annotations:
     template: ""
-webhooks:
-{{- if contains "PodWebhook=false" .Values.featureGates }}{{ else }}
-{{- if or (contains "AllAlpha=true" .Values.featureGates) (contains "PodUnavailableBudgetUpdateGate=true" .Values.featureGates) (contains "PodUnavailableBudgetDeleteGate=true" .Values.featureGates) (contains "WorkloadSpread=true" .Values.featureGates) }}
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-pod
-  failurePolicy: {{ .Values.webhookConfiguration.failurePolicy.pods }}
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vpod.kb.io
-  namespaceSelector:
-    matchExpressions:
-    - key: control-plane
-      operator: DoesNotExist
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-{{- if or (contains "AllAlpha=true" .Values.featureGates) (contains "PodUnavailableBudgetUpdateGate=true" .Values.featureGates) }}
-    - UPDATE
-{{- else }}{{- end }}
-{{- if or (contains "AllAlpha=true" .Values.featureGates) (contains "PodUnavailableBudgetDeleteGate=true" .Values.featureGates) (contains "WorkloadSpread=true" .Values.featureGates) }}
-    - DELETE
-{{- else }}{{- end }}
-    resources:
-    - pods
-{{- else }}{{- end }}
-{{- if or (contains "AllAlpha=true" .Values.featureGates) (contains "PodUnavailableBudgetDeleteGate=true" .Values.featureGates) (contains "WorkloadSpread=true" .Values.featureGates) }}
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-pod
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  name: vpodeviction.kb.io
-  namespaceSelector:
-    matchExpressions:
-    - key: control-plane
-      operator: DoesNotExist
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    resources:
-    - pods/eviction
-{{- else }}{{- end }}
+{{- if .Values.externalCerts.annotations }}
+{{ toYaml .Values.externalCerts.annotations | indent 4 }}
 {{- end }}
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-apps-kruise-io-v1alpha1-resourcedistribution
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vresourcedistribution.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - resourcedistributions
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-apps-kruise-io-v1alpha1-advancedcronjob
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vadvancedcronjob.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - advancedcronjobs
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-apps-kruise-io-v1alpha1-broadcastjob
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vbroadcastjob.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - broadcastjobs
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-apps-deployment
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vbuiltindeployment.kb.io
-  objectSelector:
-    matchExpressions:
-    - key: policy.kruise.io/delete-protection
-      operator: Exists
-  rules:
-  - apiGroups:
-    - apps
-    apiVersions:
-    - v1
-    operations:
-    - DELETE
-    resources:
-    - deployments
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-apps-replicaset
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vbuiltinreplicaset.kb.io
-  objectSelector:
-    matchExpressions:
-    - key: policy.kruise.io/delete-protection
-      operator: Exists
-  rules:
-  - apiGroups:
-    - apps
-    apiVersions:
-    - v1
-    operations:
-    - DELETE
-    resources:
-    - replicasets
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-apps-statefulset
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vbuiltinstatefulset.kb.io
-  objectSelector:
-    matchExpressions:
-    - key: policy.kruise.io/delete-protection
-      operator: Exists
-  rules:
-  - apiGroups:
-    - apps
-    apiVersions:
-    - v1
-    operations:
-    - DELETE
-    resources:
-    - statefulsets
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-apps-kruise-io-v1alpha1-cloneset
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vcloneset.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - clonesets
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-customresourcedefinition
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vcustomresourcedefinition.kb.io
-  objectSelector:
-    matchExpressions:
-    - key: policy.kruise.io/delete-protection
-      operator: Exists
-  rules:
-  - apiGroups:
-    - apiextensions.k8s.io
-    apiVersions:
-    - v1
-    - v1beta1
-    operations:
-    - DELETE
-    resources:
-    - customresourcedefinitions
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-apps-kruise-io-v1alpha1-daemonset
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vdaemonset.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - daemonsets
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-apps-kruise-io-v1alpha1-imagepulljob
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vimagepulljob.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - imagepulljobs
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-namespace
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vnamespace.kb.io
-  objectSelector:
-    matchExpressions:
-    - key: policy.kruise.io/delete-protection
-      operator: Exists
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - DELETE
-    resources:
-    - namespaces
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-apps-kruise-io-v1alpha1-nodeimage
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vnodeimage.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - nodeimages
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-apps-kruise-io-persistentpodstate
-  failurePolicy: Fail
-  name: vpersistentpodstate.kb.io
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - persistentpodstates
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-apps-kruise-io-podprobemarker
-  failurePolicy: Fail
-  name: vpodprobemarker.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - podprobemarkers
-  sideEffects: None
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-policy-kruise-io-podunavailablebudget
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vpodunavailablebudget.kb.io
-  rules:
-  - apiGroups:
-    - policy.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - podunavailablebudgets
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-apps-kruise-io-v1alpha1-sidecarset
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vsidecarset.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - sidecarsets
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-apps-kruise-io-statefulset
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vstatefulset.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - statefulsets
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-apps-kruise-io-v1alpha1-uniteddeployment
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vuniteddeployment.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - uniteddeployments
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: kruise-webhook-service
-      namespace: {{ .Values.installation.namespace }}
-      path: /validate-apps-kruise-io-v1alpha1-workloadspread
-  failurePolicy: Fail
-  admissionReviewVersions:
-  - v1
-  - v1beta1
-  sideEffects: None
-  timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
-  name: vworkloadspread.kb.io
-  rules:
-  - apiGroups:
-    - apps.kruise.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - workloadspreads
-{{- end}}
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-apps-deployment
+    failurePolicy: Ignore
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vbuiltindeployment.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: policy.kruise.io/delete-protection
+          operator: Exists
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+    rules:
+      - apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        operations:
+          - DELETE
+        resources:
+          - deployments
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-apps-replicaset
+    failurePolicy: Ignore
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vbuiltinreplicaset.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: policy.kruise.io/delete-protection
+          operator: Exists
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+    rules:
+      - apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        operations:
+          - DELETE
+        resources:
+          - replicasets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-apps-statefulset
+    failurePolicy: Ignore
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vbuiltinstatefulset.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: policy.kruise.io/delete-protection
+          operator: Exists
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+    rules:
+      - apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        operations:
+          - DELETE
+        resources:
+          - statefulsets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-customresourcedefinition
+    failurePolicy: Ignore
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vcustomresourcedefinition.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: policy.kruise.io/delete-protection
+          operator: Exists
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+    rules:
+      - apiGroups:
+          - apiextensions.k8s.io
+        apiVersions:
+          - v1
+          - v1beta1
+        operations:
+          - DELETE
+        resources:
+          - customresourcedefinitions
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-namespace
+    failurePolicy: Ignore
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vnamespace.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: policy.kruise.io/delete-protection
+          operator: Exists
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - DELETE
+        resources:
+          - namespaces
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-ingress
+    failurePolicy: Ignore
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vingress.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: policy.kruise.io/delete-protection
+          operator: Exists
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+    rules:
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+          - v1beta1
+        operations:
+          - DELETE
+        resources:
+          - ingresses
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-service
+    failurePolicy: Ignore
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vservice.kb.io
+    objectSelector:
+      matchExpressions:
+        - key: policy.kruise.io/delete-protection
+          operator: Exists
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - DELETE
+        resources:
+          - services
+    sideEffects: None
+{{- if not (contains "PodWebhook=false" .Values.featureGates) }}
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-pod
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vpod.kb.io
+    namespaceSelector:
+      matchExpressions:
+        - key: control-plane
+          operator: NotIn
+          values:
+            - openkruise
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+          - DELETE
+        resources:
+          - pods
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-pod
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vpodeviction.kb.io
+    namespaceSelector:
+      matchExpressions:
+        - key: control-plane
+          operator: NotIn
+          values:
+            - openkruise
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods/eviction
+    sideEffects: None
+{{- end }}
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-apps-kruise-io-v1alpha1-resourcedistribution
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vresourcedistribution.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - resourcedistributions
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-apps-kruise-io-v1alpha1-workloadspread
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vworkloadspread.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - workloadspreads
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-apps-kruise-io-v1alpha1-advancedcronjob
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vadvancedcronjob.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - advancedcronjobs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-apps-kruise-io-v1alpha1-broadcastjob
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vbroadcastjob.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - broadcastjobs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-apps-kruise-io-v1alpha1-cloneset
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vcloneset.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - clonesets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-apps-kruise-io-v1alpha1-daemonset
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vdaemonset.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - daemonsets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-apps-kruise-io-v1alpha1-imagelistpulljob
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vimagelistpulljob.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - imagelistpulljobs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-apps-kruise-io-v1alpha1-imagepulljob
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vimagepulljob.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - imagepulljobs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-apps-kruise-io-v1alpha1-nodeimage
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vnodeimage.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - nodeimages
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-apps-kruise-io-persistentpodstate
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vpersistentpodstate.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - persistentpodstates
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-apps-kruise-io-podprobemarker
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vpodprobemarker.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - podprobemarkers
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-policy-kruise-io-podunavailablebudget
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vpodunavailablebudget.kb.io
+    rules:
+      - apiGroups:
+          - policy.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - podunavailablebudgets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-apps-kruise-io-v1alpha1-sidecarset
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vsidecarset.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - sidecarsets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-apps-kruise-io-statefulset
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vstatefulset.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - statefulsets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kruise-webhook-service
+        namespace: {{ .Values.installation.namespace }}
+        path: /validate-apps-kruise-io-v1alpha1-uniteddeployment
+    failurePolicy: Fail
+    timeoutSeconds: {{ .Values.webhookConfiguration.timeoutSeconds }}
+    name: vuniteddeployment.kb.io
+    rules:
+      - apiGroups:
+          - apps.kruise.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - uniteddeployments
+    sideEffects: None

--- a/charts/kruise/values.yaml
+++ b/charts/kruise/values.yaml
@@ -10,10 +10,18 @@ installation:
   roleListGroups:
     - '*'
 
-featureGates: ""
+featureGates: "ImagePullJobGate=true"
+
+externalCerts:
+  # annotations to patch for webhook configuration and crd
+  # e.g. cert-manager.io/inject-ca-from: kruise-system/kruise-webhook
+  annotations: {}
 
 # KUBE_CACHE_MUTATION_DETECTOR
 enableKubeCacheMutationDetector: false
+
+# imagePullSecrets to pull kruise images
+imagePullSecrets: []
 
 manager:
   # settings for log print
@@ -24,7 +32,7 @@ manager:
   replicas: 2
   image:
     repository: openkruise/kruise-manager
-    tag: v1.4.0
+    tag: v1.8.3
   webhook:
     port: 9876
   metrics:
@@ -34,6 +42,8 @@ manager:
   pprofAddr: "localhost:8090"
 
   resyncPeriod: "0"
+
+  loggingFormat: ""
 
   # resources of kruise-manager container
   resources:
@@ -50,13 +60,7 @@ manager:
   nodeSelector: {}
   tolerations: []
 
-  # set serviceAccountName to set permissions externally
-  serviceAccountName: ""
-
 webhookConfiguration:
-  enabled: true
-  failurePolicy:
-    pods: Ignore
   timeoutSeconds: 30
 
 daemon:
@@ -65,12 +69,22 @@ daemon:
     level: "4"
 
   port: 10221
+  enablePprof: true
   pprofAddr: "localhost:10222"
 
   socketLocation: "/var/run"
   socketFile: ""
 
   nodeSelector: {}
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: type
+            operator: NotIn
+            values:
+            - virtual-kubelet
   resources:
     limits:
       cpu: 50m
@@ -78,8 +92,6 @@ daemon:
     requests:
       cpu: "0"
       memory: "0"
-  # set serviceAccountName to set permissions externally
-  serviceAccountName: ""
 
   # Extra environment variables that will be pass onto pods.
   # For example, when the daemon is used behind a http proxy, you can set the proxy environment variables here.
@@ -93,7 +105,16 @@ daemon:
   # - name: NO_PROXY
   #   value: localhost,0.0.0.0,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
 
+  credentialProvider:
+    enable: false
+    configmap: credential-provider-config
+    hostPath: credential-provider-plugin
+    awsCredentialsDir: ""
+
 serviceAccount:
   annotations: {}
 
-imagePullPolicy: IfNotPresent
+helmHooks:
+  image:
+    repository: openkruise/kruise-helm-hook
+    tag: v0.1.0

--- a/charts/matrixone-operator/Chart.yaml
+++ b/charts/matrixone-operator/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: matrixone-operator
 description: Matrixone Kubernetes Operator
 type: application
-version: 1.3.0-alpha.3
+version: 1.3.0-alpha.4
 appVersion: 0.1.0
 kubeVersion: ">=1.19.0-0"
 icon: https://raw.githubusercontent.com/matrixorigin/artwork/main/docs/overview/logo.png
 dependencies:
   - name: kruise
-    version: "1.4.0"
+    version: "1.8.3"
     repository: "https://matrixorigin.github.io/matrixone-operator"
     condition: kruise.enabled

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -82,8 +82,15 @@ function kind::ensure-kind() {
 }
 
 function kind::load-image() {
+    local kruise_image
+    kruise_image=$(helm template kruise "${ROOT}/charts/kruise" | awk '/^[[:space:]]+image:.*kruise-manager/ {print $2; exit}')
+    if [[ -z "${kruise_image}" ]]; then
+        echo "error: failed to resolve Kruise manager image from local chart"
+        return 1
+    fi
+
     kind::prepare_image ${CLUSTER} ${MO_IMAGE_REPO}:${MO_VERSION}
-    kind::prepare_image ${CLUSTER} openkruise/kruise-manager:v1.2.0
+    kind::prepare_image ${CLUSTER} "${kruise_image}"
     kind::prepare_image ${CLUSTER} minio/minio:RELEASE.2023-11-01T01-57-10Z
 }
 
@@ -113,10 +120,25 @@ function e2e::run() {
 }
 
 function e2e::install() {
+  local chart_root
+  chart_root=$(mktemp -d)
+
+  mkdir -p "${chart_root}/matrixone-operator/charts"
+  cp charts/matrixone-operator/Chart.yaml charts/matrixone-operator/values.yaml "${chart_root}/matrixone-operator/"
+  cp -R charts/matrixone-operator/templates "${chart_root}/matrixone-operator/"
+  if ! helm package charts/kruise --destination "${chart_root}/matrixone-operator/charts"; then
+    rm -rf -- "${chart_root}"
+    return 1
+  fi
+
   echo "> Create operator namespace"
   kubectl create ns "${OPNAMESPACE}"
   echo "> Install mo operator"
-  helm install mo ./charts/matrixone-operator --dependency-update --set image.repository=${REPO} --set image.tag=${TAG} -n "${OPNAMESPACE}"
+  if ! helm install mo "${chart_root}/matrixone-operator" --set image.repository="${REPO}" --set image.tag="${TAG}" -n "${OPNAMESPACE}"; then
+    rm -rf -- "${chart_root}"
+    return 1
+  fi
+  rm -rf -- "${chart_root}"
 
   echo "> Wait webhook certificate injected"
   sleep 30
@@ -137,6 +159,6 @@ function e2e::cleanup() {
 function e2e::workflow() {
   e2e::check
   trap "e2e::cleanup" EXIT
-  e2e::install
+  e2e::install || return 1
   e2e::run
 }


### PR DESCRIPTION
## Summary

- upgrade the bundled OpenKruise Helm Chart from v1.4.0 to v1.8.3
- bump the matrixone-operator Chart from `1.3.0-alpha.3` to `1.3.0-alpha.4`
- package the local Kruise Chart before publishing or running repository E2E tests
- keep the matrixone-operator source code, container image, and `kruise-api` Go dependency unchanged

This fixes the Kruise daemon startup failure on Kubernetes 1.34/containerd 2.x, where Kruise v1.4.0 attempts to use the removed CRI v1alpha2 ImageService.

Closes #609.

## Upgrade behavior

The target release performs an in-place Helm upgrade:

- update Kruise CRD definitions in place
- roll the Kruise manager and daemon from v1.4.0 to v1.8.3
- preserve existing MatrixOne CRs, workloads, Pods, PVCs, and data
- keep the matrixone-operator image at `matrixorigin/matrixone-operator:1.2.0-alpha.5`

## E2E scope

Two E2E paths are relevant:

1. **Manual upgrade E2E:** validated the full v1.4.0 to v1.8.3 in-place upgrade, workload identity preservation, SQL compatibility, rollback, and a second upgrade.
2. **Repository CI E2E:** historically installed Kruise v1.4.0. This PR updates it to package and install the local Kruise v1.8.3 Chart, so CI tests the exact code under review before v1.8.3 exists in the MatrixOrigin remote Chart repository.

The `github.com/openkruise/kruise-api v1.4.0` dependency is intentionally unchanged. It controls compile-time API types, not the Kruise controller image deployed in E2E.

## Validation completed

- `make verify`
- `actionlint .github/workflows/release_chart.yml`
- Helm dependency, lint, package, and template checks
- Kubernetes 1.34.8/containerd 2.3.1 reproduction and recovery with Kruise v1.8.3
- Kubernetes 1.28.13/containerd 1.7.18 full MatrixOne upgrade, 47 SQL probes, workload/PVC identity checks, rollback, and second upgrade

## Follow-up

The non-blocking `StorageClass` watch/RBAC log observation is tracked separately in #610.
