### PR TITLE
ci: publish prepackaged Helm charts

### DIFF
--- a/.github/workflows/release_chart.yml
+++ b/.github/workflows/release_chart.yml
@@ -30,11 +30,15 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Package local chart dependencies
+      - name: Package charts
         run: |
-          mkdir -p charts/matrixone-operator/charts
+          mkdir -p charts/matrixone-operator/charts .cr-release-packages .cr-index
           helm package charts/kruise \
             --destination charts/matrixone-operator/charts
+          helm package charts/kruise \
+            --destination .cr-release-packages
+          helm package charts/matrixone-operator \
+            --destination .cr-release-packages
 
       - name: Run Artifact Hub lint
         run: |
@@ -42,11 +46,21 @@ jobs:
           ./ah lint -p charts/matrixone-operator || exit 1
           rm -f ./ah
 
-      - name: Run chart-releaser
+      - name: Install chart-releaser
         uses: helm/chart-releaser-action@98bccfd32b0f76149d188912ac8e45ddd3f8695f # tag=v1.4.1
         with:
-          charts_dir: charts
+          install_only: true
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Publish charts
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "chart-{{ .Version }}"
           CR_SKIP_EXISTING: true
+        run: |
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repo="${GITHUB_REPOSITORY#*/}"
+          cr upload -o "$owner" -r "$repo" -c "$GITHUB_SHA"
+          cr index -o "$owner" -r "$repo" \
+            -c "https://${owner}.github.io/${repo}" --push


### PR DESCRIPTION
## Summary

- prepackage both `kruise-1.8.3.tgz` and `matrixone-operator-1.3.0-alpha.4.tgz` with Helm
- embed the local Kruise package in the parent Chart before packaging it
- use chart-releaser only to upload the prepared archives and update the GitHub Pages index
- preserve the existing release naming and skip-existing behavior

## Why

The Chart Publish run triggered after #611 failed while `chart-releaser v1.4.1` packaged the parent Chart:

```text
Packaging chart 'charts/matrixone-operator'...
Error: can't get a valid version for repositories kruise
```

Although the workflow had already placed `kruise-1.8.3.tgz` under the parent Chart, `cr package` tried to resolve Kruise v1.8.3 from the remote MatrixOrigin Chart repository before that version had been published.

This change removes that publication-order dependency. Merging it to `main` will trigger Chart Publish again and should create:

- `chart-1.8.3`
- `chart-1.3.0-alpha.4`

Failed run: https://github.com/matrixorigin/matrixone-operator/actions/runs/32573542424

## Validation

- `actionlint .github/workflows/release_chart.yml`
- generated both expected archives in a clean temporary Chart tree
- verified the parent archive embeds Kruise v1.8.3
- `helm lint` passed for the packaged parent Chart
- confirmed the pinned chart-releaser action supports `install_only`
- `make verify`
