### PR TITLE
ci: disable default buildx attestations when pushing images

### DIFF
--- a/.github/workflows/release_image.yml
+++ b/.github/workflows/release_image.yml
@@ -67,6 +67,11 @@ jobs:
 
       - name: Build
         uses: docker/build-push-action@v2
+        env:
+          # Alicloud ACR rejects the provenance attestation manifest that buildx
+          # attaches by default since BuildKit v0.11 ("unknown manifest class for
+          # application/vnd.oci.empty.v1+json"), which fails the whole push.
+          BUILDX_NO_DEFAULT_ATTESTATIONS: "1"
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .


### PR DESCRIPTION
Fixes #613

## Problem

`Release Image` has failed on every run since 2026-08-21, so no operator nightly image has been published since 2026-07-14. The `Build` step is rejected by Alicloud ACR:

```
#36 pushing layers 8.9s done
#36 pushing manifest for registry.cn-hangzhou.aliyuncs.com/mocloud/matrixone-operator:nightly-d261876-2026-08-22@sha256:5065870... 1.9s done
#36 ERROR: failed to push registry.cn-hangzhou.aliyuncs.com/mocloud/matrixone-operator:nightly-d261876-2026-08-22: denied: unknown manifest class for application/vnd.oci.empty.v1+json
```

Layers and the image manifest push successfully; only the final object is refused. That object is the **provenance attestation manifest**, which BuildKit has attached by default since v0.11. It is referenced from the OCI image index through a descriptor whose config mediaType is `application/vnd.oci.empty.v1+json`, and ACR does not recognise it. Docker Hub accepts the format, so only the ACR targets fail.

Nothing in the workflow file changed. `docker/setup-buildx-action@v1` does not pin a buildx version, so it installs whatever is current and the behaviour drifted underneath us. The failures start at #607, which predates the Kruise chart work and touched neither `Dockerfile` nor `release_image.yml`.

## Change

`docker/build-push-action@v2` is too old to expose a `provenance` input, so this opts out via the buildx-native environment variable, which works regardless of the action version:

```yaml
      - name: Build
        uses: docker/build-push-action@v2
        env:
          BUILDX_NO_DEFAULT_ATTESTATIONS: "1"
```

The pushed artifact becomes a plain multi-arch image index that ACR accepts. Image content, tags, platforms and cache configuration are unchanged.

## Verification

This can only be fully verified by the push itself, since the failure is registry-side and the ACR credentials are only available to the workflow. Locally verified so far:

- the workflow still parses and the `env` block is attached to the `Build` step;
- the change is additive — five lines, no existing key modified.

Please confirm the post-merge `Release Image` run publishes `nightly-<sha>-<date>` to all three registries.

## Not included

`release_image.yml` still uses `actions/checkout@v3`, `docker/login-action@v1`, `docker/setup-buildx-action@v1` and `docker/build-push-action@v2`, all targeting Node 20 and now force-run on Node 24 with deprecation warnings. Bumping those (and switching to an explicit `provenance: false` on `build-push-action@v6`) is worth doing, but keeping it out of this PR means restoring publishing is not entangled with an action-version bump that changes more behaviour at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
